### PR TITLE
Catch non-hashable values in table data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix getting id from optional pconfig=None ([#2337](https://github.com/MultiQC/MultiQC/pull/2337))
 - Barplot: keep sample order ([#2339](https://github.com/MultiQC/MultiQC/pull/2339))
 - MegaQC: dump `pconfig` ([#2344](https://github.com/MultiQC/MultiQC/pull/2344))
+- Catch non-hashable values in table data ([#2348](https://github.com/MultiQC/MultiQC/pull/2348))
 
 ### New modules
 

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -196,40 +196,47 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
                 if badge_col is not None:
                     valstring = f'<span class="badge" style="background-color:{badge_col}">{valstring}</span>'
 
-                # Categorical background colours supplied
-                if val in header.get("bgcols", {}).keys():
-                    col = f"style=\"background-color:{header['bgcols'][val]} !important;\""
-                    if s_name not in t_rows:
-                        t_rows[s_name] = dict()
-                    t_rows[s_name][rid] = '<td val="{val}" class="{rid} {h}" {c}>{v}</td>'.format(
-                        val=val, rid=rid, h=hide, c=col, v=valstring
-                    )
-
-                # Build table cell background colour bar
-                elif header["scale"]:
-                    if c_scale is not None:
-                        col = " background-color:{} !important;".format(
-                            c_scale.get_colour(val, source=f'Table "{dt.id}", column "{k}"')
+                # Determine background color based on scale. Only relevant for hashable values. If value is for some
+                # reason a dict or a list, it's not hashable and the logic determining the color will not work.
+                hashable = True
+                try:
+                    hash(val)
+                except TypeError:
+                    hashable = False
+                    print(f"Value {val} is not hashable for table {dt.id}, column {k}, sample {s_name}")
+                if hashable:
+                    # Categorical background colours supplied
+                    if val in header.get("bgcols", {}).keys():
+                        col = f"style=\"background-color:{header['bgcols'][val]} !important;\""
+                        if s_name not in t_rows:
+                            t_rows[s_name] = dict()
+                        t_rows[s_name][rid] = '<td val="{val}" class="{rid} {h}" {c}>{v}</td>'.format(
+                            val=val, rid=rid, h=hide, c=col, v=valstring
                         )
-                    else:
-                        col = ""
-                    bar_html = f'<span class="bar" style="width:{percentage}%;{col}"></span>'
-                    val_html = f'<span class="val">{valstring}</span>'
-                    wrapper_html = f'<div class="wrapper">{bar_html}{val_html}</div>'
 
-                    if s_name not in t_rows:
-                        t_rows[s_name] = dict()
-                    t_rows[s_name][rid] = '<td val="{val}" class="data-coloured {rid} {h}">{c}</td>'.format(
-                        val=val, rid=rid, h=hide, c=wrapper_html
-                    )
+                    # Build table cell background colour bar
+                    elif header["scale"]:
+                        if c_scale is not None:
+                            col = " background-color:{} !important;".format(
+                                c_scale.get_colour(val, source=f'Table "{dt.id}", column "{k}"')
+                            )
+                        else:
+                            col = ""
+                        bar_html = f'<span class="bar" style="width:{percentage}%;{col}"></span>'
+                        val_html = f'<span class="val">{valstring}</span>'
+                        wrapper_html = f'<div class="wrapper">{bar_html}{val_html}</div>'
+
+                        if s_name not in t_rows:
+                            t_rows[s_name] = dict()
+                        t_rows[s_name][rid] = '<td val="{val}" class="data-coloured {rid} {h}">{c}</td>'.format(
+                            val=val, rid=rid, h=hide, c=wrapper_html
+                        )
 
                 # Scale / background colours are disabled
                 else:
                     if s_name not in t_rows:
                         t_rows[s_name] = dict()
-                    t_rows[s_name][rid] = '<td val="{val}" class="{rid} {h}">{v}</td>'.format(
-                        val=val, rid=rid, h=hide, v=valstring
-                    )
+                    t_rows[s_name][rid] = f'<td val="{val}" class="{rid} {hide}">{valstring}</td>'
 
                 # Is this cell hidden or empty?
                 if s_name not in t_rows_empty:


### PR DESCRIPTION
This happened when DRAGEN had `defaultdict(dict)` as a data structure for table data, so this line populated a missing "Sex" column for a sample with an empty dict: https://github.com/MultiQC/MultiQC/blob/main/multiqc/plots/table_object.py#L281