### PR TITLE
Update Singularity build command in installation.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
 - Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 - Fix incorrect scale IDs caught by linting ([#2272](https://github.com/MultiQC/MultiQC/pull/2272))
+- Update Singularity build command in installation.md ([#2273](https://github.com/MultiQC/MultiQC/pull/2273))
 
 ### New modules
 

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -297,7 +297,7 @@ This image was also renamed, versions up to v1.19 can be found at [`ghcr.io/ewel
 To build a singularity container image from the docker image, use the following command: _(change `1.20` to the current MultiQC version)_
 
 ```bash
-singularity build multiqc-1.20.sif docker://multiqc/multiqc:1.20
+singularity build multiqc-1.20.sif docker://multiqc/multiqc:v1.20
 ```
 
 Then, use `singularity run` to run the image with the normal MultiQC arguments:

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -241,7 +241,7 @@ docker run -t -v `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc . --title "My amaz
 
 By default, docker will use the `:latest` tag. For MultiQC, this is set to be the most recent release.
 To use the most recent development code, use `multiqc/multiqc:dev`.
-You can also specify specific versions, eg: `multiqc/multiqc:1.20`.
+You can also specify specific versions, eg: `multiqc/multiqc:v1.20`.
 
 Note that all files on the command line (eg. config files) must also be mounted in the docker container to be accessible.
 For more help, look into [the Docker documentation](https://docs.docker.com/engine/reference/commandline/run/).


### PR DESCRIPTION
Just a small change to the Singularity section of the install instructions:

`docker://multiqc/multiqc:1.20` is not the right URI, need to use `v1.20` (replacing version as appropriate) as the tag instead 

Using the former command results in `FATAL:   While performing build: conveyor failed to get: reading manifest 1.20 in docker.io/multiqc/multiqc: manifest unknown: manifest unknown`

Using `v1.19` instead worked.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [X] This comment contains a description of changes (with reason)
