### PR TITLE
Make "Copy Table" button target the `table` element specifically

### DIFF
--- a/multiqc/modules/software_versions.py
+++ b/multiqc/modules/software_versions.py
@@ -53,7 +53,7 @@ class MultiqcModule(BaseMultiqcModule):
         html = [
             dedent(
                 f"""\
-                <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="#{table_id}">
+                <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="table#{table_id}">
                     <span class="glyphicon glyphicon-copy"></span> Copy table
                 </button>
                 <table class="table mqc_versions_table" id="{table_id}">

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -253,7 +253,7 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
     if not config.simple_output:
         # Copy Table Button
         html += f"""
-        <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="#{dt.id}">
+        <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="table#{dt.id}">
             <span class="glyphicon glyphicon-copy"></span> Copy table
         </button>
         """


### PR DESCRIPTION
When the section `anchor` is identical to the table id (e.g. https://github.com/MultiQC/MultiQC/issues/2293), the "Copy Table" button breaks, as it effectively targets the first element it can find with the ID, which happens to be the section header:

https://github.com/MultiQC/MultiQC/blob/4905cb8b4d72c0d39b0d0b9d6884d10413c9cd76/multiqc/templates/default/content.html#L42

Modifying the copy table target to target the `table` element specifically.

But ideally, we might want to make sure that IDs are different in custom content as well, without requiring users to make `section_anchor` and plot `id` distinct (run `report.save_htmlid` on one of them?).

Fixes https://github.com/MultiQC/MultiQC/issues/2293
