### PR TITLE
fix general stats for mosdepth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix gettng id from optional pconfig=None ([#2337](https://github.com/MultiQC/MultiQC/pull/2337))
 - Barplot: keep sample order ([#2339](https://github.com/MultiQC/MultiQC/pull/2339))
 - MegaQC: dump `pconfig` ([#2344](https://github.com/MultiQC/MultiQC/pull/2344))
+- fix general stats for mosdepth ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
 
 ### New modules
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -327,44 +327,46 @@ class MultiqcModule(BaseMultiqcModule):
                 self.genstats_mediancov(genstats, genstats_headers, cumcov_dist_data)
 
         # Add mosdepth summary to General Stats
-        genstats_headers.update({
-            "mean_coverage": {
-                "title": "Mean Cov.",
-                "description": "Mean coverage",
-                "min": 0,
-                "scale": "BuPu",
+        genstats_headers.update(
+            {
+                "mean_coverage": {
+                    "title": "Mean Cov.",
+                    "description": "Mean coverage",
+                    "min": 0,
+                    "scale": "BuPu",
+                },
+                "min_coverage": {
+                    "title": "Min Cov.",
+                    "description": "Minimum coverage",
+                    "min": 0,
+                    "scale": "BuPu",
+                    "hidden": True,
+                },
+                "max_coverage": {
+                    "title": "Max Cov.",
+                    "description": "Maximum coverage",
+                    "min": 0,
+                    "scale": "BuPu",
+                    "hidden": True,
+                },
+                "coverage_bases": {
+                    "title": f"{config.base_count_prefix} Total Coverage Bases",
+                    "description": f"Total coverage of bases ({config.base_count_desc})",
+                    "min": 0,
+                    "shared_key": "base_count",
+                    "scale": "Greens",
+                    "hidden": True,
+                },
+                "length": {
+                    "title": "Genome length",
+                    "description": "Total length of the genome",
+                    "min": 0,
+                    "scale": "Greys",
+                    "format": "{:,d}",
+                    "hidden": True,
+                },
             },
-            "min_coverage": {
-                "title": "Min Cov.",
-                "description": "Minimum coverage",
-                "min": 0,
-                "scale": "BuPu",
-                "hidden": True,
-            },
-            "max_coverage": {
-                "title": "Max Cov.",
-                "description": "Maximum coverage",
-                "min": 0,
-                "scale": "BuPu",
-                "hidden": True,
-            },
-            "coverage_bases": {
-                "title": f"{config.base_count_prefix} Total Coverage Bases",
-                "description": f"Total coverage of bases ({config.base_count_desc})",
-                "min": 0,
-                "shared_key": "base_count",
-                "scale": "Greens",
-                "hidden": True,
-            },
-            "length": {
-                "title": "Genome length",
-                "description": "Total length of the genome",
-                "min": 0,
-                "scale": "Greys",
-                "format": "{:,d}",
-                "hidden": True,
-            },
-        })
+        )
         self.general_stats_addcols(genstats, genstats_headers)
 
     def parse_cov_dist(self, scope):

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -327,7 +327,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.genstats_mediancov(genstats, genstats_headers, cumcov_dist_data)
 
         # Add mosdepth summary to General Stats
-        genstats_headers = {
+        genstats_headers.update({
             "mean_coverage": {
                 "title": "Mean Cov.",
                 "description": "Mean coverage",
@@ -364,7 +364,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "format": "{:,d}",
                 "hidden": True,
             },
-        }
+        })
         self.general_stats_addcols(genstats, genstats_headers)
 
     def parse_cov_dist(self, scope):


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Fixes general stats for mosdepth, includes coverage threshold columns

Regression from https://github.com/MultiQC/MultiQC/pull/2257

That PR overwrote general stats headers instead of just adding. Some of the functions called had already set fields on general stats headers.

The issue happens on multiqc testdata!!

Before my fix:

![Screenshot 2024-02-18 at 06-07-57 MultiQC Report](https://github.com/MultiQC/MultiQC/assets/6404517/5d9e40e3-816e-406e-8716-c5a2482d2264)

After:

![Screenshot 2024-02-18 at 06-08-20 MultiQC Report](https://github.com/MultiQC/MultiQC/assets/6404517/2c2f542a-483a-43ba-933f-2aeee19e228d)

What tests do we need to add so this would have been caught via automated testing?
