### PR TITLE
bcl2fastq: fix the top undetermined barcodes plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Module updates
 
+- **bcl2fastq**: fix the top undetermined barcodes plot ([#2340](https://github.com/MultiQC/MultiQC/pull/2340))
 - **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12


### PR DESCRIPTION
The top undetermined barcodes were not sorted for some reason before selecting the top 20, and because of that the plot was broken since 1.16. Fixing. 

Fixes https://github.com/MultiQC/MultiQC/issues/2336