### PR TITLE
More Plotly cleanup and fixes

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -213,8 +213,8 @@ def _modules_modified_by_pr(pr_number) -> set[str]:
 
     # Now adding module-specific files
     for path in altered_files:
-        if str(path).startswith(f"{MODULES_DIR}/"):
-            mod_name = path.parent.name
+        if path.is_relative_to(MODULES_DIR):
+            mod_name = path.relative_to(MODULES_DIR).parts[0]
             mod_names.add(mod_name)
 
     return mod_names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
 - Remove legacy Highcharts/Matplotlib code an optional template `highcharts` ([#2292](https://github.com/MultiQC/MultiQC/pull/2292))
 - Move GitHub repository to `MultiQC` organisation ([#2243](https://github.com/MultiQC/MultiQC/pull/2243))
 - Update all GitHub actions to their latest versions ([#2242](https://github.com/ewels/MultiQC/pull/2242))
-- Seqera CLI: Updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
-- Fix old link in Bismark docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
-- BclConvert: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
-- Picard: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
 - Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 - Fix incorrect scale IDs caught by linting ([#2272](https://github.com/MultiQC/MultiQC/pull/2272))
 - Docs: fix missing `v` prefix in docker image tags ([#2273](https://github.com/MultiQC/MultiQC/pull/2273))
@@ -20,12 +16,8 @@
 - Add `filesearch_file_shared` config option, remove unnecessary per-module `shared` flags in search patterns ([#2227](https://github.com/ewels/MultiQC/pull/2227))
 - Use alternative method to walk directory using pathlib ([#2277](https://github.com/MultiQC/MultiQC/pull/2277))
 - Export `config.output_dir` in MegaQC JSON ([#2287](https://github.com/MultiQC/MultiQC/pull/2287))
-- Seqera Platform CLI: handle failed tasks ([#2286](https://github.com/MultiQC/MultiQC/pull/2286))
 - Drop support for module tags ([#2278](https://github.com/MultiQC/MultiQC/pull/2278))
-- Support multiple datasets in custom content ([#2291](https://github.com/MultiQC/MultiQC/pull/2291))
-- BclConvert: handle samples with zero yield ([#2297](https://github.com/MultiQC/MultiQC/pull/2297))
-- CI: test Windows on a single module to avoid timing out ([#2304](https://github.com/MultiQC/MultiQC/pull/2304))
-- Use Plotly `autorangeoptions` instead of `range`. Properly apply floor and ceiling ([#2306](https://github.com/MultiQC/MultiQC/pull/2306))
+- Custom content: support multiple datasets ([#2291](https://github.com/MultiQC/MultiQC/pull/2291))
 
 ### New modules
 
@@ -40,16 +32,19 @@
 
 - **Bcftools**: order variant depths plot categories ([#2289](https://github.com/MultiQC/MultiQC/pull/2289))
 - **Bcftools**: add missing `self.ignore_samples` in stats ([#2288](https://github.com/MultiQC/MultiQC/pull/2288))
-- **BCLConvert**: Add index, project names to sample statistics and calculate mean quality for lane statistics. ([#2261](https://github.com/MultiQC/MultiQC/pull/2261))
-- **BclConvert**: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
+- **BCL Convert**: add index, project names to sample statistics and calculate mean quality for lane statistics. ([#2261](https://github.com/MultiQC/MultiQC/pull/2261))
+- **BCL Convert**: fix duplicated `yield` for 3.9.3+ when the yield is provided explicitly in Quality_Metrics ([#2253](https://github.com/MultiQC/MultiQC/pull/2253))
+- **BCL Convert**: handle samples with zero yield ([#2297](https://github.com/MultiQC/MultiQC/pull/2297))
+- **Bismark**: fix old link in Bismark docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - **Bismark**: fix old link in docs ([#2252](https://github.com/MultiQC/MultiQC/pull/2252))
 - **Cutadapt**: support JSON format ([#2281](https://github.com/MultiQC/MultiQC/pull/2281))
 - **HiFiasm**: account for lines with no asterisk ([#2268](https://github.com/MultiQC/MultiQC/pull/2268))
-- **HUMID**: Add cluster statistics ([#2265](https://github.com/MultiQC/MultiQC/pull/2265))
-- **mosdepth**: Add additional summaries to general stats #2257 ([#2257](https://github.com/MultiQC/MultiQC/pull/2257))
+- **HUMID**: add cluster statistics ([#2265](https://github.com/MultiQC/MultiQC/pull/2265))
+- **mosdepth**: add additional summaries to general stats #2257 ([#2257](https://github.com/MultiQC/MultiQC/pull/2257))
 - **Picard**: fix using multiple times in report: do not pass `module.anchor` to `self.find_log_files` ([#2255](https://github.com/MultiQC/MultiQC/pull/2255))
-- **QualiMap**: address NBSP as thousand separators ([#2282](https://github.com/MultiQC/MultiQC/pull/2282))
-- **Seqera Platform CLI**: Updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
+- **QualiMap**: address NBSP as thousands separators ([#2282](https://github.com/MultiQC/MultiQC/pull/2282))
+- **Seqera Platform CLI**: updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
+- **Seqera Platform CLI**: handle failed tasks ([#2286](https://github.com/MultiQC/MultiQC/pull/2286))
 
 ## [MultiQC v1.19](https://github.com/ewels/MultiQC/releases/tag/v1.19) - 2023-12-18
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -8,14 +8,15 @@ script-src 'self'
     'sha256-bEI7fmPkynn/19cr8rouPnov+ZbZ7P8bsWO2AiSfIGM=' # // Javascript for the FastQC MultiQC Mod///////////////// Per Base Sequence Cont
     'sha256-s+I8RWf3BWIpPmzCGLcbThkbBqyCu0jQ6bYb3ES1iDA=' # /*** plotly.js v2.27.0* Copyright 2012-2023, Plotly, Inc.* All rights reserved.*
     'sha256-eiGS4SJ1q6AOA5XgpkbRE5+XO2rNz+D2JjZ6lY57uwg=' # ////////////////////////////////////////////////// Flat plots controls//////////
-    'sha256-bfZnWs5fBuHQjRdWoZnyYPvE8Yt72b6ZR3djAP5Rf9k=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
+    'sha256-VQVaSCWx7Tw7JDkvFSYrZog9dle5pp+JncGkAdO1JHQ=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
     'sha256-1OBEUwtItTLX7y6ruLkqRS+jj5o2XKFAF6Z8mp+Y/U0=' # ////////////////////////////////////////////////// MultiQC Table code///////////
     'sha256-f8lyyCxWBLVPbYs/tVc1OEs3glMEm8wimK2K0SZprlM=' # ////////////////////////////////////////////////// MultiQC Report Toolbox Code//
     'sha256-ASQylzECdP7VNkxfkmQwDp4jNK9wdjolkizZgk2Zen0=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
     'sha256-MaWOHt3Ypx+T0eaSaDVcZaqFeYuyvtYPok/th8uU/1s=' # class LinePlot extends Plot {  activeDatasetSize() {    if (this.datasets.length
     'sha256-MoNMGbvzqWOC7dSfxHbJJYTdku35WXwcFpx5auIgvwI=' # class ScatterPlot extends Plot {  activeDatasetSize() {    if (this.datasets.len
     'sha256-4o06/K8XbqKEjPmqX0NFpD63VEZGYlgmb3wTZGE3DXE=' # class HeatmapPlot extends Plot {  constructor(dump) {    super(dump);    this.xC
-    'sha256-lU9nANX+BDx4HvhiaGlnHBQoHQNid5SVGaY+rz21/Lc=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
+    'sha256-J1hk+IJNtxaSYwkdE/OOMkkcGHFLfsxqVIcK/jAkymU=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
+    'sha256-L0eGKfzVDFdE34HopbSv113Z4Qv7z22YyZ3aCfFB1D4=' # // Return JS code required for plotting a single sample// RSeQC plot. Attempt to
 
     # 1.19
     'sha256-dtGH1XcAyKopMui5x20KnPxuGuSx9Rs6piJB/4Oqu6I=' # jquery.tablesorter.min.js

--- a/multiqc/modules/rseqc/assets/js/multiqc_rseqc.js
+++ b/multiqc/modules/rseqc/assets/js/multiqc_rseqc.js
@@ -30,7 +30,7 @@ function is_name_hidden(name) {
   // some local vars to make the code readable
   const hiddenText = window.mqc_hide_f_texts;
   const regexp_mode = window.mqc_hide_regex_mode;
-  const hide_show_mode = window.mqc_hide_mode == "show";
+  const hide_show_mode = window.mqc_hide_mode === "show";
   var match = false;
   // check hidden status for "name"
   if (hiddenText.length > 0) {
@@ -79,25 +79,25 @@ function get_highlight_color(name) {
 
 function single_sample_plot(e) {
   // In case of repeated modules: #rseqc_junction_saturation_plot, #rseqc_junction_saturation_plot-1, ..
-  var rseqc_junction_saturation_plot = $(e.currentTarget).closest(".hc-plot");
-  var rseqc_junction_saturation_plot_id = rseqc_junction_saturation_plot.attr("id");
-  var junction_sat_single_hint = rseqc_junction_saturation_plot
+  let rseqc_junction_saturation_plot = $(e.currentTarget).closest(".hc-plot");
+  let rseqc_junction_saturation_plot_id = rseqc_junction_saturation_plot.attr("id");
+  let junction_sat_single_hint = rseqc_junction_saturation_plot
     .closest(".mqc-section")
     .find("#junction_sat_single_hint");
-  var highlight_enabled = is_highlight_enabled();
-  var sample_color = "";
+  let highlight_enabled = is_highlight_enabled();
+  let sample_color = "";
 
   // Get the three datasets for this sample
-  var data = [{ name: "All Junctions" }, { name: "Known Junctions" }, { name: "Novel Junctions" }];
+  let data = [{ name: "All Junctions" }, { name: "Known Junctions" }, { name: "Novel Junctions" }];
 
-  var k = 0;
-  for (var i = 0; i < 3; i++) {
-    var ds = mqc_plots[rseqc_junction_saturation_plot_id]["datasets"][i];
+  let k = 0;
+  for (let i = 0; i < 3; i++) {
+    let ds = mqc_plots[rseqc_junction_saturation_plot_id]["datasets"][i];
     for (k = 0; k < ds.length; k++) {
       // explicitly take renaming into account, however
       // there is no protection against degenerate renaming:
       let current_sample_name = get_current_name(ds[k]["name"]);
-      if (current_sample_name == this.series.name) {
+      if (current_sample_name === this.series.name) {
         if (highlight_enabled) {
           sample_color = get_highlight_color(current_sample_name);
         }
@@ -108,7 +108,7 @@ function single_sample_plot(e) {
   }
 
   // Create single plot div, and hide overview
-  var newplot = $(
+  let newplot = $(
     '<div id="rseqc_junction_saturation_single"> \
         <div id="rseqc_junction_saturation_single_controls"> \
           <button class="btn btn-primary btn-sm" id="rseqc-junction_sat_single_return"> \
@@ -126,7 +126,7 @@ function single_sample_plot(e) {
         </div> \
       </div>',
   );
-  var pwrapper = rseqc_junction_saturation_plot.parent().parent();
+  let pwrapper = rseqc_junction_saturation_plot.parent().parent();
   newplot.insertAfter(pwrapper).hide().slideDown();
   pwrapper.slideUp();
   junction_sat_single_hint.slideUp();
@@ -155,12 +155,12 @@ function single_sample_plot(e) {
   // Listeners for previous / next plot
   newplot.find(".rseqc-junction_sat_single_prevnext").click(function (e) {
     e.preventDefault();
-    var current_sample_name;
-    var sample_is_hidden = true;
+    let current_sample_name;
+    let sample_is_hidden = true;
     // this shouldn't result in infinite loop, as there has to be
     // at least one sample non-hidden to activate single-sample view:
     while (sample_is_hidden) {
-      if ($(this).data("action") == "prev") {
+      if ($(this).data("action") === "prev") {
         k--;
         if (k < 0) {
           k = mqc_plots[rseqc_junction_saturation_plot_id]["datasets"][0].length - 1;
@@ -176,11 +176,11 @@ function single_sample_plot(e) {
       current_sample_name = get_current_name(mqc_plots[rseqc_junction_saturation_plot_id]["datasets"][0][k]["name"]);
       sample_is_hidden = is_name_hidden(current_sample_name);
     }
-    var hc = newplot.find(".hc-plot").highcharts();
-    for (var i = 0; i < 3; i++) {
+    let hc = newplot.find(".hc-plot").highcharts();
+    for (let i = 0; i < 3; i++) {
       hc.series[i].setData(mqc_plots[rseqc_junction_saturation_plot_id]["datasets"][i][k]["data"], false);
     }
-    var ptitle = "RSeQC Junction Saturation: " + current_sample_name;
+    let ptitle = "RSeQC Junction Saturation: " + current_sample_name;
     if (highlight_enabled) {
       sample_color = get_highlight_color(current_sample_name);
     }

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -217,6 +217,7 @@ class BarPlot(Plot):
                         "maxallowed": xmax_cnt,
                     },
                 ),
+                showlegend=len(dataset.cats) > 1,
             )
             dataset.trace_params.update(
                 orientation="h",

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -224,6 +224,7 @@ class HeatmapPlot(Plot):
                 [0.9, "#d73027"],
                 [1, "#a50026"],
             ]
+        decimal_places = pconfig.get("decimalPlaces", 2)
         for ds in self.datasets:
             ds.trace_params = {
                 "colorscale": colorscale,
@@ -234,7 +235,7 @@ class HeatmapPlot(Plot):
             }
             # Enable datalabels if there are less than 20x20 cells, unless heatmap_config.datalabels is set explicitly
             if pconfig.get("datalabels") is None and num_rows * num_cols < 400:
-                ds.trace_params["texttemplate"] = "%{z:.2f}"
+                ds.trace_params["texttemplate"] = "%{z:." + str(decimal_places) + "f}"
 
     def dump_for_javascript(self) -> Dict:
         """Serialise the plot data to pick up in JavaScript"""

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -169,7 +169,6 @@ class Plot(ABC):
             )
             if self.flat
             else None,
-            autotypenumbers="strict",  # do not convert strings to numbers
         )
         # Layout update for the counts/percentage switch
         self.pct_axis_update = dict(

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -541,7 +541,7 @@ def find_outliers(
     mean = np.mean(values)
     std_dev = np.std(values)
     if std_dev == 0:
-        logger.warning(f"All {len(values)} points have the same values" + (f", metric: '{metric}'" if metric else ""))
+        logger.debug(f"All {len(values)} points have the same values" + (f", metric: '{metric}'" if metric else ""))
         return np.zeros(len(values), dtype=bool)
 
     # Calculate Z-scores (measures of "outlyingness")
@@ -555,7 +555,7 @@ def find_outliers(
         indices = np.where(z_scores > z_cutoff)[0]
         while len(indices) <= len(added_values) and z_cutoff > 1.0:
             new_z_cutoff = z_cutoff - 0.2
-            logger.warning(
+            logger.debug(
                 f"No outliers found with Z-score cutoff {z_cutoff:.1f}, trying a lower cutoff: {new_z_cutoff:.1f}"
                 + (f", metric: '{metric}'" if metric else "")
             )

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -176,13 +176,14 @@ class ViolinPlot extends Plot {
         values.push(value);
       });
 
+      let axisKey = metricIdx === 0 ? "" : metricIdx + 1;
       traces.push({
         type: "violin",
         x: values,
         name: metricIdx, // headerByMetric[metric].title + "  ",
         text: samples, // sample names
-        xaxis: "x" + (metricIdx === 0 ? "" : metricIdx + 1),
-        yaxis: "y" + (metricIdx === 0 ? "" : metricIdx + 1),
+        xaxis: "x" + axisKey,
+        yaxis: "y" + axisKey,
         ...params,
       });
     });
@@ -214,11 +215,11 @@ class ViolinPlot extends Plot {
 
     let highlightingEnabled = sampleSettings.filter((s) => s.highlight).length > 0;
 
-    let seed = 1;
+    let seed = 42.1231;
     function random() {
       // Math.random does not have a seed, so we use this
       let x = Math.sin(seed++) * 10000;
-      return x - Math.floor(x);
+      return x - Math.round(x);
     }
     let scatters = [];
     // Add scatter plots on top of violins to show individual points
@@ -251,7 +252,7 @@ class ViolinPlot extends Plot {
         scatters.push({
           type: "scatter",
           x: [value],
-          y: [metricIdx + random() * jitter - jitter / 2], // add vertical jitter
+          y: [metricIdx + random() * jitter], // add vertical jitter
           text: [state.name ?? sample],
           xaxis: "x" + axisKey,
           yaxis: "y" + axisKey,


### PR DESCRIPTION
Few more fixes to the plotly code:

- [x] Heatmap: support `decimalPlaces`
- [x] Barplot: show legend only if >1 categories (makes `use_legend` redundant)
- [x] Barplot: set height relative to number of cats for barmode="group"
- [ ] There is still an annoying gap between inner bars when barmode="group"
- [x] Violin: print outliers warnings as debug messages
- [x] Violin: fix scatter points placement
- [x] Fix changelog ci in this PR