### PR TITLE
Use Plotly `autorangeoptions` instead of `range`. Properly apply floor and ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Support multiple datasets in custom content ([#2291](https://github.com/MultiQC/MultiQC/pull/2291))
 - BclConvert: handle samples with zero yield ([#2297](https://github.com/MultiQC/MultiQC/pull/2297))
 - CI: test Windows on a single module to avoid timing out ([#2304](https://github.com/MultiQC/MultiQC/pull/2304))
+- Use Plotly `autorangeoptions` instead of `range`. Properly apply floor and ceiling ([#2306](https://github.com/MultiQC/MultiQC/pull/2306))
 
 ### New modules
 

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -199,13 +199,12 @@ class BarPlot(Plot):
                     for i in range(len(dataset.samples))
                 )
 
-            xmin_cnt = self.pconfig.get("ymin", xmin_cnt)
-            xmax_cnt = self.pconfig.get("ymax", xmax_cnt)
             dataset.layout.update(
                 yaxis=dict(
                     title=None,
                     hoverformat=dataset.layout["xaxis"]["hoverformat"],
                     ticksuffix=dataset.layout["xaxis"]["ticksuffix"],
+                    autorangeoptions=dataset.layout["xaxis"]["autorangeoptions"],
                     # Prevent JavaScript from automatically parsing categorical values as numbers:
                     type="category",
                 ),
@@ -213,7 +212,10 @@ class BarPlot(Plot):
                     title=dict(text=dataset.layout["yaxis"]["title"]["text"]),
                     hoverformat=dataset.layout["yaxis"]["hoverformat"],
                     ticksuffix=dataset.layout["yaxis"]["ticksuffix"],
-                    range=[xmin_cnt, xmax_cnt],
+                    autorangeoptions={
+                        "minallowed": xmin_cnt,
+                        "maxallowed": xmax_cnt,
+                    },
                 ),
             )
             dataset.trace_params.update(
@@ -261,13 +263,14 @@ class BarPlot(Plot):
 
                 if barmode == "group":
                     # calculating the min percentage range as well because it will be negative for negative values
-                    xmin_pct = min(min(cat["data_pct"][i] for cat in dataset.cats) for i in range(len(dataset.samples)))
+                    dataset.pct_range["xaxis"]["min"] = min(
+                        min(cat["data_pct"][i] for cat in dataset.cats) for i in range(len(dataset.samples))
+                    )
                 else:
-                    xmin_pct = min(
+                    dataset.pct_range["xaxis"]["min"] = min(
                         sum(cat["data_pct"][i] if cat["data_pct"][i] < 0 else 0 for cat in dataset.cats)
                         for i in range(len(dataset.samples))
                     )
-                dataset.pct_range = [xmin_pct, 100]
 
         if self.add_log_tab:
             # Sorting from small to large so the log switch makes sense

--- a/multiqc/templates/default/assets/js/plotting.js
+++ b/multiqc/templates/default/assets/js/plotting.js
@@ -208,9 +208,7 @@ $(function () {
     mqc_plots[target].lActive = !$(this).hasClass("active");
     $(this).toggleClass("active");
 
-    mqc_plots[target].axisControlledBySwitches.map((axis) => {
-      Plotly.relayout(target, axis + ".type", mqc_plots[target].lActive ? "log" : "linear");
-    });
+    renderPlot(target);
   });
 
   // Switch data source
@@ -381,15 +379,23 @@ function renderPlot(target) {
 
   // Apply pct/log toggle states
   plot.axisControlledBySwitches.map((axis) => {
-    plot.layout[axis].type = plot.lActive ? "log" : "linear";
+    // Setting range explicitly just for the bar plot:
+    plot.layout[axis].type = "linear";
+    let min = plot.layout[axis]["autorangeoptions"]["minallowed"];
+    let max = plot.layout[axis]["autorangeoptions"]["maxallowed"];
     if (plot.pActive) {
-      updateObject(plot.layout[axis], plot["pctAxisUpdate"], false);
-      plot.layout[axis]["range"] = [...dataset["pct_range"]];
+      updateObject(plot.layout[axis], plot.pctAxisUpdate, false);
+      min = dataset["pct_range"][axis]["min"];
+      max = dataset["pct_range"][axis]["max"];
     }
     if (plot.lActive) {
+      plot.layout[axis].type = "log";
       // otherwise Plotly will interpret the range as log10:
-      plot.layout[axis]["range"] = null;
+      min = min > 0 ? Math.log10(min) : null;
+      max = max > 0 ? Math.log10(max) : null;
     }
+    plot.layout[axis]["autorangeoptions"]["minallowed"] = min;
+    plot.layout[axis]["autorangeoptions"]["maxallowed"] = max;
   });
 
   let traces = plot.buildTraces();


### PR DESCRIPTION
More proper way to set the range. Allows to set each boundary separately instead of the whole tuple at once. 

The `autorangeoptions` section also supports analogues of xFloor/xCeiling, so using that instead of a hack.

Along the way, improved setting the percentage/log10 views of the barplot range.