### PR TITLE
DRAGEN: fix showing the number of found samples 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - **bcl2fastq**: fix the top undetermined barcodes plot ([#2340](https://github.com/MultiQC/MultiQC/pull/2340))
 - **DRAGEN**: add few coverage metrics in general stats ([#2341](https://github.com/MultiQC/MultiQC/pull/2341))
+- **DRAGEN**: fix showing number of samples ([#2347](https://github.com/MultiQC/MultiQC/pull/2347))
 - **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - **bcl2fastq**: fix the top undetermined barcodes plot ([#2340](https://github.com/MultiQC/MultiQC/pull/2340))
 - **DRAGEN**: add few coverage metrics in general stats ([#2341](https://github.com/MultiQC/MultiQC/pull/2341))
-- **DRAGEN**: fix showing number of samples ([#2347](https://github.com/MultiQC/MultiQC/pull/2347))
+- **DRAGEN**: fix showing the number of found samples ([#2347](https://github.com/MultiQC/MultiQC/pull/2347))
 - **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
 - **mosdepth**: Fix regression in showing general stats ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@
 - Group-mode bar plot: fix inner gap ([#2321](https://github.com/MultiQC/MultiQC/pull/2321))
 - Pin Plotly package and add a runtime version check ([#2325](https://github.com/MultiQC/MultiQC/pull/2325))
 - Always create JSON even when MegaQC upload disabled ([#2330](https://github.com/MultiQC/MultiQC/pull/2330))
-- Fix gettng id from optional pconfig=None ([#2337](https://github.com/MultiQC/MultiQC/pull/2337))
+- Fix getting id from optional pconfig=None ([#2337](https://github.com/MultiQC/MultiQC/pull/2337))
 - Barplot: keep sample order ([#2339](https://github.com/MultiQC/MultiQC/pull/2339))
 - MegaQC: dump `pconfig` ([#2344](https://github.com/MultiQC/MultiQC/pull/2344))
-- fix general stats for mosdepth ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
 
 ### New modules
 
@@ -21,6 +20,7 @@
 - **DRAGEN**: add few coverage metrics in general stats ([#2341](https://github.com/MultiQC/MultiQC/pull/2341))
 - **DRAGEN**: fix showing number of samples ([#2347](https://github.com/MultiQC/MultiQC/pull/2347))
 - **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
+- **mosdepth**: Fix regression in showing general stats ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12
 

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -548,7 +548,7 @@ class DragenCoverageMetrics(BaseMultiqcModule):
 
                 cov_data[cleaned_sample][phenotype] = out["data"]  # Add/overwrite the sample.
 
-                all_samples[cleaned_sample + "." + phenotype].append(file)
+                all_samples[cleaned_sample].append(file)
                 match_overall_mean_cov[cleaned_sample][phenotype] = (original_sample, file["root"])
                 all_metrics.update(out["metric_IDs_with_original_names"])
 
@@ -563,7 +563,7 @@ class DragenCoverageMetrics(BaseMultiqcModule):
         cov_headers = make_coverage_headers(all_metrics)
 
         # Check samples for duplicates.
-        check_duplicate_samples(all_samples, log, "dragen/coverage_metrics")
+        check_duplicate_samples(all_samples, log)
 
         # Report found info/warnings/errors, which were collected while
         # calling the coverage_parser and constructing cov_headers.
@@ -591,7 +591,7 @@ class DragenCoverageMetrics(BaseMultiqcModule):
                 helptext=cov_section["helptext"],
                 plot=cov_section["plot"],
             )
-        return {sample + phenotype for sample in cov_data for phenotype in cov_data[sample]}
+        return cov_data.keys()
 
 
 def make_data_for_txt_reports(coverage_data, metrics):

--- a/multiqc/modules/dragen/dragen.py
+++ b/multiqc/modules/dragen/dragen.py
@@ -116,4 +116,4 @@ class MultiqcModule(
 
         if len(samples_found) == 0:
             raise ModuleNoSamplesFound
-        log.info(f"Found {len(samples_found)} reports")
+        log.info(f"Found samples: {len(samples_found)}")

--- a/multiqc/modules/dragen/ploidy_estimation_metrics.py
+++ b/multiqc/modules/dragen/ploidy_estimation_metrics.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 
 from multiqc.modules.base_module import BaseMultiqcModule
 
@@ -57,8 +56,7 @@ def parse_ploidy_estimation_metrics_file(f):
     PLOIDY ESTIMATION,,Ploidy estimation,X0
     """
 
-    data = defaultdict(dict)
-
+    data = {}
     for line in f["f"].splitlines():
         _, _, metric, stat = line.split(",")
         if stat.strip() == "":

--- a/multiqc/modules/dragen/utils.py
+++ b/multiqc/modules/dragen/utils.py
@@ -141,7 +141,7 @@ def exist_and_number(data, *metrics):
     return all(isinstance(data.get(m, None), int) or isinstance(data.get(m, None), float) for m in metrics)
 
 
-def check_duplicate_samples(sample_names, logger, module):
+def check_duplicate_samples(sample_names, logger):
     """Check samples for duplicate names. Warn about found ones."""
     message = ""
     line1 = "\n  {} was built from the following samples:"


### PR DESCRIPTION
Do not count phenotypes and targets as separate samples when showing the number of found reports.

Fix https://github.com/MultiQC/MultiQC/issues/2332