### PR TITLE
DRAGEN: add few coverage metrics in general stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Module updates
 
 - **bcl2fastq**: fix the top undetermined barcodes plot ([#2340](https://github.com/MultiQC/MultiQC/pull/2340))
+- **DRAGEN**: add few coverage metrics in general stats ([#2341](https://github.com/MultiQC/MultiQC/pull/2341))
 - **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -268,6 +268,7 @@ METRICS = {
         "suffix": " %",
         "scale": "Purples",
         "colour": "255, 0, 0",
+        "exclude": False,
     },
     "aligned bases": {
         "order_priority": 0.3,
@@ -293,6 +294,7 @@ METRICS = {
         "scale": "Greens",
         "suffix": " %",
         "bgcols": {"NA": "#00FFFF"},
+        "exclude": False,
     },
     "average chr x coverage over region": {
         "order_priority": 1.0,
@@ -323,6 +325,7 @@ METRICS = {
         "order_priority": 3,
         "exclude": False,
         "hidden_own": False,
+        "hidden": False,
         "title": "Depth",
         "scale": "BrBG",
         "colour": "0, 255, 255",
@@ -353,6 +356,7 @@ METRICS = {
         "title": "Med aut cov",
         "suffix": " x",
         "scale": "Greens",
+        "exclude": False,
     },
     "mean/median autosomal coverage ratio over region": {
         "order_priority": 7.1,
@@ -367,6 +371,7 @@ METRICS = {
     "uniformity of coverage (pct > d.d*mean) over region": {
         "suffix": " %",
         "colour": "55, 255, 55",
+        "exclude": False,
         "extra": {
             # "Uniformity of coverage (PCT > 0.2*mean) over region" metric.
             "0.2": {
@@ -406,6 +411,7 @@ METRICS = {
         "scale": "Purples",
         "suffix": " %",
         "colour": "255, 50, 25",
+        "exclude": False,
         WGS: {
             # "scale": "Reds",
         },
@@ -772,6 +778,7 @@ def create_table_handlers():
                         m_id = re.sub(r"(\s|-|\.|_)+", " ", phenotype + "_" + metric)
                         gen_data[sample][m_id] = data[metric]
                         gen_headers[m_id] = coverage_headers[_metric].copy()
+                        del gen_headers[m_id]["colour"]
                         """
                         Some modifications are necessary to improve informativeness
                         of the general table, because several/many familiar tables

--- a/multiqc/modules/dragen/ploidy_estimation_metrics.py
+++ b/multiqc/modules/dragen/ploidy_estimation_metrics.py
@@ -61,6 +61,8 @@ def parse_ploidy_estimation_metrics_file(f):
 
     for line in f["f"].splitlines():
         _, _, metric, stat = line.split(",")
+        if stat.strip() == "":
+            continue
         try:
             stat = float(stat)
         except ValueError:


### PR DESCRIPTION
To match with 1.14, re-added a few coverage metrics into general stats. Showing Depth by default, and others are hidden.

Additionally, to match with 1.14, skip the `Sex` column if the metric is not available in ploidy estimation metrics.

https://github.com/MultiQC/MultiQC/issues/2332