### PR TITLE
Bcftools: order variant depths plot categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@
 
 ### Module updates
 
-- **BclConvert**: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
+- **Bcftools**: order variant depths plot categories ([#2289](https://github.com/MultiQC/MultiQC/pull/2289))
 - **BCLConvert**: Add index, project names to sample statistics and calculate mean quality for lane statistics. ([#2261](https://github.com/MultiQC/MultiQC/pull/2261))
+- **BclConvert**: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
 - **Bismark**: fix old link in docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - **HiFiasm**: account for lines with no asterisk ([#2268](https://github.com/MultiQC/MultiQC/pull/2268))
 - **mosdepth**: Add additional summaries to general stats #2257 ([#2257](https://github.com/MultiQC/MultiQC/pull/2257))

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -314,6 +314,11 @@ class StatsReportMixin:
             )
         # Make line graph of variants per depth
         if len(self.bcftools_stats_depth_data) > 0:
+            # Order depth bins as numbers
+            for sname, d in self.bcftools_stats_depth_data.items():
+                d = dict(sorted(d.items(), key=lambda x: int(re.sub(r"\D", "", x[0]))))
+                self.bcftools_stats_depth_data[sname] = d
+
             pconfig = {
                 "id": "bcftools_stats_variant_depths",
                 "title": "Bcftools Stats: Variant depths",

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -314,11 +314,16 @@ class StatsReportMixin:
             )
         # Make line graph of variants per depth
         if len(self.bcftools_stats_depth_data) > 0:
-            # Order depth bins as numbers
-            for sname, d in self.bcftools_stats_depth_data.items():
-                d = dict(sorted(d.items(), key=lambda x: int(re.sub(r"\D", "", x[0]))))
-                self.bcftools_stats_depth_data[sname] = d
-
+            # Get shared list of bins and order them numerically
+            all_bins = []
+            for sname, val_by_bin in self.bcftools_stats_depth_data.items():
+                all_bins.extend(list(val_by_bin.keys()))
+            all_bins = sorted(all_bins, key=lambda x: int(re.sub(r"\D", "", x)))
+            # Order bins in samples and fill missing bins:
+            sorted_data = {
+                sname: {b: self.bcftools_stats_depth_data[sname].get(b, 0) for b in all_bins}
+                for sname in self.bcftools_stats_depth_data
+            }
             pconfig = {
                 "id": "bcftools_stats_variant_depths",
                 "title": "Bcftools Stats: Variant depths",
@@ -333,7 +338,7 @@ class StatsReportMixin:
                 name="Variant depths",
                 anchor="bcftools-stats_depth_plot",
                 description="Read depth support distribution for called variants",
-                plot=linegraph.plot(self.bcftools_stats_depth_data, pconfig),
+                plot=linegraph.plot(sorted_data, pconfig),
             )
 
         # Make bargraph plot of missing sites


### PR DESCRIPTION
On the variant depths plot, depth bins end up shuffled when there are many samples, because for some samples data for some depths can be unavailable or zero. 

Add code to fill in missing bins, and order them globally across samples.