### PR TITLE
Always create JSON even when MegaQC upload disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Warn if `run_modules` contains a non-existent module ([#2322](https://github.com/MultiQC/MultiQC/pull/2322))
 - Group-mode bar plot: fix inner gap ([#2321](https://github.com/MultiQC/MultiQC/pull/2321))
 - Pin Plotly package and add a runtime version check ([#2325](https://github.com/MultiQC/MultiQC/pull/2325))
+- fix: JSON not being created when MegaQC upload disabled ([#2330](https://github.com/MultiQC/MultiQC/pull/2330))
 
 ### New modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Warn if `run_modules` contains a non-existent module ([#2322](https://github.com/MultiQC/MultiQC/pull/2322))
 - Group-mode bar plot: fix inner gap ([#2321](https://github.com/MultiQC/MultiQC/pull/2321))
 - Pin Plotly package and add a runtime version check ([#2325](https://github.com/MultiQC/MultiQC/pull/2325))
-- fix: JSON not being created when MegaQC upload disabled ([#2330](https://github.com/MultiQC/MultiQC/pull/2330))
+- Always create JSON even when MegaQC upload disabled ([#2330](https://github.com/MultiQC/MultiQC/pull/2330))
 
 ### New modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -956,7 +956,7 @@ def run(
     plugin_hooks.mqc_trigger("before_report_generation")
 
     # Data Export / MegaQC integration - save report data to file or send report data to an API endpoint
-    if (config.data_dump_file or config.megaqc_url) and config.megaqc_upload:
+    if config.data_dump_file or (config.megaqc_url and config.megaqc_upload):
         multiqc_json_dump = megaqc.multiqc_dump_json(report)
         if config.data_dump_file:
             util_functions.write_data_file(multiqc_json_dump, "multiqc_data", False, "json")


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Currently `JSON` file is not created if `--no-megaqc-upload` specified. I think `JSON` should always be created, except if `config.data_dump == False`.