### PR TITLE
Dragen: support `gvcf_metrics`

### DIFF
--- a/multiqc/modules/dragen/dragen.py
+++ b/multiqc/modules/dragen/dragen.py
@@ -37,19 +37,19 @@ class MultiqcModule(
     DragenScRnaMetrics,
     DragenScAtacMetrics,
 ):
-    """DRAGEN provides a number of differrent pipelines and outputs, including base calling, DNA and RNA alignment,
+    """DRAGEN provides a number of different pipelines and outputs, including base calling, DNA and RNA alignment,
     post-alignment processing and variant calling, covering virtually all stages of typical NGS data processing.
     However, it can be treated as a fast aligner with additional features on top, as users will unlikely use any
     features without enabling DRAGEN mapping. So we will treat this module as an alignment tool module and
     place it accordingly in the module_order list, in docs, etc.
 
     The QC metrics DRAGEN generates resemble those of samtools-stats, qualimap, mosdepth, bcftools-stats and alike.
-    Whenver possible, the visual output is made similar to those modules.
+    Whenever possible, the visual output is made similar to those modules.
 
     Note that this MultiQC module supports some of DRAGEN output but not all. Contributions are welcome!
 
     The code is structured in a way so every mix-in parses one type of QC file that DRAGEN generates
-    (e.g. *.mapping_metrics.csv, *.wgs_fine_hist_normal.csv, etc). If a corresponding file is found, a mix-in adds
+    (e.g. *.mapping_metrics.csv, *.wgs_fine_hist_normal.csv, etc.). If a corresponding file is found, a mix-in adds
     a section into the report.
     """
 

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -282,6 +282,7 @@ fn_clean_exts:
   - ".wgs_coverage_metrics"
   - ".wgs_hist"
   - ".vc_metrics"
+  - ".gvcf_metrics"
   - ".ploidy_estimation_metrics"
   - "_overall_mean_cov"
   - ".fragment_length_hist"

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -288,6 +288,8 @@ diamond:
   fn: "diamond.log"
 dragen/vc_metrics:
   fn: "*.vc_metrics.csv"
+dragen/gvcf_metrics:
+  fn: "*.gvcf_metrics.csv"
 dragen/ploidy_estimation_metrics:
   fn: "*.ploidy_estimation_metrics.csv"
 dragen/wgs_contig_mean_cov:


### PR DESCRIPTION
Supports `gvcf_metrics`. Whenever both `vc_metrics` and `gvcf_metrics` are available, overrides corresponding metrics from `vc_metrics` with those found in `gvcf_metrics`.

Fixes https://github.com/MultiQC/MultiQC/issues/2326