### PR TITLE
Changelog bot: do not require PR title start with module name before checking if it is a module change

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -228,8 +228,8 @@ def _determine_change_type(pr_title, pr_number) -> tuple[str, dict]:
     added_modules = _modules_added_by_pr(pr_number)
     modified_modules = _modules_modified_by_pr(pr_number)
 
+    # Sanity check PR name suggesting a newly added module
     if pr_title.lower().capitalize().startswith("New module: "):
-        # Sanity check PR name suggesting a newly added module
         if len(added_modules) == 0:
             raise RuntimeError(
                 f"Could not find a new folder in '{MODULES_DIR}' with expected python files for the new module"

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -225,35 +225,34 @@ def _determine_change_type(pr_title, pr_number) -> tuple[str, dict]:
     Determine the type of the PR: new module, module update, or core update.
     Returns a tuple of the section name and the module info.
     """
+    added_modules = _modules_added_by_pr(pr_number)
+    modified_modules = _modules_modified_by_pr(pr_number)
 
     if pr_title.lower().capitalize().startswith("New module: "):
-        added_modules = _modules_added_by_pr(pr_number)
+        # Sanity check PR name suggesting a newly added module
         if len(added_modules) == 0:
             raise RuntimeError(
                 f"Could not find a new folder in '{MODULES_DIR}' with expected python files for the new module"
             )
         if len(added_modules) > 1:
             RuntimeError(f"Found multiple added modules: {added_modules}")
-        else:
-            mod_info = _find_module_info(added_modules[0])
-            proper_pr_title = f"New module: {mod_info['name']}"
-            if pr_title != proper_pr_title:
-                try:
-                    _run_cmd(f"cd {workspace_path} && gh pr edit --title '{proper_pr_title}'")
-                except (RuntimeError, subprocess.CalledProcessError) as e:
-                    print(
-                        f"Error executing command: {e}. Please alter the title manually: '{proper_pr_title}'",
-                        file=sys.stderr,
-                    )
-            return "### New modules", mod_info
 
-    # Check what modules were changed by the PR, and if the title starts with one
-    # of the names of the changed modules, assume it's a module update.
-    modified_modules = _modules_modified_by_pr(pr_number)
-    if len(modified_modules) == 1:
+    if len(added_modules) == 1 and len(modified_modules) == 0:
+        mod_info = _find_module_info(added_modules[0])
+        proper_pr_title = f"New module: {mod_info['name']}"
+        if pr_title != proper_pr_title:
+            try:
+                _run_cmd(f"cd {workspace_path} && gh pr edit --title '{proper_pr_title}'")
+            except (RuntimeError, subprocess.CalledProcessError) as e:
+                print(
+                    f"Error executing command: {e}. Please alter the title manually: '{proper_pr_title}'",
+                    file=sys.stderr,
+                )
+        return "### New modules", mod_info
+
+    elif len(modified_modules) == 1 and len(added_modules) == 0:
         mod_info = _find_module_info(modified_modules.pop())
-        if pr_title.lower().startswith(f"{mod_info['name'].lower()}: "):
-            return "### Module updates", mod_info
+        return "### Module updates", mod_info
 
     section = "### MultiQC updates"  # Default section for non-module (core) updates.
     return section, {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - MegaQC: dump `pconfig` ([#2344](https://github.com/MultiQC/MultiQC/pull/2344))
 - Catch non-hashable values in table data ([#2348](https://github.com/MultiQC/MultiQC/pull/2348))
 - Prevent parsing numerical sample names in heatmap ([#2349](https://github.com/MultiQC/MultiQC/pull/2349))
+- Changelog bot: do not require PR title start with module name before checking if it is a module change ([#2351](https://github.com/MultiQC/MultiQC/pull/2351))
 
 ### New modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - MegaQC: dump `pconfig` ([#2344](https://github.com/MultiQC/MultiQC/pull/2344))
 - Catch non-hashable values in table data ([#2348](https://github.com/MultiQC/MultiQC/pull/2348))
 - Prevent parsing numerical sample names in heatmap ([#2349](https://github.com/MultiQC/MultiQC/pull/2349))
-- Changelog bot: do not require PR title start with module name before checking if it is a module change ([#2351](https://github.com/MultiQC/MultiQC/pull/2351))
 
 ### New modules
 


### PR DESCRIPTION
If only one module changed, assume it's a module change.