### PR TITLE
Group-mode bar plot: fix inner gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Group-mode bar plot: fix inner gap ([#2321](https://github.com/MultiQC/MultiQC/pull/2321))
+
 ### New modules
 
 ### Module updates

--- a/CSP.txt
+++ b/CSP.txt
@@ -2,6 +2,9 @@
 # (Content Security Policy), you will need the following scripts allowlisted:
 
 script-src 'self'
+    # 1.21
+    'sha256-dwM1eUjdMDMsOAYMmE9F86/zv3Zme5VSXoLlJMHLrtg=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+
     # 1.20
     'sha256-tTUP7XMWeShHDbCfkNfh2MTlcpIsSP6ybV/ChnAPZyo=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//
     'sha256-GklszK6SQ46EiosR+K0skEd4P6blQVwOIWIXI2k1JkI=' # // Javascript for the FastQC MultiQC Mod///////////////// Per Base Sequence Cont

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -92,9 +92,7 @@ class BarPlot(Plot):
                 data = cat["data_pct"] if is_pct else cat["data"]
 
                 params = copy.deepcopy(self.trace_params)
-                marker = params["marker"]
-                marker["color"] = f"rgb({cat['color']})"
-
+                params["marker"]["color"] = f"rgb({cat['color']})"
                 fig.add_trace(
                     go.Bar(
                         y=self.samples,
@@ -166,7 +164,8 @@ class BarPlot(Plot):
             bargap=0.2,
             yaxis=dict(
                 showgrid=False,
-                categoryorder="category descending",  # otherwise the bars will be in reversed order to sample order
+                # Otherwise the bars will be in reversed order to sample order:
+                categoryorder="category descending",
                 automargin=True,  # to make sure there is enough space for ticks labels
                 title=None,
                 hoverformat=self.layout.xaxis.hoverformat,
@@ -183,6 +182,9 @@ class BarPlot(Plot):
                 # like we had a standard bar graph without subplots. We need to remove the space
                 # between the legend groups to make it look like a single legend.
                 tracegroupgap=0,
+                # Plotly plots the grouped bar graph in a reversed order in respect to
+                # the legend, so reversing the legend to match it:
+                traceorder="normal" if barmode != "group" else "reversed",
             ),
             hovermode="y unified",
             hoverlabel=dict(

--- a/multiqc/templates/default/assets/js/plots/bar.js
+++ b/multiqc/templates/default/assets/js/plots/bar.js
@@ -55,24 +55,42 @@ class BarPlot extends Plot {
     let traceParams = this.datasets[this.activeDatasetIdx]["trace_params"];
 
     return cats.map((cat) => {
-      return this.filteredSettings.map((sample, sampleIdx) => {
+      if (this.layout.barmode === "stack") {
+        // Plotting each sample as a separate trace to be able to set alpha for each
+        // sample color separately, so we can dim the de-highlighted samples.
+        return this.filteredSettings.map((sample, sampleIdx) => {
+          let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
+
+          let alpha = highlighted.length > 0 && sample.highlight === null ? 0.1 : 1;
+          params.marker.color = "rgba(" + cat.color + "," + alpha + ")";
+
+          return {
+            type: "bar",
+            x: [cat.data[sampleIdx]],
+            y: [sample.name],
+            name: cat.name,
+            meta: cat.name,
+            // To make sure the legend uses bright category colors and not the dim ones:
+            showlegend: sampleIdx === firstHighlightedSample,
+            legendgroup: cat.name,
+            ...params,
+          };
+        });
+      } else {
+        // "group"
+        // Plotly adds giant gaps between bars in the group mode when adding each sample as a
+        // separate trace. Sacrificing dimming the de-highlighted bars to get rid of this gap.
         let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
-
-        let alpha = highlighted.length > 0 && sample.highlight === null ? 0.1 : 1;
-        params.marker.color = "rgba(" + cat.color + "," + alpha + ")";
-
+        samples = this.filteredSettings.map((s) => s.name);
         return {
           type: "bar",
-          x: [cat.data[sampleIdx]],
-          y: [sample.name],
+          x: cat.data,
+          y: samples,
           name: cat.name,
           meta: cat.name,
-          // To make sure the legend uses bright category colors and not the deemed ones.
-          showlegend: sampleIdx === firstHighlightedSample,
-          legendgroup: cat.name,
           ...params,
         };
-      });
+      }
     });
   }
 

--- a/multiqc/templates/default/assets/js/plots/bar.js
+++ b/multiqc/templates/default/assets/js/plots/bar.js
@@ -82,6 +82,8 @@ class BarPlot extends Plot {
         // separate trace. Sacrificing dimming the de-highlighted bars to get rid of this gap.
         let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
         samples = this.filteredSettings.map((s) => s.name);
+        params.marker.color = "rgba(" + cat.color + ")";
+
         return {
           type: "bar",
           x: cat.data,


### PR DESCRIPTION
When adding each sample to the bar graph as a separate trace, when the barmode is `group` the Plotly adds a giant gap between the inner bars:

<img width="979" alt="Screenshot 2024-02-12 at 17 44 41" src="https://github.com/MultiQC/MultiQC/assets/1575412/689a8ad6-a8a6-407f-81af-715ae79e73cd">

Since the group mode is not used often, we can sacrifice dimming the de-highlighted bars and leave the trace labels as a highlight marker alone:

<img width="1127" alt="Screenshot 2024-02-12 at 17 46 31" src="https://github.com/MultiQC/MultiQC/assets/1575412/1ed18380-0e98-498d-bbb6-54d3004c7eee">
