### PR TITLE
Fix "Copy Table" behaviour for table+violin

### DIFF
--- a/multiqc/plots/beeswarm.py
+++ b/multiqc/plots/beeswarm.py
@@ -34,22 +34,6 @@ def plot(data: List[Dict], headers: Optional[Union[List[Dict], Dict]] = None, pc
                     max values etc.
     :return: HTML string
     """
-    if headers is None:
-        headers = []
-    if pconfig is None:
-        pconfig = {}
-
-    # Allow user to overwrite any given config for this plot
-    if "id" in pconfig and pconfig["id"] and pconfig["id"] in config.custom_plot_config:
-        for k, v in config.custom_plot_config[pconfig["id"]].items():
-            pconfig[k] = v
-
-    # Given one dataset - turn it into a list
-    if not isinstance(data, list):
-        data = [data]
-    if not isinstance(headers, list):
-        headers = [headers]
-
     # Make a datatable object
     dt = table_object.DataTable(data, headers, pconfig)
 

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -61,11 +61,17 @@ class Plot(ABC):
     # Default width for flat plots
     FLAT_PLOT_WIDTH = 1100
 
-    def __init__(self, plot_type: PlotType, pconfig: Dict, n_datasets: int):
+    def __init__(
+        self,
+        plot_type: PlotType,
+        pconfig: Dict,
+        n_datasets: int,
+        id: Optional[str] = None,
+    ):
         if n_datasets == 0:
             raise ValueError("No datasets to plot")
 
-        self.id = pconfig.get("id")
+        self.id = id or pconfig.get("id")
         if self.id is None:  # ID of the plot group
             uniq_suffix = "".join(random.sample(string.ascii_lowercase, 10))
             is_static_suf = "static_" if config.plots_force_flat else ""

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import re
 from typing import Dict, List, Union, Any, Optional
 import copy
 
@@ -331,7 +330,7 @@ class ViolinPlot(Plot):
             pconfig,
             n_datasets=len(list_of_values_by_sample_by_metric),
             # To make sure we use a different ID for the table and the violin plot
-            id="violin-" + pconfig["id"],
+            id=f"violin-{dt.id}" if self.show_table else None,
         )
 
         self.datasets: List[ViolinPlot.Dataset] = [
@@ -447,18 +446,17 @@ class ViolinPlot(Plot):
                 + f' data-toggle="tooltip"></span> Showing {self.n_samples} samples.</p>'
             )
 
-        html = (
-            f"<div id='mqc-violin-{self.id}' style='{'display: none;' if (self.show_table and self.show_table_by_default) else ''}'>"
-            + f"{warning}"
-            + f"{violin_html}"
-            + "</div>"
-        )
-        if self.dt:
-            table_id = re.sub("^violin-", "table-", self.id)
-            table_html, configuration_modal = make_table(self.dt, table_id=table_id, violin_switch=True)
+        if not self.dt:
+            # Show violin alone
+            html = warning + violin_html
+        else:
+            # Switch between table and violin
+            table_html, configuration_modal = make_table(self.dt, violin_id=self.id)
+            visibility = "style='display: none;'" if self.show_table_by_default else ""
+            html = f"<div id='mqc_violintable_wrapper_{self.id}' {visibility}>{warning}{violin_html}</div>"
             if self.show_table:
                 visibility = "style='display: none;'" if not self.show_table_by_default else ""
-                html += f"<div id='mqc-{table_id}' {visibility}>{table_html}</div>"
+                html += f"<div id='mqc_violintable_wrapper_{self.dt.id}' {visibility}>{table_html}</div>"
             html += configuration_modal
         return html
 
@@ -477,12 +475,12 @@ class ViolinPlot(Plot):
     def buttons(self) -> []:
         """Add a control panel to the plot"""
         buttons = []
-        if not self.flat and any(len(ds.metrics) > 1 for ds in self.datasets):
+        if not self.flat and any(len(ds.metrics) > 1 for ds in self.datasets) and self.dt.id is not None:
             buttons.append(
                 self._btn(
                     cls="mqc_table_configModal_btn",
                     label="<span class='glyphicon glyphicon-th'></span> Configure columns",
-                    data_attrs={"toggle": "modal", "target": f"#{self.id}_configModal"},
+                    data_attrs={"toggle": "modal", "target": f"#{self.dt.id}_configModal"},
                 )
             )
         if self.show_table:
@@ -490,6 +488,7 @@ class ViolinPlot(Plot):
                 self._btn(
                     cls="mqc-violin-to-table",
                     label="<span class='glyphicon glyphicon-th-list'></span> Table",
+                    data_attrs={"table-id": self.dt.id, "violin-id": self.id},
                 )
             )
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import re
 from typing import Dict, List, Union, Any, Optional
 import copy
 
@@ -321,11 +322,17 @@ class ViolinPlot(Plot):
         assert len(list_of_values_by_sample_by_metric) == len(list_of_header_by_metric)
         assert len(list_of_values_by_sample_by_metric) > 0
 
-        super().__init__(PlotType.VIOLIN, pconfig, len(list_of_values_by_sample_by_metric))
-
         self.dt = dt
         self.show_table_by_default = dt is not None and show_table_by_default
         self.show_table = dt is not None
+
+        super().__init__(
+            PlotType.VIOLIN,
+            pconfig,
+            n_datasets=len(list_of_values_by_sample_by_metric),
+            # To make sure we use a different ID for the table and the violin plot
+            id="violin-" + pconfig["id"],
+        )
 
         self.datasets: List[ViolinPlot.Dataset] = [
             ViolinPlot.Dataset.create(ds, values_by_sample_by_metric, headers_by_metric)
@@ -447,9 +454,11 @@ class ViolinPlot(Plot):
             + "</div>"
         )
         if self.dt:
-            table_html, configuration_modal = make_table(self.dt, violin_switch=True)
+            table_id = re.sub("^violin-", "table-", self.id)
+            table_html, configuration_modal = make_table(self.dt, table_id=table_id, violin_switch=True)
             if self.show_table:
-                html += f"<div id='mqc-table-{self.id}' style='{'display: none;' if not self.show_table_by_default else ''}'>{table_html}</div>"
+                visibility = "style='display: none;'" if not self.show_table_by_default else ""
+                html += f"<div id='mqc-{table_id}' {visibility}>{table_html}</div>"
             html += configuration_modal
         return html
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -27,8 +27,8 @@ def plot(dt: DataTable, show_table_by_default=False) -> str:
 
 
 class ViolinPlot(Plot):
-    VIOLIN_HEIGHT = 70
-    EXTRA_HEIGHT = 50
+    VIOLIN_HEIGHT = 70  # single violin height
+    EXTRA_HEIGHT = 63  # extra space for the title and footer
 
     @dataclasses.dataclass
     class Dataset(BaseDataset):

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -30,11 +30,6 @@ def plot(data, headers=None, pconfig=None):
     :param headers: list of optional dicts with column config in key:value pairs.
     :return: HTML ready to be inserted into the page
     """
-    if headers is None:
-        headers = []
-    if pconfig is None:
-        pconfig = {}
-
     # Make a datatable object
     dt = table_object.DataTable(data, headers, pconfig)
 

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -86,8 +86,6 @@ class ViolinPlot extends Plot {
       violinValuesBySampleByMetric,
       scatterValuesBySampleByMetric,
     ] = this.prepData();
-    if (metrics.length === 0) return [];
-    if (sampleSettings.filter((s) => !s.hidden).length === 0) return [];
 
     let outliersWarning = true;
     metrics.forEach((metric) => {

--- a/multiqc/templates/default/assets/js/plotting.js
+++ b/multiqc/templates/default/assets/js/plotting.js
@@ -363,7 +363,7 @@ function renderPlot(target) {
   if (plot.datasets.length === 0) return false;
 
   // Useful for default views like a table that can be switched to a Violin plot.
-  if (plot.static) return;
+  // if (plot.static) return;
 
   let container = $("#" + target);
 

--- a/multiqc/templates/default/assets/js/plotting.js
+++ b/multiqc/templates/default/assets/js/plotting.js
@@ -362,9 +362,6 @@ function renderPlot(target) {
   if (plot === undefined) return false;
   if (plot.datasets.length === 0) return false;
 
-  // Useful for default views like a table that can be switched to a Violin plot.
-  // if (plot.static) return;
-
   let container = $("#" + target);
 
   // When the plot was already rendered, it's faster to call react, using the same signature

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -125,7 +125,7 @@ $(function () {
       $(target + " tbody tr").each(function () {
         let hasVal = false;
         $(this)
-          .find("td:visible")
+          .find("td")
           .each(function () {
             if (!$(this).hasClass("sorthandle") && $(this).text() !== "") {
               hasVal = true;

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -36,19 +36,19 @@ $(function () {
 
     $(".mqc-table-to-violin").click(function (e) {
       e.preventDefault();
-      let target = $(this).data("pid");
-      if (mqc_plots[target]) mqc_plots[target].static = false;
-      $("#mqc-table-" + target).hide();
-      $("#mqc-violin-" + target).show();
-      renderPlot(target);
+      let tableId = $(this).data("table-id");
+      let violinId = $(this).data("violin-id");
+      $("#mqc_violintable_wrapper_" + tableId).hide();
+      $("#mqc_violintable_wrapper_" + violinId).show();
+      renderPlot(violinId);
     });
 
     $(".mqc-violin-to-table").click(function (e) {
       e.preventDefault();
-      let target = $(this).data("pid");
-      if (mqc_plots[target]) mqc_plots[target].static = true;
-      $("#mqc-violin-" + target).hide();
-      $("#mqc-table-" + target).show();
+      let tableId = $(this).data("table-id");
+      let violinId = $(this).data("violin-id");
+      $("#mqc_violintable_wrapper_" + tableId).show();
+      $("#mqc_violintable_wrapper_" + violinId).hide();
     });
 
     // Copy table contents to clipboard
@@ -89,18 +89,22 @@ $(function () {
     /////// COLUMN CONFIG
     // show + hide columns
     $(".mqc_table_col_visible").change(function () {
-      let target = $(this).data("target");
-      mqc_table_col_updateVisible(target);
+      let tableId = $(this).data("table-id");
+      let violinId = $(this).data("violin-id");
+      mqc_table_col_updateVisible(tableId, violinId);
     });
     // Bulk set visible / hidden
     $(".mqc_configModal_bulkVisible").click(function (e) {
       e.preventDefault();
-      let target = $(this).data("target");
+      let tableId = $(this).data("table-id");
+      let violinId = $(this).data("violin-id");
       let visible = $(this).data("action") === "showAll";
-      $(target + "_configModal_table tbody .mqc_table_col_visible").prop("checked", visible);
-      mqc_table_col_updateVisible(target);
+      $("#" + tableId + "_configModal_table tbody .mqc_table_col_visible").prop("checked", visible);
+      mqc_table_col_updateVisible(tableId, violinId);
     });
-    function mqc_table_col_updateVisible(target) {
+    function mqc_table_col_updateVisible(tableId, violinId) {
+      let target = "#" + tableId;
+
       let metricsHidden = {};
       $(target + "_configModal_table .mqc_table_col_visible").each(function () {
         let metric = $(this).val();
@@ -136,15 +140,14 @@ $(function () {
       $(target + "_numcols").text($(target + " thead th:visible").length - 1);
 
       // Also update the violin plot
-      let pid = target.replace("#", "");
-      let plot = mqc_plots[pid];
-      if (plot !== undefined) {
+      if (violinId !== undefined) {
+        let plot = mqc_plots[violinId];
         plot.datasets.map((dataset) => {
           dataset["metrics"].map((metric) => {
             dataset["header_by_metric"][metric]["hidden"] = metricsHidden[metric];
           });
         });
-        renderPlot(pid);
+        renderPlot(violinId);
       }
     }
 
@@ -429,16 +432,16 @@ $(function () {
 // button is only visible when this is hidden. Ace!
 function change_mqc_table_col_order(table) {
   // Find the targets of this sorting
-  let tid = table.attr("id");
-  let target = tid.replace("_configModal_table", "");
+  let elemId = table.attr("id");
+  let tableId = elemId.replace("_configModal_table", "");
 
   // Collect the desired order of columns
   let classes = [];
-  $("#" + tid + " tbody tr").each(function () {
+  $("#" + elemId + " tbody tr").each(function () {
     classes.push($(this).attr("class"));
   });
   // Go through each row
-  $("#" + target + " tr").each(function () {
+  $("#" + tableId + " tr").each(function () {
     let cols = {};
     let row = $(this);
     // Detach any cell that matches a known class from above
@@ -451,7 +454,7 @@ function change_mqc_table_col_order(table) {
       });
     });
     // Insert detached cells back in the order given in the sorted table
-    for (var idx in classes) {
+    for (let idx in classes) {
       let c = classes[idx];
       if (cols[c] !== undefined) {
         row.append(cols[c]);


### PR DESCRIPTION
When we have both table and a violin view available, their wrappers end up having the same HTML `id`, effectively breaking the "Copy Table" functionality. 

Unfortunately, making sure that the IDs were distinct wasn't straightforward as a lot of callbacks depend on the ids. Eventually, we may want to add some abstractions for "plot views" or something, to make the code more organized and generalizable for multiple plot representations.