### PR TITLE
CI: test Windows on a single module to avoid timing out

### DIFF
--- a/.github/workflows/multiqc.yml
+++ b/.github/workflows/multiqc.yml
@@ -185,4 +185,8 @@ jobs:
 
       # Run all of the tests! Remember the BACKslash path separator!
       - name: All modules / Custom report filename
-        run: multiqc ${{ needs.changes.outputs.single_module }} --strict test_data\test-data-main\data\modules\ --filename full_report.html
+        run: |
+          single_module=${{ needs.changes.outputs.single_module }}
+          # want to run on just one module to avoid the windows job to time out:
+          single_module=${single_module:-"-m samtools"}   
+          multiqc ${{ single_module }} --strict test_data\test-data-main\data\modules\ \--filename full_report.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Drop support for module tags ([#2278](https://github.com/MultiQC/MultiQC/pull/2278))
 - Support multiple datasets in custom content ([#2291](https://github.com/MultiQC/MultiQC/pull/2291))
 - BclConvert: handle samples with zero yield ([#2297](https://github.com/MultiQC/MultiQC/pull/2297))
+- CI: test Windows on a single module to avoid timing out ([#2304](https://github.com/MultiQC/MultiQC/pull/2304))
 
 ### New modules
 


### PR DESCRIPTION
The Windows job keeps getting stuck on `verifybamid`: https://github.com/MultiQC/MultiQC/actions/runs/7832560787/job/21373181130

There is nothing special about the `verifybamid` module, though. The Windows job also started running for much longer even on the packages installation stage: https://github.com/MultiQC/MultiQC/actions/runs/7815698826/job/21319591875, so perhaps it's something transient. Hard to debug really without being able to log in into the instance.