### PR TITLE
Configuration: fix reading `config.output_fn_name` and `--filename`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Drop support for module tags ([#2278](https://github.com/MultiQC/MultiQC/pull/2278))
 - Pin `Pillow` package, wrap add_logo in try-except ([#2312](https://github.com/MultiQC/MultiQC/pull/2312))
 - Custom content: support multiple datasets ([#2291](https://github.com/MultiQC/MultiQC/pull/2291))
+- Configuration: fix reading config.output_fn_name and --filename ([#2314](https://github.com/MultiQC/MultiQC/pull/2314))
 
 ### New modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -436,6 +436,8 @@ def run(
     if use_filename_as_sample_name:
         config.use_filename_as_sample_name = True
         logger.info("Using log filenames for sample names")
+    if filename is not None:
+        config.output_fn_name = filename
     if make_data_dir:
         config.make_data_dir = True
     if no_data_dir:
@@ -513,6 +515,7 @@ def run(
     del exclude
     del outdir
     del use_filename_as_sample_name
+    del filename
     del replace_names
     del sample_names
     del sample_filters
@@ -575,19 +578,19 @@ def run(
     if len(ignore_samples) > 0:
         logger.debug(f"Ignoring sample names that match: {', '.join(ignore_samples)}")
         config.sample_names_ignore.extend(ignore_samples)
-    if filename == "stdout":
+    if config.output_fn_name == "stdout":
         config.output_fn = sys.stdout
         logger.info("Printing report to stdout")
     else:
-        if config.title is not None and filename is None:
-            filename = re.sub(r"[^\w.-]", "", re.sub(r"[-\s]+", "-", config.title)).strip()
-            filename += "_multiqc_report"
-        if filename is not None:
-            if filename.endswith(".html"):
-                filename = filename[:-5]
-            config.output_fn_name = filename
-            config.data_dir_name = f"{filename}_data"
-            config.plots_dir_name = f"{filename}_plots"
+        if config.title is not None and config.output_fn_name is None:
+            config.output_fn_name = re.sub(r"[^\w.-]", "", re.sub(r"[-\s]+", "-", config.title)).strip()
+            config.output_fn_name += "_multiqc_report"
+        if config.output_fn_name is not None:
+            if config.output_fn_name.endswith(".html"):
+                config.output_fn_name = config.output_fn_name[:-5]
+            config.output_fn_name = config.output_fn_name
+            config.data_dir_name = f"{config.output_fn_name}_data"
+            config.plots_dir_name = f"{config.output_fn_name}_plots"
         if not config.output_fn_name.endswith(".html") and config.make_report:
             config.output_fn_name = f"{config.output_fn_name}.html"
 
@@ -641,13 +644,13 @@ def run(
     tmp_dir = tempfile.mkdtemp()
     logger.debug(f"Using temporary directory for creating report: {tmp_dir}")
     config.data_tmp_dir = os.path.join(tmp_dir, "multiqc_data")
-    if filename != "stdout" and config.make_data_dir is True:
+    if config.output_fn_name != "stdout" and config.make_data_dir is True:
         config.data_dir = config.data_tmp_dir
         os.makedirs(config.data_dir)
     else:
         config.data_dir = None
     config.plots_tmp_dir = os.path.join(tmp_dir, "multiqc_plots")
-    if filename != "stdout" and config.export_plots is True:
+    if config.output_fn_name != "stdout" and config.export_plots is True:
         config.plots_dir = config.plots_tmp_dir
         os.makedirs(config.plots_dir)
     else:
@@ -957,7 +960,7 @@ def run(
             f.write(json.dumps(report.plot_data))
 
     # Make the final report path & data directories
-    if filename != "stdout":
+    if config.output_fn_name != "stdout":
         if config.make_report:
             config.output_fn = os.path.join(config.output_dir, config.output_fn_name)
         config.data_dir = os.path.join(config.output_dir, config.data_dir_name)
@@ -1143,7 +1146,7 @@ def run(
         # Use jinja2 to render the template and overwrite
         config.analysis_dir = [os.path.realpath(d) for d in config.analysis_dir]
         report_output = j_template.render(report=report, config=config)
-        if filename == "stdout":
+        if config.output_fn_name == "stdout":
             print(report_output.encode("utf-8"), file=sys.stdout)
         else:
             try:

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -143,22 +143,24 @@ class DataTable:
                 shared_key = headers[idx][k].get("shared_key", None)
                 suffix = None
                 if shared_key in ["read_count", "long_read_count", "base_count"]:
-                    if shared_key == "read_count":
+                    if shared_key == "read_count" and config.read_count_prefix:
                         multiplier = config.read_count_multiplier
                         suffix = " " + config.read_count_prefix
-                    elif shared_key == "long_read_count":
+                    elif shared_key == "long_read_count" and config.long_read_count_prefix:
                         multiplier = config.long_read_count_multiplier
                         suffix = " " + config.long_read_count_prefix
-                    elif shared_key == "base_count":
+                    elif shared_key == "base_count" and config.base_count_prefix:
                         multiplier = config.base_count_multiplier
                         suffix = " " + config.base_count_prefix
+                    else:
+                        multiplier = 1
                     if headers[idx][k].get("modify") is None:
                         headers[idx][k]["modify"] = lambda x: x * multiplier
                     if headers[idx][k].get("min") is None:
                         headers[idx][k]["min"] = 0
                     if headers[idx][k].get("format") is None:
                         if multiplier == 1:
-                            headers[idx][k]["format"] = "{:,.0f}"
+                            headers[idx][k]["format"] = "{:,d}"
                 if suffix:
                     suffix = suffix.replace(" ", "&nbsp;")
                     if "suffix" not in headers[idx][k]:


### PR DESCRIPTION
Fixes https://github.com/MultiQC/MultiQC/issues/2305

Additionally, fix when `config.base_count_prefix` is set to null