### PR TITLE
Barplot: keep sample order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Pin Plotly package and add a runtime version check ([#2325](https://github.com/MultiQC/MultiQC/pull/2325))
 - Always create JSON even when MegaQC upload disabled ([#2330](https://github.com/MultiQC/MultiQC/pull/2330))
 - Fix gettng id from optional pconfig=None ([#2337](https://github.com/MultiQC/MultiQC/pull/2337))
+- Barplot: keep sample order ([#2339](https://github.com/MultiQC/MultiQC/pull/2339))
 
 ### New modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -3,7 +3,7 @@
 
 script-src 'self'
     # 1.21
-    'sha256-dwM1eUjdMDMsOAYMmE9F86/zv3Zme5VSXoLlJMHLrtg=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+    'sha256-bHPK47f6TsuMbS8pR8jVPzEK4orYin9an6P5OkYf+n8=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
 
     # 1.20
     'sha256-tTUP7XMWeShHDbCfkNfh2MTlcpIsSP6ybV/ChnAPZyo=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -55,6 +55,14 @@ class BarPlot(Plot):
             cats: List[Dict],
             samples: List[str],
         ) -> "BarPlot.Dataset":
+            # Need to reverse samples as the bar plot will show them reversed
+            samples = list(reversed(samples))
+            for cat in cats:
+                # Reverse the data to match the reversed samples
+                cat["data"] = list(reversed(cat["data"]))
+                if "data_pct" in cat:
+                    cat["data_pct"] = list(reversed(cat["data_pct"]))
+
             # Post-process categories
             for cat in cats:
                 # Split long category names
@@ -164,8 +172,7 @@ class BarPlot(Plot):
             bargap=0.2,
             yaxis=dict(
                 showgrid=False,
-                # Otherwise the bars will be in reversed order to sample order:
-                categoryorder="category descending",
+                categoryorder="trace",  # keep sample order
                 automargin=True,  # to make sure there is enough space for ticks labels
                 title=None,
                 hoverformat=self.layout.xaxis.hoverformat,

--- a/multiqc/templates/default/assets/js/plots/bar.js
+++ b/multiqc/templates/default/assets/js/plots/bar.js
@@ -55,7 +55,7 @@ class BarPlot extends Plot {
     let traceParams = this.datasets[this.activeDatasetIdx]["trace_params"];
 
     return cats.map((cat) => {
-      if (this.layout.barmode === "stack") {
+      if (this.layout.barmode !== "group") {
         // Plotting each sample as a separate trace to be able to set alpha for each
         // sample color separately, so we can dim the de-highlighted samples.
         return this.filteredSettings.map((sample, sampleIdx) => {


### PR DESCRIPTION
With `categoryorder="category descending"`, plotly automatically orders samples in the barplot. Disabling it and keeping the original order.

Address https://github.com/MultiQC/MultiQC/issues/2336