### PR TITLE
Remove unused dependency on `future` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix old link in Bismark docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - BclConvert: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
 - Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
-- remove one last reference to Python2 ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
+- Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 
 ### New modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix old link in Bismark docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - BclConvert: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
 - Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
+- remove one last reference to Python2 ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 
 ### New modules
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         "numpy",
         "click",
         "coloredlogs",
-        "future>0.14.0",
         "jinja2>=3.0.0",
         "markdown",
         "packaging",


### PR DESCRIPTION
python3-future is being removed now from Debian

multiqc has been patched today without this one line

https://bugs.debian.org/cgi-bin/pkgreport.cgi?src=multiqc