### PR TITLE
Hifiasm: account for lines with no asterisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,17 @@
 - Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 - Module for metaphlan ([#2262](https://github.com/MultiQC/MultiQC/pull/2262))
 - WIP: Add cluster statistics for HUMID ([#2265](https://github.com/MultiQC/MultiQC/pull/2265))
-- changed hifiasm module to account for lines with no asterisk ([#2268](https://github.com/MultiQC/MultiQC/pull/2268))
 
 ### New modules
 
 ### Module updates
 
-- **mosdepth**: Add additional summaries to general stats #2257 ([#2257](https://github.com/MultiQC/MultiQC/pull/2257))
-- **Seqera Platform CLI**: Updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
-- **Bismark**: fix old link in docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - **BclConvert**: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
+- **Bismark**: fix old link in docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
+- **HiFiasm**: account for lines with no asterisk ([#2268](https://github.com/MultiQC/MultiQC/pull/2268))
+- **mosdepth**: Add additional summaries to general stats #2257 ([#2257](https://github.com/MultiQC/MultiQC/pull/2257))
 - **Picard**: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
+- **Seqera Platform CLI**: Updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
 
 ## [MultiQC v1.19](https://github.com/ewels/MultiQC/releases/tag/v1.19) - 2023-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 - Module for metaphlan ([#2262](https://github.com/MultiQC/MultiQC/pull/2262))
 - WIP: Add cluster statistics for HUMID ([#2265](https://github.com/MultiQC/MultiQC/pull/2265))
+- changed hifiasm module to account for lines with no asterisk ([#2268](https://github.com/MultiQC/MultiQC/pull/2268))
 
 ### New modules
 

--- a/multiqc/modules/hifiasm/hifiasm.py
+++ b/multiqc/modules/hifiasm/hifiasm.py
@@ -100,8 +100,11 @@ class MultiqcModule(BaseMultiqcModule):
                 # Special case
                 if occurrence == "rest":
                     continue
-                # Count of the occurrence
-                count = int(spline[3])
+                # Count of the occurrence, checking for lines with no asterisk before count.
+                if "*" in spline[2]:
+                    count = int(spline[3])
+                else:
+                    count = int(spline[2])
                 data[int(occurrence)] = count
             # If we are no longer in the histogram
             elif found_histogram:


### PR DESCRIPTION

- [x] This comment contains a description of changes (with reason)

- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [x] Code is tested and works locally (including with `--strict` flag)
- [x] `docs/README.md` is updated with link to below
- [x] `docs/modulename.md` is created
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work

The hifiasm module doesn't account for kmer graphs which do not start with an asterisk. It is unknown if this is a recent update, or just something that occurs on small input data. 

I have updated it to check whether a kmer graph line starts with an asterisk, and use a different strategy if not.
