### PR TITLE
Add CRISPResso2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [**biobambam2**](https://github.com/gt1/biobambam2)
     * Added submodule for `bamsormadup` tool
     * Totally cheating - it uses Picard MarkDuplicates but with a custom search pattern and naming
+* [**crispresso2**](http://crispresso2.pinellolab.org/)
+    * Analysis of genome editing outcomes from deep sequencing data
 * [**mtnucratio**](https://github.com/apeltzer/MTNucRatioCalculator)
     * Added little helper tool to compute mt to nuclear ratios for NGS data.
 * [**mosdepth**](https://github.com/brentp/mosdepth)

--- a/README.md
+++ b/README.md
@@ -31,32 +31,33 @@ it ideal for routine fast quality control.
 Currently, supported tools include:
 
 
-|Read QC & pre-processing         | Aligners / quantifiers  | Post-alignment processing   | Post-alignment QC                    |
-|---------------------------------|-------------------------|-----------------------------|--------------------------------------|
-|[Adapter Removal][adapterremoval]|[BBMap][bbmap]           |[Bamtools][bamtools]         |[biobambam2][biobambam2]              |
-|[AfterQC][afterqc]               |[BISCUIT][biscuit]       |[Bcftools][bcftools]         |[BUSCO][busco]                        |
-|[Bcl2fastq][bcl2fastq]           |[Bismark][bismark]       |[GATK][gatk]                 |[Conpair][conpair]                    |
-|[BBTools][bbmap]                 |[Bowtie][bowtie-1]       |[HOMER][homer]               |[DamageProfiler][damageprofiler]      |
-|[BioBloom Tools][biobloomtools]  |[Bowtie 2][bowtie-2]     |[HTSeq][htseq]               |[DeDup][dedup]                        |
-|[ClipAndMerge][clipandmerge]     |[HiCUP][hicup]           |[MACS2][macs2]               |[deepTools][deeptools]                |
-|[Cluster Flow][clusterflow]      |[HiC-Pro][hicpro]        |[Picard][picard]             |[Disambiguate][disambiguate]          |
-|[Cutadapt][cutadapt]             |[HISAT2][hisat2]         |[Prokka][prokka]             |[goleft][goleft]                      |
-|[leeHom][leehom]                 |[Kallisto][kallisto]     |[RSEM][rsem]                 |[HiCExplorer][hicexplorer]            |
-|[InterOp][interop]               |[Long Ranger][longranger]|[Samblaster][samblaster]     |[methylQA][methylqa]                  |
-|[FastQC][fastqc]                 |[Salmon][salmon]         |[Samtools][samtools]         |[miRTrace][mirtrace]                  |
-|[FastQ Screen][fastq-screen]     |[Slamdunk][slamdunk]     |[SnpEff][snpeff]             |[mosdepth][mosdepth]                  |
-|[Fastp][fastp]                   |[STAR][star]             |[Subread featureCounts][featurecounts]|[Peddy][peddy]               |
-|[FLASh][flash]                   |[Tophat][tophat]         |[Stacks][stacks]             |[phantompeakqualtools][phantompeakqualtools]|
-|[Flexbar][flexbar]               |                         |[THetA2][theta2]             |[Preseq][preseq]                      |
-|[Jellyfish][jellyfish]           |                         |                             |[QoRTs][qorts]                        |
-|[KAT][kat]                       |                         |                             |[Qualimap][qualimap]                  |
-|[MinIONQC][minionqc]             |                         |                             |[QUAST][quast]                        |
-|[Skewer][skewer]                 |                         |                             |[RNA-SeQC][rna_seqc]                  |
-|[SortMeRNA][sortmerna]           |                         |                             |[RSeQC][rseqc]                        |
-|                                 |                         |                             |[Sargasso][sargasso]                  |
-|                                 |                         |                             |[Supernova][supernova]                |
-|                                 |                         |                             |[VCFTools][vcftools]                  |
-|                                 |                         |                             |[VerifyBAMID][verifybamid]            |
+| Read QC & pre-processing                   | Aligners / quantifiers    | Post-alignment processing              | Post-alignment QC                            |
+|:-------------------------------------------|:--------------------------|:---------------------------------------|:---------------------------------------------|
+| [Adapter Removal][adapterremoval]          | [BBMap][bbmap]            | [Bamtools][bamtools]                   | [biobambam2][biobambam2]                     |
+| [AfterQC][afterqc]                         | [BISCUIT][biscuit]        | [Bcftools][bcftools]                   | [BUSCO][busco]                               |
+| [Bcl2fastq][bcl2fastq]                     | [Bismark][bismark]        | [GATK][gatk]                           | [Conpair][conpair]                           |
+| [BBTools][bbmap]                           | [Bowtie][bowtie-1]        | [HOMER][homer]                         | [CRISPResso2][crispresso2]                   |
+| [BioBloom Tools][biobloomtools]            | [Bowtie 2][bowtie-2]      | [HTSeq][htseq]                         | [DamageProfiler][damageprofiler]             |
+| [ClipAndMerge][clipandmerge]               | [HiCUP][hicup]            | [MACS2][macs2]                         | [DeDup][dedup]                               |
+| [Cluster Flow][clusterflow]                | [HiC-Pro][hicpro]         | [Picard][picard]                       | [deepTools][deeptools]                       |
+| [Cutadapt][cutadapt]                       | [HISAT2][hisat2]          | [Prokka][prokka]                       | [Disambiguate][disambiguate]                 |
+| [leeHom][leehom]                           | [Kallisto][kallisto]      | [RSEM][rsem]                           | [goleft][goleft]                             |
+| [InterOp][interop]                         | [Long Ranger][longranger] | [Samblaster][samblaster]               | [HiCExplorer][hicexplorer]                   |
+| [FastQC][fastqc]                           | [Salmon][salmon]          | [Samtools][samtools]                   | [methylQA][methylqa]                         |
+| [FastQ Screen][fastq-screen]               | [Slamdunk][slamdunk]      | [SnpEff][snpeff]                       | [miRTrace][mirtrace]                         |
+| [Fastp][fastp]                             | [STAR][star]              | [Subread featureCounts][featurecounts] | [mosdepth][mosdepth]                         |
+| [FLASh][flash]                             | [Tophat][tophat]          | [Stacks][stacks]                       | [Peddy][peddy]                               |
+| [Flexbar][flexbar]                         |                           | [THetA2][theta2]                       | [phantompeakqualtools][phantompeakqualtools] |
+| [Jellyfish][jellyfish]                     |                           |                                        | [Preseq][preseq]                             |
+| [KAT][kat]                                 |                           |                                        | [QoRTs][qorts]                               |
+| [MinIONQC][minionqc]                       |                           |                                        | [Qualimap][qualimap]                         |
+| [Skewer][skewer]                           |                           |                                        | [QUAST][quast]                               |
+| [SortMeRNA][sortmerna]                     |                           |                                        | [RNA-SeQC][rna_seqc]                         |
+| [Trimmomatic][trimmomatic]                 |                           |                                        | [RSeQC][rseqc]                               |
+|                                            |                           |                                        | [Sargasso][sargasso]                         |
+|                                            |                           |                                        | [Supernova][supernova]                       |
+|                                            |                           |                                        | [VCFTools][vcftools]                         |
+|                                            |                           |                                        | [VerifyBAMID][verifybamid]                   |
 
 
 MultiQC can also easily parse data from custom scripts, if correctly formatted / configured.
@@ -175,6 +176,7 @@ Code contributions from:
 [@mlusignan](https://github.com/mlusignan),
 [@moonso](https://github.com/moonso),
 [@noirot](https://github.com/noirot),
+[@olgabot](https://github.com/olgabot),
 [@remiolsen](https://github.com/remiolsen),
 [@rdali](https://github.com/rdali),
 [@rlegendre](https://github.com/rlegendre),
@@ -207,6 +209,7 @@ MultiQC is released under the GPL v3 or later licence.
 [clipandmerge]:   http://multiqc.info/docs/#clipandmerge
 [clusterflow]:    http://multiqc.info/docs/#cluster-flow
 [conpair]:        http://multiqc.info/docs/#conpair
+[crispresso2]:    http://multiqc.info/docs/#crispresso2
 [cutadapt]:       http://multiqc.info/docs/#cutadapt
 [damageprofiler]: http://multiqc.info/docs/#damageprofiler
 [dedup]:          http://multiqc.info/docs/#dedup

--- a/docs/modules/crispresso2.md
+++ b/docs/modules/crispresso2.md
@@ -1,0 +1,12 @@
+---
+Name: CRISPResso2 URL: http://crispresso2.pinellolab.org/ Description: > ###
+Analysis of genome editing outcomes from deep sequencing data
+---
+
+[CRISPResso2](http://crispresso2.pinellolab.org/) is a software pipeline
+designed to enable rapid and intuitive interpretation of genome editing
+experiments. Briefly, CRISPResso2:
+
+ * aligns sequencing reads to a reference sequence
+ * quantifies insertions, mutations and deletions to determine whether a read is modified or unmodified by genome editing
+ * summarizes editing results in intuitive plots and datasets

--- a/multiqc/modules/crispresso2/__init__.py
+++ b/multiqc/modules/crispresso2/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+from .crispresso2 import MultiqcModule
+

--- a/multiqc/modules/crispresso2/crispresso2.py
+++ b/multiqc/modules/crispresso2/crispresso2.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+
+""" MultiQC module to parse output from CRISPResso """
+
+from __future__ import print_function
+from collections import OrderedDict
+import logging
+from pprint import pprint
+import os
+import re
+
+import pandas as pd
+
+from multiqc import config
+from multiqc.plots import bargraph
+from multiqc.modules.base_module import BaseMultiqcModule
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    """ CRISPResso module """
+
+    def __init__(self):
+
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(name='CRISPResso2', anchor='crispresso2',
+        href="http://crispresso2.pinellolab.org",
+        info="Analysis of genome editing outcomes from deep sequencing data.")
+
+        # Find and load any Kallisto reports
+        self.crispresso2_data = dict()
+        for f in self.find_log_files('crispresso2/allele_frequency_table', filehandles=True):
+            # log.info("Found {}!")
+            filename = os.path.join(f['root'], f['fn'])
+            # pprint(f)
+            self.parse_allele_frequencies(filename)
+
+        for f in self.find_log_files('crispresso2/mapping_statistics'):
+            # log.info("Found {}!")
+            # filename = os.path.join(f['root'], f['fn'])
+            pprint(f)
+            self.parse_mapping_statistics(f)
+
+        for f in self.find_log_files('crispresso2/editing_frequencies'):
+            # log.info("Found {}!")
+            # filename = os.path.join(f['root'], f['fn'])
+            pprint(f)
+
+
+        # # Filter to strip out ignored sample names
+        # self.kallisto_data = self.ignore_samples(self.kallisto_data)
+        #
+        # if len(self.kallisto_data) == 0:
+        #     raise UserWarning
+        #
+        log.info("Found {} reports".format(len(self.crispresso2_data)))
+
+        # Write parsed report data to a file (BaseMultiqcModule function)
+        self.write_data_file(self.crispresso2_data, 'multiqc_crispresso2')
+        pprint(self.crispresso2_data)
+
+        #
+        # Plot of alleles
+        self.add_section( plot = self.crispresso2_mapping_stats_plot() )
+        self.add_section( plot =  self.crispresso2_allele_plot() )
+        self.crispresso2_general_stats_table()
+
+    def parse_allele_frequencies(self, filename):
+        df = pd.read_csv(filename, sep='\t', compression='zip')
+        sample_id = self.get_sample_id_from_dirname(filename)
+
+        allele_data = self.get_read_status_line(df, sample_id, "#Reads")
+
+        # Assign to this sample_id
+        self.crispresso2_data[sample_id] = allele_data
+
+    def parse_mapping_statistics(self, f):
+        sample_id = self.get_sample_id_from_dirname(f['root'])
+
+        for i, line in enumerate(f['f'].splitlines()):
+            split = line.split('\t')
+            if i == 0:
+                keys = split
+            if i == 1:
+                values = [int(x) for x in split]
+
+        data = dict(zip(keys, values))
+        data['reads_unaligned'] = data['READS AFTER PREPROCESSING'] - data['READS ALIGNED']
+        data['reads_removed_by_preprocessing'] = data['READS IN INPUTS'] - data['READS AFTER PREPROCESSING']
+
+        self.crispresso2_data[sample_id].update(data)
+
+    @staticmethod
+    def get_sample_id_from_dirname(dirname):
+        # sample_id = os.path.basename(os.path.dirname(filename))
+        sample_id = dirname.split("CRISPResso_on_")[-1]
+        sample_id = sample_id.split('.collapsed')[0]
+        return sample_id
+
+    @staticmethod
+    def get_read_status_line(df, sample_id, read_quantification,
+                             groupby=['Reference_Name', 'Read_Status']):
+        reads = df.groupby(groupby)[read_quantification].sum()
+        reads_tidy = reads.reset_index()
+        reads_tidy['sample_id'] = sample_id
+        reads_tidy['reference_name_with_status'] = reads_tidy.apply(
+            lambda x: "{Reference_Name}_{Read_Status}".format(**x), axis=1)
+        df_line = reads_tidy.pivot(index='sample_id',
+                                   columns='reference_name_with_status',
+                                   values=read_quantification)
+        series = df_line.iloc[0]
+        percentages = 100 * series/series.sum()
+        percentages.index = percentages.index + "_percentage"
+
+        # Combine both percentages and raw numbers
+        line = pd.concat([percentages, series])
+
+        # Convert to dictionary since that's what MultiQC uses
+        line = line.to_dict()
+        return line
+
+    # def kallisto_general_stats_table(self):
+    #     """Take the parsed stats from the Kallisto report and add it to the
+    #     basic stats table at the top of the report """
+    #
+    #     headers = OrderedDict()
+    #     headers['fragment_length'] = {
+    #         'title': 'Frag Length',
+    #         'description': 'Estimated average fragment length',
+    #         'min': 0,
+    #         'suffix': 'bp',
+    #         'scale': 'RdYlGn'
+    #     }
+    #     headers['percent_aligned'] = {
+    #         'title': '% Aligned',
+    #         'description': '% processed reads that were pseudoaligned',
+    #         'max': 100,
+    #         'min': 0,
+    #         'suffix': '%',
+    #         'scale': 'YlGn'
+    #     }
+    #     headers['pseudoaligned_reads'] = {
+    #         'title': '{} Aligned'.format(config.read_count_prefix),
+    #         'description': 'Pseudoaligned reads ({})'.format(config.read_count_desc),
+    #         'min': 0,
+    #         'scale': 'PuRd',
+    #         'modify': lambda x: x * config.read_count_multiplier,
+    #         'shared_key': 'read_count'
+    #     }
+    #     self.general_stats_addcols(self.kallisto_data, headers)
+
+    def crispresso2_allele_plot(self):
+        """ Make the HighCharts HTML to plot the alignment rates """
+
+        # Specify the order of the different possible categories
+        keys = OrderedDict()
+        keys['HDR_MODIFIED'] = { 'color': "#6a3d9a", 'name': 'HDR Modified' }
+        keys['HDR_UNMODIFIED'] = { 'color': "#cab2d6", 'name': 'HDR Unmodified' }
+        keys['Reference_MODIFIED'] = { 'color': "#33a02c", 'name': 'Reference Modified' }
+        keys['Reference_UNMODIFIED'] = { 'color': "#b2df8a", 'name': 'Reference Unmodified' }
+
+        # Config for the plot
+        config = {
+            'id': 'crispresso2_alleles',
+            'title': 'CRISPResso2: Allele Frequencies',
+            'ylab': '# Reads',
+            'cpswitch_counts_label': 'Number of Reads'
+        }
+
+        return bargraph.plot(self.crispresso2_data, keys, config)
+
+    def crispresso2_mapping_stats_plot(self):
+        """ Make the HighCharts HTML to plot the alignment rates """
+
+        # Specify the order of the different possible categories
+
+        ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c", "#fb9a99", "#e31a1c",
+         "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a", "#ffff99", "#b15928"]
+        keys = OrderedDict()
+        keys['reads_removed_by_preprocessing'] = { 'name': 'Removed by preprocessing' }
+        keys['READS ALIGNED'] = {  'name': 'Aligned' }
+        keys['reads_unaligned'] = { 'name': 'Unaligned' }
+
+        # Config for the plot
+        config = {
+            'id': 'crispresso2_mapping_stats',
+            'title': 'CRISPResso2: Mapping Statistics',
+            'ylab': '# Reads',
+            'cpswitch_counts_label': 'Number of Reads'
+        }
+
+        return bargraph.plot(self.crispresso2_data, keys, config)
+
+    def crispresso2_general_stats_table(self):
+        """ Take the parsed stats from the CRISPresso2 report and add it to the
+        basic stats table at the top of the report """
+
+        headers = OrderedDict()
+
+        # headers['READS IN INPUTS'] = {
+        #     'title': 'Input reads to CRISPResso2',
+        #     'min': 0,
+        #     # 'suffix': '%',
+        #     # 'format': '{:,d}',
+        #     # 'scale': 'Blues'
+        # }
+        # headers['READS AFTER PREPROCESSING'] = {
+        #     'title': 'Reads after CRISPResso2 preprocessing',
+        #     'min': 0,
+        #     # 'suffix': '%',
+        #     # 'format': '{:,d}',
+        #     # 'scale': 'Blues'
+        # }
+        # headers['READS ALIGNED'] = {
+        #     'title': 'Reads aligned in CRISPResso2',
+        #     'min': 0,
+        #     # 'suffix': '%',
+        #     # 'format': '{:,d}',
+        #     # 'scale': 'Blues'
+        # }
+        headers['HDR_UNMODIFIED_percentage'] = {
+            'title': 'HDR Unmodified',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'format': '{:,.2f}',
+            'scale': 'Purples'
+        }
+        headers['HDR_MODIFIED_percentage'] = {
+            'title': 'HDR Modified',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'format': '{:,.2f}',
+            'scale': 'Purples'
+        }
+        headers['Reference_UNMODIFIED_percentage'] = {
+            'title': 'Reference Modified',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'format': '{:,.2f}',
+            'scale': 'Greens'
+        }
+        headers['Reference_MODIFIED_percentage'] = {
+            'title': 'Reference Un,odified',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'format': '{:,.2f}',
+            'scale': 'Greens'
+        }
+        self.general_stats_addcols(self.crispresso2_data, headers)

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -247,6 +247,10 @@ module_order:
             - WGS
             - cancer
             - DNA
+    - crispresso2:
+        module_tag:
+            - DNA
+            - RNA
     - peddy:
         module_tag:
             - DNA

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -203,6 +203,12 @@ conpair/concordance:
 conpair/contamination:
     contents: 'Tumor sample contamination level: '
     num_lines: 3
+crispresso2/allele_frequency_table:
+    fn: 'Alleles_frequency_table.zip'
+crispresso2/mapping_statistics:
+    fn: 'CRISPResso_mapping_statistics.txt'
+crispresso2/editing_frequencies:
+    fn: 'CRISPResso_quantification_of_editing_frequency.txt'
 cutadapt:
     contents: 'This is cutadapt'
     # contents: 'cutadapt version' # Use this instead if using very old versions of cutadapt (eg. v1.2)

--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -1,0 +1,4 @@
+# STAR logs are renamed to "log.final.out" instead of "Log.final.out"
+sp:
+    star:
+        fn: '*log.final.out'

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
             'clipandmerge = multiqc.modules.clipandmerge:MultiqcModule',
             'clusterflow = multiqc.modules.clusterflow:MultiqcModule',
             'conpair = multiqc.modules.conpair:MultiqcModule',
+            'crispresso2 = multiqc.modules.crispresso2:MultiqcModule',
             'custom_content = multiqc.modules.custom_content:custom_module_classes', # special case
             'cutadapt = multiqc.modules.cutadapt:MultiqcModule',
             'damageprofiler = multiqc.modules.damageprofiler:MultiqcModule',


### PR DESCRIPTION
This PR adds functionality for CRISPResso2 outputs. One of the input files is a zip which was problematic for using `pandas.read_csv` so I did `os.path.join` to get the original filename, which I don't know if that's what you want. Also I didn't see pandas in the dependencies so we'll see if that stays...


![2019-08-14_crispresso2_multiqc_with_table_v3](https://user-images.githubusercontent.com/806256/63091877-ae895e00-bf14-11e9-9783-60736cf727ae.gif)


## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated
 - [x] `docs/README.md` is updated with link to below
 - [x] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work


(Can remove the ac8e7b4 commit, sorry)