### PR TITLE
Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Seqera CLI: Updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
 - Fix old link in Bismark docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - BclConvert: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
+- Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
 
 ### New modules
 

--- a/multiqc/modules/biobambam2/biobambam2.py
+++ b/multiqc/modules/biobambam2/biobambam2.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.general_stats_data = dict()
         n = dict()
 
-        n["bamsormadup"] = MarkDuplicates.parse_reports(self, "bamsormadup")
+        n["bamsormadup"] = MarkDuplicates.parse_reports(self, "biobambam2/bamsormadup")
         if n["bamsormadup"] > 0:
             log.info(f"Found {n['bamsormadup']} bamsormadup reports")
 

--- a/multiqc/modules/picard/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/picard/AlignmentSummaryMetrics.py
@@ -16,7 +16,7 @@ def parse_reports(module):
     data_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/alignment_metrics", filehandles=True):
+    for f in module.find_log_files("picard/alignment_metrics", filehandles=True):
         # Sample name from input file name by default.
         s_name = f["s_name"]
         keys = None

--- a/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
+++ b/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
@@ -17,7 +17,7 @@ def parse_reports(module):
     samplestats_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/basedistributionbycycle", filehandles=True):
+    for f in module.find_log_files("picard/basedistributionbycycle", filehandles=True):
         # Sample name from input file name by default.
         s_name = f["s_name"]
 

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -40,7 +40,7 @@ def parse_reports(module):
     data_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/crosscheckfingerprints", filehandles=True):
+    for f in module.find_log_files("picard/crosscheckfingerprints", filehandles=True):
         # Parse an individual CrosscheckFingerprints Report
         (metrics, comments) = _take_till(f["f"], lambda line: line.startswith("#") or line == "\n")
         header = next(metrics).rstrip("\n").split("\t")

--- a/multiqc/modules/picard/ExtractIlluminaBarcodes.py
+++ b/multiqc/modules/picard/ExtractIlluminaBarcodes.py
@@ -16,7 +16,7 @@ def parse_reports(module):
     data_by_lane = defaultdict(dict)
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/extractilluminabarcodes", filehandles=True):
+    for f in module.find_log_files("picard/extractilluminabarcodes", filehandles=True):
         # Sample name from input file name by default
         lane = f["s_name"]
         keys = None

--- a/multiqc/modules/picard/GcBiasMetrics.py
+++ b/multiqc/modules/picard/GcBiasMetrics.py
@@ -25,7 +25,7 @@ def parse_reports(module):
     summary_data_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/gcbias", filehandles=True):
+    for f in module.find_log_files("picard/gcbias", filehandles=True):
         # Sample name from input file name by default.
         s_name = f["s_name"]
         gc_col = None

--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -75,7 +75,7 @@ def parse_reports(module):
     data_by_bait_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/hsmetrics", filehandles=True):
+    for f in module.find_log_files("picard/hsmetrics", filehandles=True):
         s_name = f["s_name"]
         keys = None
         commadecimal = None

--- a/multiqc/modules/picard/IlluminaBasecallingMetrics.py
+++ b/multiqc/modules/picard/IlluminaBasecallingMetrics.py
@@ -15,7 +15,7 @@ def parse_reports(module):
     data_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/collectilluminabasecallingmetrics", filehandles=True):
+    for f in module.find_log_files("picard/collectilluminabasecallingmetrics", filehandles=True):
         keys = None
 
         for line in f["f"]:

--- a/multiqc/modules/picard/InsertSizeMetrics.py
+++ b/multiqc/modules/picard/InsertSizeMetrics.py
@@ -18,7 +18,7 @@ def parse_reports(module):
     samplestats_by_sample = dict()
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/insertsize", filehandles=True):
+    for f in module.find_log_files("picard/insertsize", filehandles=True):
         # Sample name from input file name by default
         s_name = f["s_name"]
         in_hist = False

--- a/multiqc/modules/picard/MarkDuplicates.py
+++ b/multiqc/modules/picard/MarkDuplicates.py
@@ -12,7 +12,7 @@ from multiqc.plots import bargraph
 log = logging.getLogger(__name__)
 
 
-def parse_reports(module, sp_key="markdups"):
+def parse_reports(module, sp_key="picard/markdups"):
     """
     Find Picard MarkDuplicates reports and parse their data.
     Note that this function is also used by the biobambam2 module, that's why
@@ -68,7 +68,7 @@ def parse_reports(module, sp_key="markdups"):
             return False
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/{sp_key}", filehandles=True):
+    for f in module.find_log_files(sp_key, filehandles=True):
         s_name = f["s_name"]
         parsed_lists = defaultdict(list)
         keys = None

--- a/multiqc/modules/picard/QualityByCycleMetrics.py
+++ b/multiqc/modules/picard/QualityByCycleMetrics.py
@@ -17,7 +17,7 @@ def parse_reports(self):
     formats = [int, float]
     all_data = read_histogram(
         self,
-        f"{self.anchor}/quality_by_cycle",
+        "picard/quality_by_cycle",
         headers,
         formats,
         picard_tool="MeanQualityByCycle",

--- a/multiqc/modules/picard/QualityScoreDistributionMetrics.py
+++ b/multiqc/modules/picard/QualityScoreDistributionMetrics.py
@@ -18,7 +18,7 @@ def parse_reports(self):
     formats = [int, int]
     all_data = read_histogram(
         self,
-        f"{self.anchor}/quality_score_distribution",
+        "picard/quality_score_distribution",
         headers,
         formats,
         picard_tool="QualityScoreDistribution",

--- a/multiqc/modules/picard/QualityYieldMetrics.py
+++ b/multiqc/modules/picard/QualityYieldMetrics.py
@@ -34,7 +34,7 @@ def parse_reports(module):
     expected_header = list(DESC.keys())
 
     # Go through logs and find Metrics
-    for f in module.find_log_files(f"{module.anchor}/quality_yield_metrics", filehandles=True):
+    for f in module.find_log_files("picard/quality_yield_metrics", filehandles=True):
         # Sample name from input file name by default.
         s_name = f["s_name"]
 


### PR DESCRIPTION
Shouldn't pass `self.anchor` to `self.find_log_files` dynamically as part of the search pattern - it breaks when a module is being used multiple times, since `self.anchor` would be overwritten. It's an artefact of supporting different tools in the same Picard functions, but Sentieon is not a separate module anymore, the only other place where Picard functions are reused is Biobamba, which we can account for specifically. So fixing the parameters to hardcode `picard`.

Fixes https://github.com/MultiQC/MultiQC/issues/2192