### PR TITLE
Export `config.output_dir` in MegaQC JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Unicode file reading errors: attempt to skip non-unicode characters ([#2275](https://github.com/MultiQC/MultiQC/pull/2275))
 - Heatmap: check if value is numeric when calculating min and max ([#2276](https://github.com/MultiQC/MultiQC/pull/2276))
 - Use alternative method to walk directory using pathlib ([#2277](https://github.com/MultiQC/MultiQC/pull/2277))
+- feat: JSON cwd ([#2287](https://github.com/MultiQC/MultiQC/pull/2287))
 
 ### New modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Unicode file reading errors: attempt to skip non-unicode characters ([#2275](https://github.com/MultiQC/MultiQC/pull/2275))
 - Heatmap: check if value is numeric when calculating min and max ([#2276](https://github.com/MultiQC/MultiQC/pull/2276))
 - Use alternative method to walk directory using pathlib ([#2277](https://github.com/MultiQC/MultiQC/pull/2277))
-- feat: JSON cwd ([#2287](https://github.com/MultiQC/MultiQC/pull/2287))
+- Export `config.output_dir` in MegaQC JSON ([#2287](https://github.com/MultiQC/MultiQC/pull/2287))
 
 ### New modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -434,7 +434,7 @@ def run(
         analysis_dir = [analysis_dir]
     config.analysis_dir = analysis_dir
     if outdir is not None:
-        config.output_dir = outdir
+        config.output_dir = os.path.realpath(outdir)
     if use_filename_as_sample_name:
         config.use_filename_as_sample_name = True
         logger.info("Using log filenames for sample names")

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -25,10 +25,7 @@ logger = logging.getLogger("multiqc")
 # Get the MultiQC version
 version = importlib_metadata.version("multiqc")
 short_version = version
-# Get cwd and script path (included in MegaQC JSON)
-cwd = os.path.realpath(os.getcwd())
 script_path = os.path.dirname(os.path.realpath(__file__))
-# Get Git hash
 git_hash = None
 git_hash_short = None
 try:

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -25,6 +25,7 @@ logger = logging.getLogger("multiqc")
 # Get the MultiQC version
 version = importlib_metadata.version("multiqc")
 short_version = version
+cwd = os.path.realpath(os.getcwd())
 script_path = os.path.dirname(os.path.realpath(__file__))
 git_hash = None
 git_hash_short = None

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -25,8 +25,10 @@ logger = logging.getLogger("multiqc")
 # Get the MultiQC version
 version = importlib_metadata.version("multiqc")
 short_version = version
+# Get cwd and script path (included in MegaQC JSON)
 cwd = os.path.realpath(os.getcwd())
 script_path = os.path.dirname(os.path.realpath(__file__))
+# Get Git hash
 git_hash = None
 git_hash_short = None
 try:

--- a/multiqc/utils/megaqc.py
+++ b/multiqc/utils/megaqc.py
@@ -49,6 +49,8 @@ def multiqc_dump_json(report):
             "subtitle",
             "title",
             "version",
+            "cwd",
+            "output_dir",
         ],
     }
     for s in export_vars:

--- a/multiqc/utils/megaqc.py
+++ b/multiqc/utils/megaqc.py
@@ -49,7 +49,6 @@ def multiqc_dump_json(report):
             "subtitle",
             "title",
             "version",
-            "cwd",
             "output_dir",
         ],
     }


### PR DESCRIPTION
Add `output_dir` to JSON file, so it can be included in `MegaQC`.
Store `output_dir` as an absolute path, so it can be used in multiqc/megaqc#22.