### PR TITLE
Add box plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Catch non-hashable values in table data ([#2348](https://github.com/MultiQC/MultiQC/pull/2348))
 - Prevent parsing numerical sample names in heatmap ([#2349](https://github.com/MultiQC/MultiQC/pull/2349))
 - Infinite dmax or dmin fail JSON dump load in JavaScript ([#2354](https://github.com/MultiQC/MultiQC/pull/2354))
+- Add box plot ([#2358](https://github.com/MultiQC/MultiQC/pull/2358))
 
 ### New modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -5,7 +5,8 @@ script-src 'self'
     # 1.21
     'sha256-bHPK47f6TsuMbS8pR8jVPzEK4orYin9an6P5OkYf+n8=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
     'sha256-yRjvY4tSJ5z2ggAL/i5pJj+peALSAG9PD51Z0Hf7wzQ=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
-    'sha256-az74ueShpjkk2DuURkv/5TV3/Mxy2K0z00jsa3TPM1k=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+    'sha256-OzhPBnFiZsSBpwe4cpwbOg4/dYQSPNXG20bECdDtONM=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+    'sha256-mVO5Pel/niJHZXAV5BhYrr15QkRTeRFbjRpIVLbBsb4=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
 
     # 1.20
     'sha256-tTUP7XMWeShHDbCfkNfh2MTlcpIsSP6ybV/ChnAPZyo=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//

--- a/CSP.txt
+++ b/CSP.txt
@@ -4,6 +4,8 @@
 script-src 'self'
     # 1.21
     'sha256-bHPK47f6TsuMbS8pR8jVPzEK4orYin9an6P5OkYf+n8=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+    'sha256-yRjvY4tSJ5z2ggAL/i5pJj+peALSAG9PD51Z0Hf7wzQ=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
+    'sha256-az74ueShpjkk2DuURkv/5TV3/Mxy2K0z00jsa3TPM1k=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
 
     # 1.20
     'sha256-tTUP7XMWeShHDbCfkNfh2MTlcpIsSP6ybV/ChnAPZyo=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -205,16 +205,6 @@ html = bargraph.plot([data, data], cats, pconfig=...)
 
 Note that, as in this example, the plot data can be the same dictionary supplied twice.
 
-### Interactive / Flat image plots
-
-Note that the `bargraph.plot()` function can generate both interactive
-JavaScript (HighCharts) powered report plots _and_ flat image plots made using
-MatPlotLib. This choice is made within the function based on config variables
-such as number of data series and command line flags.
-
-Note that both plot types should come out looking pretty much identical. If
-you spot something that's missing in the flat image plots, let me know.
-
 ## Line graphs
 
 This base function works much like the above, but for two-dimensional
@@ -267,10 +257,10 @@ pconfig = {
     "ymax": None,                # Max y limit
     "ymin": None,                # Min y limit
     "yLog": False,               # Use log10 y axis?
-    "yPlotBands": None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#yAxis.plotBands
-    "xPlotBands": None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#xAxis.plotBands
-    "yPlotLines": None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#yAxis.plotLines
-    "xPlotLines": None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#xAxis.plotLines
+    "yPlotBands": None,          # Highlighted background bands
+    "xPlotBands": None,          # Highlighted background bands
+    "yPlotLines": None,          # Highlighted background lines
+    "xPlotLines": None,          # Highlighted background lines
     "tt_label": "{x}: {y:.2f}",  # Use to customise tooltip label, e.g. '{point.x} base pairs'
     "tt_decimals": None,         # Tooltip decimals when categories = True (when false use tt_label)
     "tt_suffix": None,           # Tooltip suffix when categories = True (when false use tt_label)
@@ -799,3 +789,12 @@ pconfig = {
     ]
 }
 ```
+
+## Interactive / Flat image plots
+
+Note that the all plotting functions except for `table` can generate both interactive
+JavaScript-powered report plots _and_ flat image plots. This choice is made
+depending on the presence of the `--flat` (`config.plots_flat`) flag.
+
+Note that both plot types should come out looking pretty much identical. If
+you spot something that's missing in the flat image plots, let me know.

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -38,7 +38,7 @@ self.add_section(
     anchor="mymod_section",
     description="This plot shows some really nice data.",
     helptext="This longer string (can be **markdown**) helps explain how to interpret the plot",
-    plot=bargraph.plot(data, categories, pconfig)
+    plot=bargraph.plot(data, cats=..., pconfig=...)
 )
 ```
 
@@ -70,7 +70,7 @@ data = {
         'aligned': 1275,
     }
 }
-html = bargraph.plot(data)
+html = bargraph.plot(data, pconfig=...)
 ```
 
 To specify the order of categories in the plot, you can supply a list of
@@ -78,7 +78,7 @@ dictionary keys. This can also be used to exclude a key from the plot.
 
 ```python
 cats = ['aligned', 'not_aligned']
-html = bargraph.plot(data, cats)
+html = bargraph.plot(data, cats, pconfig=...)
 ```
 
 If `cats` is given as a dict instead of a list, you can specify a nice name

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -16,12 +16,14 @@ Once you've done that, you will have access to the corresponding plotting
 functions:
 
 ```python
-bargraph.plot()
-linegraph.plot()
-scatter.plot()
-table.plot()
-beeswarm.plot()
-heatmap.plot()
+from multiqc.plots import bargraph, linegraph, scatter, table, violin, heatmap, box
+bargraph.plot(data=..., cats=..., pconfig=...)
+linegraph.plot(data=..., pconfig=...)
+scatter.plot(data=..., pconfig=...)
+table.plot(data=..., headers=..., pconfig=...)
+violin.plot(data=..., headers=..., pconfig=...)
+heatmap.plot(data=..., xcats=..., ycats=..., pconfig=...)
+box.plot(list_of_data_by_sample=..., pconfig=...)
 ```
 
 These have been designed to work in a similar manner to each other - you
@@ -31,12 +33,12 @@ report. You can add this to the module introduction or sections as described
 above. For example:
 
 ```python
-self.add_section (
-    name = 'Module Section',
-    anchor = 'mymod_section',
-    description = 'This plot shows some really nice data.',
-    helptext = 'This longer string (can be **markdown**) helps explain how to interpret the plot',
-    plot = bargraph.plot(self.parsed_data, categories, pconfig)
+self.add_section(
+    name="Module Section",
+    anchor="mymod_section",
+    description="This plot shows some really nice data.",
+    helptext="This longer string (can be **markdown**) helps explain how to interpret the plot",
+    plot=bargraph.plot(data, categories, pconfig)
 )
 ```
 
@@ -68,7 +70,7 @@ data = {
         'aligned': 1275,
     }
 }
-html_content = bargraph.plot(data)
+html = bargraph.plot(data)
 ```
 
 To specify the order of categories in the plot, you can supply a list of
@@ -76,7 +78,7 @@ dictionary keys. This can also be used to exclude a key from the plot.
 
 ```python
 cats = ['aligned', 'not_aligned']
-html_content = bargraph.plot(data, cats)
+html = bargraph.plot(data, cats)
 ```
 
 If `cats` is given as a dict instead of a list, you can specify a nice name
@@ -101,27 +103,27 @@ the plot. The defaults are as follows:
 ```python
 config = {
     # Building the plot
-    'id': '<random string>',                # HTML ID used for the plot
-    'cpswitch': True,                       # Show the 'Counts / Percentages' switch?
-    'cpswitch_c_active': True,              # Initial display with 'Counts' specified? False for percentages.
-    'cpswitch_counts_label': 'Counts',      # Label for 'Counts' button
-    'cpswitch_percent_label': 'Percentages',# Label for 'Percentages' button
-    'logswitch': False,                     # Show the 'Log10' switch?
-    'logswitch_active': False,              # Initial display with 'Log10' active?
-    'logswitch_label': 'Log10',             # Label for 'Log10' button
-    'hide_zero_cats': True,                 # Hide categories where data for all samples is 0
+    "id": "<random string>",                  # HTML ID used for the plot
+    "cpswitch": True,                         # Show the 'Counts / Percentages' switch?
+    "cpswitch_c_active": True,                # Initial display with 'Counts' specified? False for percentages.
+    "cpswitch_counts_label": "Counts",        # Label for 'Counts' button
+    "cpswitch_percent_label": "Percentages",  # Label for 'Percentages' button
+    "logswitch": False,                       # Show the 'Log10' switch?
+    "logswitch_active": False,                # Initial display with 'Log10' active?
+    "logswitch_label": "Log10",               # Label for 'Log10' button
+    "hide_zero_cats": True,                   # Hide categories where data for all samples is 0
     # Customising the plot
-    'title': None,                          # Plot title - should be in format "Module Name: Plot Title"
-    'ylab': None,                           # Y axis label
-    'ymax': None,                           # Max y limit
-    'ymin': None,                           # Min y limit
-    'tt_label': '{x}: {y:.2f}%',            # Customise tooltip label
-    'xsuffix': "%",                         # Suffix for the x-axis values and labels. Parsed from tt_label by default
-    'ysuffix': "%",                         # Suffix for the y-axis values and labels. Parsed from tt_label by default
-    'stacking': 'normal',                   # Set to None to have category bars side by side
-    'tt_decimals': 0,                       # Number of decimal places to use in the tooltip number
-    'tt_suffix': '',                        # Suffix to add after tooltip number
-    'height': 500                           # The default height of the plot, in pixels
+    "title": None,                            # Plot title - should be in format "Module Name: Plot Title"
+    "ylab": None,                             # Y axis label
+    "ymax": None,                             # Max y limit
+    "ymin": None,                             # Min y limit
+    "tt_label": "{x}: {y:.2f}%",              # Customise tooltip label
+    "xsuffix": "%",                           # Suffix for the x-axis values and labels. Parsed from tt_label by default
+    "ysuffix": "%",                           # Suffix for the y-axis values and labels. Parsed from tt_label by default
+    "stacking": "relative",                   # Set to "group" to have category bars side by side
+    "tt_decimals": 0,                         # Number of decimal places to use in the tooltip number
+    "tt_suffix": "",                          # Suffix to add after tooltip number
+    "height": 500                             # The default height of the plot, in pixels
 }
 ```
 
@@ -146,16 +148,25 @@ and specify the `data_labels` config option with the text to be used for the but
 pconfig = {
     'data_labels': ['Reads', 'Bases']
 }
-html_content = bargraph.plot([data1, data2], pconfig=pconfig)
+html = bargraph.plot([data1, data2], pconfig=pconfig)
 ```
 
-You can also customise the y-axis label and min/max values for each dataset:
+You can also customise any plot configuration per-dataset, for example,
+the y-axis label, min/max values, or title:
 
 ```python
 pconfig = {
-    'data_labels': [
-        {'name': 'Reads', 'ylab': 'Number of Reads'},
-        {'name': 'Bases', 'ylab': 'Number of Base Pairs', 'ymax':100}
+    "data_labels": [
+        {
+            "name": "Reads",  # Button label
+            "ylab": "Reads",  # Y-axis label
+        },
+        {
+            "name": "Base Pairs",
+            "ylab": "Base Pairs",
+            "ymax": 100,
+            "title": "Number of Base Pairs",  # Plot title
+        },
     ]
 }
 ```
@@ -171,8 +182,8 @@ For example, with two datasets supplied as above:
 
 ```python
 cats = [
-    ['aligned_reads','unaligned_reads'],
-    ['aligned_base_pairs','unaligned_base_pairs'],
+    ["aligned_reads", "unaligned_reads"],
+    ["aligned_base_pairs", "unaligned_base_pairs"],
 ]
 ```
 
@@ -189,7 +200,7 @@ cats = [
         "unaligned_base_pairs": {"name": "Unaligned Base Pairs", "color": "#f7a35c"},
     },
 ]
-html_content = bargraph.plot([data, data], cats, pconfig)
+html = bargraph.plot([data, data], cats, pconfig=...)
 ```
 
 Note that, as in this example, the plot data can be the same dictionary supplied twice.
@@ -199,7 +210,7 @@ Note that, as in this example, the plot data can be the same dictionary supplied
 Note that the `bargraph.plot()` function can generate both interactive
 JavaScript (HighCharts) powered report plots _and_ flat image plots made using
 MatPlotLib. This choice is made within the function based on config variables
-such as number of dataseries and command line flags.
+such as number of data series and command line flags.
 
 Note that both plot types should come out looking pretty much identical. If
 you spot something that's missing in the flat image plots, let me know.
@@ -213,59 +224,59 @@ each containing numeric `x:y` points. For example:
 ```python
 from multiqc.plots import linegraph
 data = {
-    'sample 1': {
-        '<x val 1>': '<y val 1>',
-        '<x val 2>': '<y val 2>'
+    "sample 1": {
+        "<x val 1>": "<y val 1>",
+        "<x val 2>": "<y val 2>",
     },
-    'sample 2': {
-        '<x val 1>': '<y val 1>',
-        '<x val 2>': '<y val 2>'
-    }
+    "sample 2": {
+        "<x val 1>": "<y val 1>",
+        "<x val 2>": "<y val 2>",
+    },
 }
-html_content = linegraph.plot(data)
+
+html = linegraph.plot(data)
 ```
 
 Additionally, a configuration dict can be supplied. The defaults are as follows:
 
 ```python
-from multiqc.plots import linegraph
 pconfig = {
     # Building the plot
-    'id': '<random string>',     # HTML ID used for plot
-    'categories': False,         # Set to True to use x values as categories instead of numbers.
-    'colors': dict(),            # Provide dict with keys = sample names and values colours
-    'smooth_points': None,       # Supply a number to limit number of points / smooth data
-    'smooth_points_sumcounts': True, # Sum counts in bins, or average? Can supply list for multiple datasets
-    'logswitch': False,          # Show the 'Log10' switch?
-    'logswitch_active': False,   # Initial display with 'Log10' active?
-    'logswitch_label': 'Log10',  # Label for 'Log10' button
-    'extra_series': None,        # See section below
+    "id": "<random string>",     # HTML ID used for plot
+    "categories": False,         # Set to True to use x values as categories instead of numbers.
+    "colors": dict(),            # Provide dict with keys = sample names and values colours
+    "smooth_points": None,       # Supply a number to limit number of points / smooth data
+    "smooth_points_sumcounts": True,  # Sum counts in bins, or average? Can supply list for multiple datasets
+    "logswitch": False,          # Show the 'Log10' switch?
+    "logswitch_active": False,   # Initial display with 'Log10' active?
+    "logswitch_label": "Log10",  # Label for 'Log10' button
+    "extra_series": None,        # See section below
     # Plot configuration
-    'title': None,               # Plot title - should be in format "Module Name: Plot Title"
-    'xlab': None,                # X axis label
-    'ylab': None,                # Y axis label
-    'xCeiling': None,            # Maximum value for automatic axis limit (good for percentages)
-    'xFloor': None,              # Minimum value for automatic axis limit
-    'xMinRange': None,           # Minimum range for axis
-    'xmax': None,                # Max x limit
-    'xmin': None,                # Min x limit
-    'xLog': False,               # Use log10 x axis?
-    'yCeiling': None,            # Maximum value for automatic axis limit (good for percentages)
-    'yFloor': None,              # Minimum value for automatic axis limit
-    'yMinRange': None,           # Minimum range for axis
-    'ymax': None,                # Max y limit
-    'ymin': None,                # Min y limit
-    'yLog': False,               # Use log10 y axis?
-    'yPlotBands': None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#yAxis.plotBands
-    'xPlotBands': None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#xAxis.plotBands
-    'yPlotLines': None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#yAxis.plotLines
-    'xPlotLines': None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#xAxis.plotLines
-    'tt_label': '{x}: {y:.2f}', # Use to customise tooltip label, e.g. '{point.x} base pairs'
-    'tt_decimals': None,         # Tooltip decimals when categories = True (when false use tt_label)
-    'tt_suffix': None,           # Tooltip suffix when categories = True (when false use tt_label)
-    'height': 500                # The default height of the plot, in pixels
+    "title": None,               # Plot title - should be in format "Module Name: Plot Title"
+    "xlab": None,                # X axis label
+    "ylab": None,                # Y axis label
+    "xCeiling": None,            # Maximum value for automatic axis limit (good for percentages)
+    "xFloor": None,              # Minimum value for automatic axis limit
+    "xMinRange": None,           # Minimum range for axis
+    "xmax": None,                # Max x limit
+    "xmin": None,                # Min x limit
+    "xLog": False,               # Use log10 x axis?
+    "yCeiling": None,            # Maximum value for automatic axis limit (good for percentages)
+    "yFloor": None,              # Minimum value for automatic axis limit
+    "yMinRange": None,           # Minimum range for axis
+    "ymax": None,                # Max y limit
+    "ymin": None,                # Min y limit
+    "yLog": False,               # Use log10 y axis?
+    "yPlotBands": None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#yAxis.plotBands
+    "xPlotBands": None,          # Highlighted background bands. See http://api.highcharts.com/highcharts#xAxis.plotBands
+    "yPlotLines": None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#yAxis.plotLines
+    "xPlotLines": None,          # Highlighted background lines. See http://api.highcharts.com/highcharts#xAxis.plotLines
+    "tt_label": "{x}: {y:.2f}",  # Use to customise tooltip label, e.g. '{point.x} base pairs'
+    "tt_decimals": None,         # Tooltip decimals when categories = True (when false use tt_label)
+    "tt_suffix": None,           # Tooltip suffix when categories = True (when false use tt_label)
+    "height": 500                # The default height of the plot, in pixels
 }
-html_content = linegraph.plot(..., pconfig)
+html = linegraph.plot(..., pconfig)
 ```
 
 :::note
@@ -288,13 +299,13 @@ formats as described above). For example:
 ```python
 data = [
     {
-        'sample 1': { '<x val 1>': '<y val 1>', '<x val 2>': '<y val 2>' },
-        'sample 2': { '<x val 1>': '<y val 1>', '<x val 2>': '<y val 2>' }
+        "sample 1": {"<x val 1>": "<y val 1>", "<x val 2>": "<y val 2>"},
+        "sample 2": {"<x val 1>": "<y val 1>", "<x val 2>": "<y val 2>"},
     },
     {
-        'sample 1': { '<x val 1>': '<y val 1>', '<x val 2>': '<y val 2>' },
-        'sample 2': { '<x val 1>': '<y val 1>', '<x val 2>': '<y val 2>' }
-    }
+        "sample 1": {"<x val 1>": "<y val 1>", "<x val 2>": "<y val 2>"},
+        "sample 2": {"<x val 1>": "<y val 1>", "<x val 2>": "<y val 2>"},
+    },
 ]
 ```
 
@@ -303,9 +314,17 @@ give names to the buttons and graph labels:
 
 ```python
 config = {
-    'data_labels': [
-        {'name': 'DS 1', 'ylab': 'Dataset 1', 'xlab': 'x Axis 1'},
-        {'name': 'DS 2', 'ylab': 'Dataset 2', 'xlab': 'x Axis 2'}
+    "data_labels": [
+        {
+            "name": "DS 1",  # Button label
+            "ylab": "y axis 1",  # Y-axis label
+            "xlab": "x axis 1",  # X-axis label
+        },
+        {
+            "name": "DS 2",
+            "ylab": "y axis 2",
+            "xlab": "x axis 2",
+        },
     ]
 }
 ```
@@ -325,19 +344,63 @@ For example, to add a dotted `x = y` reference line:
 ```python
 from multiqc.plots import linegraph
 pconfig = {
-    'extra_series': {
-        'name': 'x = y',
-        'data': [[0, 0], [max_x_val, max_y_val]],
-        'dashStyle': 'Dash',
-        'lineWidth': 1,
-        'color': '#000000',
-        'marker': { 'enabled': False },
-        'enableMouseTracking': False,
-        'showInLegend': False,
+    "extra_series": {
+        "name": "x = y",
+        "data": [[0, 0], [max_x_val, max_y_val]],
+        "dashStyle": "Dash",
+        "lineWidth": 1,
+        "color": "#000000",
+        "marker": {"enabled": False},
+        "enableMouseTracking": False,
+        "showInLegend": False,
     }
 }
-html_content = linegraph.plot(data, pconfig)
+html = linegraph.plot(data, pconfig)
 ```
+
+## Box plots
+
+Box plots take similar data structure as line plots, but better visualize the
+underlying data distribution by emphasizing quartiles, mean, median, standard
+deviation, the extreme values and the outliers.
+
+Instead of x:y pairs, the box plot take a flat list of points for each sample:
+
+```python
+from multiqc.plots import box
+data = {
+    "sample 1": [9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "sample 2": [2, 4, 6, 6, 6, 10, 0, 1],
+}
+html = box.plot(data, pconfig=...)
+```
+
+It is also possible to pass a dictionary of statistics directly, instead of a list:
+
+```python
+data = {
+    "sample 1": {
+        "min": 1,
+        "q1": 3,
+        "median": 5,
+        "q3": 7,
+        "max": 9,
+        "mean": 5.5,
+    },
+    "sample 2": {
+        "min": 0,
+        "q1": 2,
+        "median": 6,
+        "q3": 6,
+        "max": 10,
+        "mean": 4.5,
+    },
+}
+html = box.plot(data, pconfig=...)
+```
+
+And similar to other plot types, multiple datasets can be passed as `data`, along with
+dataset-specific configurations provided with the `pconfig["data_labels"]` option.
 
 ## Scatter Plots
 
@@ -347,16 +410,16 @@ config options are shared between the two. The data structure is similar but not
 ```python
 from multiqc.plots import scatter
 data = {
-    'sample 1': {
-        "x": '<x val>',
-        "y": '<y val>'
+    "sample 1": {
+        "x": "<x val>",
+        "y": "<y val>",
     },
-    'sample 2': {
-        "x": '<x val>',
-        "y": '<y val>'
-    }
+    "sample 2": {
+        "x": "<x val>",
+        "y": "<y val>",
+    },
 }
-html_content = scatter.plot(data)
+html = scatter.plot(data)
 ```
 
 Note that you must use the keys `x` and `y` for each data point.
@@ -367,14 +430,14 @@ sample name suffixes (these are appended to the sample name):
 
 ```python
 data = {
-    'sample 1': [
-        { "x": '<x val>', "y": '<y val>', "color": '#a6cee3', "name": 'Type 1' },
-        { "x": '<x val>', "y": '<y val>', "color": '#1f78b4', "name": 'Type 2' }
+    "sample 1": [
+        {"x": "<x val>", "y": "<y val>", "color": "#a6cee3", "name": "Type 1"},
+        {"x": "<x val>", "y": "<y val>", "color": "#1f78b4", "name": "Type 2"},
     ],
-    'sample 2': [
-        { "x": '<x val>', "y": '<y val>', "color": '#b2df8a', "name": 'Type 1' },
-        { "x": '<x val>', "y": '<y val>', "color": '#33a02c', "name": 'Type 2' }
-    ]
+    "sample 2": [
+        {"x": "<x val>", "y": "<y val>", "color": "#b2df8a", "name": "Type 1"},
+        {"x": "<x val>", "y": "<y val>", "color": "#33a02c", "name": "Type 2"},
+    ],
 }
 ```
 
@@ -388,11 +451,11 @@ has a handful of unique ones in addition:
 
 ```python
 pconfig = {
-    'marker_colour': 'rgba(124, 181, 236, .5)', # string, base colour of points (recommend rgba / semi-transparent)
-    'marker_size': 5,               # int, size of points
-    'marker_line_colour': '#999',   # string, colour of point border
-    'marker_line_width': 1,         # int, width of point border
-    'square': False                 # Force the plot to stay square? (Maintain aspect ratio)
+    "marker_colour": "rgba(124, 181, 236, .5)",  # string, base colour of points (recommend rgba / semi-transparent)
+    "marker_size": 5,  # int, size of points
+    "marker_line_colour": "#999",  # string, colour of point border
+    "marker_line_width": 1,  # int, width of point border
+    "square": False,  # Force the plot to stay square? (Maintain aspect ratio)
 }
 ```
 
@@ -419,24 +482,24 @@ The default header keys are:
 
 ```python
 single_header = {
-    'namespace': '',                 # Name for grouping. Prepends desc and is in Config Columns modal
-    'title': '[ dict key ]',         # Short title, table column title
-    'description': '[ dict key ]',   # Longer description, goes in mouse hover text
-    'max': None,                     # Minimum value in range, for bar / colour coding
-    'min': None,                     # Maximum value in range, for bar / colour coding
-    'ceiling': None,                 # Maximum value for automatic bar limit
-    'floor': None,                   # Minimum value for automatic bar limit
-    'minRange': None,                # Minimum range for automatic bar
-    'scale': 'GnBu',                 # Colour scale for colour coding. False to disable.
-    'bgcols': None,                  # Dict with values: background colours for categorical data.
-    'colour': '<auto>',              # Colour for column grouping
-    'suffix': None,                  # Suffix for value (e.g. '%')
-    'format': '{:,.1f}',             # Value format string - default 1 decimal place
-    'cond_formatting_rules': None,   # Rules for conditional formatting table cell values - see docs below
-    'cond_formatting_colours': None, # Styles for conditional formatting of table cell values
-    'shared_key': None,              # See below for description
-    'modify': None,                  # Lambda function to modify values
-    'hidden': False                  # Set to True to hide the column on page load
+    "namespace": "",                 # Name for grouping. Prepends desc and is in Config Columns modal
+    "title": "[ dict key ]",         # Short title, table column title
+    "description": "[ dict key ]",   # Longer description, goes in mouse hover text
+    "max": None,                     # Minimum value in range, for bar / colour coding
+    "min": None,                     # Maximum value in range, for bar / colour coding
+    "ceiling": None,                 # Maximum value for automatic bar limit
+    "floor": None,                   # Minimum value for automatic bar limit
+    "minRange": None,                # Minimum range for automatic bar
+    "scale": "GnBu",                 # Colour scale for colour coding. False to disable.
+    "bgcols": None,                  # Dict with values: background colours for categorical data.
+    "colour": "<auto>",              # Colour for column grouping
+    "suffix": None,                  # Suffix for value (e.g. '%')
+    "format": "{:,.1f}",             # Value format string - default 1 decimal place
+    "cond_formatting_rules": None,   # Rules for conditional formatting table cell values - see docs below
+    "cond_formatting_colours": None, # Styles for conditional formatting of table cell values
+    "shared_key": None,              # See below for description
+    "modify": None,                  # Lambda function to modify values
+    "hidden": False                  # Set to True to hide the column on page load
 }
 ```
 
@@ -444,15 +507,15 @@ A third parameter can be specified with settings for the whole table:
 
 ```python
 table_config = {
-    'namespace': '',                           # Name for grouping. Prepends desc and is in Config Columns modal
-    'id': '<random string>',                   # ID used for the table
-    'table_title': '<table id>',               # Title of the table. Used in the column config modal
-    'save_file': False,                        # Whether to save the table data to a file
-    'raw_data_fn': 'multiqc_<table_id>_table', # File basename to use for raw data file
-    'sortRows': True,                          # Whether to sort rows alphabetically
-    'only_defined_headers': True,              # Only show columns that are defined in the headers config
-    'col1_header': 'Sample Name',              # The header used for the first column
-    'no_beeswarm': False,                      # Force a table to always be plotted (beeswarm by default if many rows)
+    "namespace": "",                           # Name for grouping. Prepends desc and is in Config Columns modal
+    "id": "<random string>",                   # ID used for the table
+    "table_title": "<table id>",               # Title of the table. Used in the column config modal
+    "save_file": False,                        # Whether to save the table data to a file
+    "raw_data_fn": "multiqc_<table_id>_table", # File basename to use for raw data file
+    "sortRows": True,                          # Whether to sort rows alphabetically
+    "only_defined_headers": True,              # Only show columns that are defined in the headers config
+    "col1_header": "Sample Name",              # The header used for the first column
+    "no_beeswarm": False,                      # Force a table to always be plotted (beeswarm by default if many rows)
 }
 ```
 
@@ -463,17 +526,18 @@ These will then be applied to all columns prior to applying column-specific head
 A very basic example of creating a table is shown below:
 
 ```python
+from multiqc.plots import table
 data = {
-    'sample 1': {
-        'aligned': 23542,
-        'not_aligned': 343,
+    "sample 1": {
+        "aligned": 23542,
+        "not_aligned": 343,
     },
-    'sample 2': {
-        'aligned': 1275,
-        'not_aligned': 7328,
-    }
+    "sample 2": {
+        "aligned": 1275,
+        "not_aligned": 7328,
+    },
 }
-table_html = table.plot(data)
+html = table.plot(data, headers=..., pconfig=...)
 ```
 
 A more complicated version with ordered columns, defaults and column-specific
@@ -481,46 +545,47 @@ settings (e.g. no decimal places):
 
 ```python
 data = {
-    'sample 1': {
-        'aligned': 23542,
-        'not_aligned': 343,
-        'aligned_percent': 98.563952271
+    "sample 1": {
+        "aligned": 23542,
+        "not_aligned": 343,
+        "aligned_percent": 98.563952271,
     },
-    'sample 2': {
-        'aligned': 1275,
-        'not_aligned': 7328,
-        'aligned_percent': 14.820411484
-    }
+    "sample 2": {
+        "aligned": 1275,
+        "not_aligned": 7328,
+        "aligned_percent": 14.820411484,
+    },
 }
 headers = {
     "aligned_percent": {
-        'title': '% Aligned',
-        'description': 'Percentage of reads that aligned',
-        'suffix': '%',
-        'max': 100,
-        'format': '{:,.0f}' # No decimal places please
+        "title": "% Aligned",
+        "description": "Percentage of reads that aligned",
+        "suffix": "%",
+        "max": 100,
+        "format": "{:,.0f}",  # No decimal places please
     },
     "aligned": {
-        'title': f'{config.read_count_prefix} Aligned',
-        'description': f'Aligned Reads ({config.read_count_desc})',
-        'shared_key': 'read_count',
-        'modify': lambda x: x * config.read_count_multiplier
+        "title": "Aligned",
+        "description": f"Aligned Reads ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "suffix": f" {config.read_count_prefix}",
+        "modify": lambda x: x * config.read_count_multiplier,
     },
     "config": {
-        'namespace': 'My Module',
-        'min': 0,
-        'scale': 'GnBu'
-    }
+        "namespace": "My Module",
+        "min": 0,
+        "scale": "GnBu",
+    },
 }
-table_html = table.plot(data, headers, config)
+html = table.plot(data, headers=headers, pconfig=...)
 ```
 
 ### Table decimal places
 
 You can customise how many decimal places a number has by using the `format` config
-key for that column. The default format string is `'{:,.1f}'`, which specifies a
-float number with a single decimal place. To remove decimals use `'{:,.0f}'`.
-To have two decimal places, use `'{:,.2f}'`.
+key for that column. The default format string is `"{:,.1f}"`, which specifies a
+float number with a single decimal place. To remove decimals use `"{:,d}"`.
+To have two decimal places, use `"{:,.2f}"`.
 
 ### Table colour scales
 
@@ -642,23 +707,25 @@ in ascending order, then by "Starting Amount (ng)", in descending (default) orde
 table with the ID `quast_table` (which you can find by clicking the "Configure Columns"
 button above the table in the report) will be sorted by "Largest contig".
 
-## Beeswarm plots (dot plots)
+## Violin plots
 
-Beeswarm plots work from the exact same data structure as tables, so the
-usage is just the same. Except instead of calling `table`, call `beeswarm`:
+Violin plots work from the exact same data structure as tables, so the
+usage is just the same. Moreover, a for every table, a switch button is available
+to view a corresponding violin plot for the underlying data.
 
 ```python
+from multiqc.plots import violin
 data = {
-    'sample 1': {
-        'aligned': 23542,
-        'not_aligned': 343,
+    "sample 1": {
+        "aligned": 23542,
+        "not_aligned": 343,
     },
-    'sample 2': {
-        'not_aligned': 7328,
-        'aligned': 1275,
-    }
+    "sample 2": {
+        "not_aligned": 7328,
+        "aligned": 1275,
+    },
 }
-beeswarm_html = beeswarm.plot(data)
+html = not violin.plot(data, headers=..., pconfig=...)
 ```
 
 The function also accepts the same headers and config parameters.
@@ -676,7 +743,8 @@ heatmap.plot(data, xcats, ycats, pconfig)
 A simple example:
 
 ```python
-hmdata = [
+from multiqc.plots import heatmap
+data = [
     [0.9, 0.87, 0.73, 0.6, 0.2, 0.3],
     [0.87, 1, 0.7, 0.6, 0.9, 0.3],
     [0.73, 0.8, 1, 0.6, 0.9, 0.3],
@@ -684,8 +752,8 @@ hmdata = [
     [0.2, 0.8, 0.7, 0.6, 1, 0.3],
     [0.3, 0.8, 0.7, 0.6, 0.9, 1],
 ]
-names = [ 'one', 'two', 'three', 'four', 'five', 'six' ]
-hm_html = heatmap.plot(hmdata, names)
+names = ["one", "two", "three", "four", "five", "six"]
+html = heatmap.plot(data, xcats=names, pconfig=...)
 ```
 
 Much like the other plots, you can change the way that the heatmap looks
@@ -693,20 +761,20 @@ using a config dictionary:
 
 ```python
 pconfig = {
-    'title': None,                 # Plot title - should be in format "Module Name: Plot Title"
-    'xTitle': None,                # X-axis title
-    'yTitle': None,                # Y-axis title
-    'min': None,                   # Minimum value (default: auto)
-    'max': None,                   # Maximum value (default: auto)
-    'square': True,                # Force the plot to stay square? (Maintain aspect ratio)
-    'xcats_samples': True,         # Is the x-axis sample names? Set to "False" to prevent report toolbox from affecting.
-    'ycats_samples': True,         # Is the y-axis sample names? Set to "False" to prevent report toolbox from affecting.
-    'colstops': [],                # Scale colour stops. See below.
-    'reverseColors': False,        # Reverse the order of the colour axis
-    'decimalPlaces': 2,            # Number of decimal places for tooltip
-    'legend': True,                # Colour axis key enabled or not
-    'datalabels': True,            # Show values in each cell. Defaults True when less than 20 samples.
-    'height': 500                  # The default height of the interactive plot, in pixels
+    "title": None,                 # Plot title - should be in format "Module Name: Plot Title"
+    "xTitle": None,                # X-axis title
+    "yTitle": None,                # Y-axis title
+    "min": None,                   # Minimum value (default: auto)
+    "max": None,                   # Maximum value (default: auto)
+    "square": True,                # Force the plot to stay square? (Maintain aspect ratio)
+    "xcats_samples": True,         # Is the x-axis sample names? Set to "False" to prevent report toolbox from affecting.
+    "ycats_samples": True,         # Is the y-axis sample names? Set to "False" to prevent report toolbox from affecting.
+    "colstops": [],                # Scale colour stops. See below.
+    "reverseColors": False,        # Reverse the order of the colour axis
+    "decimalPlaces": 2,            # Number of decimal places for tooltip
+    "legend": True,                # Colour axis key enabled or not
+    "datalabels": True,            # Show values in each cell. Defaults True when less than 20 samples.
+    "height": 500                  # The default height of the interactive plot, in pixels
 }
 ```
 
@@ -716,271 +784,18 @@ and a HTML colour. The default is `RdYlBu` from [ColorBrewer](http://colorbrewer
 
 ```python
 pconfig = {
-    'colstops': [
-        [0, '#313695'],
-        [0.1, '#4575b4'],
-        [0.2, '#74add1'],
-        [0.3, '#abd9e9'],
-        [0.4, '#e0f3f8'],
-        [0.5, '#ffffbf'],
-        [0.6, '#fee090'],
-        [0.7, '#fdae61'],
-        [0.8, '#f46d43'],
-        [0.9, '#d73027'],
-        [1, '#a50026'],
+    "colstops": [
+        [0, "#313695"],
+        [0.1, "#4575b4"],
+        [0.2, "#74add1"],
+        [0.3, "#abd9e9"],
+        [0.4, "#e0f3f8"],
+        [0.5, "#ffffbf"],
+        [0.6, "#fee090"],
+        [0.7, "#fdae61"],
+        [0.8, "#f46d43"],
+        [0.9, "#d73027"],
+        [1, "#a50026"],
     ]
 }
-```
-
-## Javascript Functions
-
-The javascript bundled in the default MultiQC template has a number of
-helper functions to make your life easier.
-
-:::note
-The MultiQC Python functions make use of these, so it's very unlikely
-that you'll need to use any of this. But it's here for reference.
-:::
-
-### Plotting line graphs
-
-`plot_xy_line_graph (target, ds)`
-
-Plots a line graph with multiple series of (x,y) data pairs. Used by
-the [linegraph.plot()](#line-graphs)
-python function.
-
-Data and configuration must be added to the document level
-`mqc_plots` variable on page load, using the target as the key.
-The variables used are as follows:
-
-```javascript
-mqc_plots[target]["plot_type"] = "xy_line";
-mqc_plots[target]["config"];
-mqc_plots[target]["datasets"];
-```
-
-Multiple datasets can be added in the `['datasets']` array. The supplied
-variable `ds` specifies which is plotted (defaults to `0`).
-
-Available config options with default vars:
-
-```javascript
-config = {
-  title: undefined, // Plot title
-  xlab: undefined, // X axis label
-  ylab: undefined, // Y axis label
-  xCeiling: undefined, // Maximum value for automatic axis limit (good for percentages)
-  xFloor: undefined, // Minimum value for automatic axis limit
-  xMinRange: undefined, // Minimum range for axis
-  xmax: undefined, // Max x limit
-  xmin: undefined, // Min x limit
-  yCeiling: undefined, // Maximum value for automatic axis limit (good for percentages)
-  yFloor: undefined, // Minimum value for automatic axis limit
-  yMinRange: undefined, // Minimum range for axis
-  ymax: undefined, // Max y limit
-  ymin: undefined, // Min y limit
-  yPlotBands: undefined, // Highlighted background bands. See http://api.highcharts.com/highcharts#yAxis.plotBands
-  xPlotBands: undefined, // Highlighted background bands. See http://api.highcharts.com/highcharts#xAxis.plotBands
-  tt_label: "{x}: {y:.2f}%", // Use to customise tooltip label, e.g. '{x} base pairs'
-  xsuffix: undefined, // Suffix for the x-axis values and labels. Parsed from tt_label by default
-  ysuffix: undefined, // Suffix for the y-axis values and labels. Parsed from tt_label by default
-};
-```
-
-An example of the markup expected, with the function being called:
-
-```html
-<div id="my_awesome_line_graph" class="hc-plot"></div>
-<script type="text/javascript">
-  mqc_plots["#my_awesome_bar_plot"]["plot_type"] = "xy_line";
-  mqc_plots["#my_awesome_line_graph"]["datasets"] = [
-    {
-      name: "Sample 1",
-      data: [
-        [1, 1.5],
-        [1.5, 3.1],
-        [2, 6.4],
-      ],
-    },
-    {
-      name: "Sample 2",
-      data: [
-        [1, 1.7],
-        [1.5, 4.3],
-        [2, 8.4],
-      ],
-    },
-  ];
-  mqc_plots["#my_awesome_line_graph"]["config"] = {
-    title: "Best Plot Ever",
-    ylab: "Pings",
-    xlab: "Pongs",
-  };
-  $(function () {
-    plot_xy_line_graph("#my_awesome_line_graph");
-  });
-</script>
-```
-
-### Plotting bar graphs
-
-`plot_stacked_bar_graph (target, ds)`
-
-Plots a bar graph with multiple series containing multiple categories.
-Used by the [bargraph.plot()](#bar-graphs)
-python function.
-
-Data and configuration must be added to the document level
-`mqc_plots` variable on page load, using the target as the key.
-The variables used are as follows:
-
-```js
-mqc_plots[target]["plot_type"] = "bar_graph";
-mqc_plots[target]["config"];
-mqc_plots[target]["datasets"];
-mqc_plots[target]["samples"];
-```
-
-All available config options with default vars:
-
-```js
-pconfig = {
-  title: undefined, // Plot title
-  xlab: undefined, // X axis label
-  ylab: undefined, // Y axis label
-  ymax: undefined, // Max y limit
-  ymin: undefined, // Min y limit
-  stacking: "normal", // Set to null to have category bars side by side (None in python)
-  sort_samples: true, // Sort samples alphanumerically
-};
-```
-
-An example of the markup expected, with the function being called:
-
-```html
-<div id="my_awesome_bar_plot" class="hc-plot"></div>
-<script type="text/javascript">
-  mqc_plots["#my_awesome_bar_plot"]["plot_type"] = "bar_graph";
-  mqc_plots["#my_awesome_bar_plot"]["samples"] = ["Sample 1", "Sample 2"];
-  mqc_plots["#my_awesome_bar_plot"]["datasets"] = [
-    { data: [4, 7], name: "Passed Test" },
-    { data: [2, 3], name: "Failed Test" },
-  ];
-  mqc_plots["#my_awesome_bar_plot"]["config"] = {
-    title: "My Awesome Plot",
-    ylab: "# Observations",
-    ymin: 0,
-    stacking: "normal",
-  };
-  $(function () {
-    plot_stacked_bar_graph("#my_awesome_bar_plot");
-  });
-</script>
-```
-
-### Switching counts and percentages
-
-If you're using the plotting functions above, it's easy to add a button which
-switches between percentages and counts. Just add the following HTML above
-your plot:
-
-```html
-<div class="btn-group switch_group">
-  <button class="btn btn-default btn-sm active" data-action="set_numbers" data-target="#my_plot">Counts</button>
-  <button class="btn btn-default btn-sm" data-action="set_percent" data-target="#my_plot">Percentages</button>
-</div>
-```
-
-_NB:_ This markup is generated automatically with the Python `self.plot_bargraph()` function.
-
-### Switching plot datasets
-
-Much like the counts / percentages buttons above, you can add a button which
-switches the data displayed in a single plot. Make sure that both datasets
-are stored in named javascript variables, then add the following markup:
-
-```html
-<div class="btn-group switch_group">
-  <button
-    class="btn btn-default btn-sm active"
-    data-action="set_data"
-    data-ylab="First Data"
-    data-newdata="data_var_1"
-    data-target="#my_plot"
-  >
-    Data 1
-  </button>
-  <button
-    class="btn btn-default btn-sm"
-    data-action="set_data"
-    data-ylab="Second Data"
-    data-newdata="data_var_2"
-    data-target="#my_plot"
-  >
-    Data 2
-  </button>
-</div>
-```
-
-Note the CSS class `active` which specifies which button is 'pressed' on page load.
-`data-ylab` and `data-xlab` can be used to specify the new axes labels.
-`data-newdata` should be the name of the javascript object with the new data
-to be plotted and `data-target` should be the CSS selector of the plot to change.
-
-### Custom event triggers
-
-Some of the events that take place in the general javascript
-code trigger jQuery events which you can hook into from within your
-module's code. This allows you to take advantage of events generated
-by the global theme whilst keeping your code modular.
-
-```javascript
-$(document).on("mqc_highlights", function (e, f_texts, f_cols, regex_mode) {
-  // This trigger is called when the highlight strings are
-  // updated. Three variables are given - an array of search
-  // strings (f_texts), an array of colours with corresponding
-  // indexes (f_cols) and a boolean var saying whether the
-  // search should be treated as a string or a regex (regex_mode)
-});
-
-$(document).on("mqc_renamesamples", function (e, f_texts, t_texts, regex_mode) {
-  // This trigger is called when samples are renamed
-  // Three variables are given - an array of search
-  // strings (f_texts), an array of replacements with corresponding
-  // indexes (t_texts) and a boolean var saying whether the
-  // search should be treated as a string or a regex (regex_mode)
-});
-
-$(document).on("mqc_hidesamples", function (e, f_texts, regex_mode) {
-  // This trigger is called when the Hide Samples filters change.
-  // Two variables are given - an array of search strings
-  // (f_texts) and a boolean saying whether the search should
-  // be treated as a string or a regex (regex_mode)
-});
-
-$("#YOUR_PLOT_ID").on("mqc_plotresize", function () {
-  // This trigger is called when a plot handle is pulled,
-  // resizing the height
-});
-
-$("#YOUR_PLOT_ID").on("mqc_original_series_click", function (e, name) {
-  // A plot able to show original images has had a point clicked.
-  // 'name' contains the name of the series that was clicked
-});
-
-$("#YOUR_PLOT_ID").on("mqc_original_chg_source", function (e, name) {
-  // A plot with original images has had a request to change the
-  // original image source (e.g. pressing Prev / Next)
-});
-
-$("#YOUR_PLOT_ID").on("mqc_plotexport_image", function (e, cfg) {
-  // A trigger to export an image of the plot. cfg contains
-  // config variables for the requested image.
-});
-
-$("#YOUR_PLOT_ID").on("mqc_plotexport_data", function (e, cfg) {
-  // A trigger to export a data file of the plot. cfg contains
-  // config variables for the requested data.
-});
 ```

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ MultiQC functions to plot a bargraph """
 
 

--- a/multiqc/plots/beeswarm.py
+++ b/multiqc/plots/beeswarm.py
@@ -1,0 +1,3 @@
+from multiqc.plots import violin
+
+plot = violin.plot

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Union
 
 import inspect
 import logging
@@ -21,7 +21,7 @@ def get_template_mod():
     return _template_mod
 
 
-def plot(list_of_data_by_sample: Dict[str, Dict] | List[Dict[str, Dict]], pconfig=None):
+def plot(list_of_data_by_sample: Union[Dict[str, Dict], List[Dict[str, Dict]]], pconfig=None):
     """
     Plot a box plot. Expects either:
     - a dict mapping sample names to data point lists (numbers),

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -1,3 +1,5 @@
+""" MultiQC functions to plot a box plot """
+
 from typing import List, Dict, Union, OrderedDict
 
 import inspect

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, OrderedDict
 
 import inspect
 import logging
@@ -33,6 +33,15 @@ def plot(list_of_data_by_sample: Union[Dict[str, Dict], List[Dict[str, Dict]]], 
     # Given one dataset - turn it into a list
     if not isinstance(list_of_data_by_sample, list):
         list_of_data_by_sample = [list_of_data_by_sample]
+
+    for i in range(len(list_of_data_by_sample)):
+        if isinstance(list_of_data_by_sample[0], OrderedDict):
+            # Legacy: users assumed that passing an OrderedDict indicates that we
+            # want to keep the sample order https://github.com/MultiQC/MultiQC/issues/2204
+            pass
+        elif pconfig.get("sort_samples", True):
+            samples = sorted(list(list_of_data_by_sample[0].keys()))
+            list_of_data_by_sample[i] = {s: list_of_data_by_sample[i][s] for s in samples}
 
     # Allow user to overwrite any given config for this plot
     if "id" in pconfig and pconfig["id"] and pconfig["id"] in config.custom_plot_config:

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -1,0 +1,77 @@
+from typing import List, Dict
+
+import inspect
+import logging
+import re
+
+from multiqc.utils import config, report
+from multiqc.plots.plotly import box
+
+logger = logging.getLogger(__name__)
+
+# Load the template so that we can access its configuration
+# Do this lazily to mitigate import-spaghetti when running unit tests
+_template_mod = None
+
+
+def get_template_mod():
+    global _template_mod
+    if not _template_mod:
+        _template_mod = config.avail_templates[config.template].load()
+    return _template_mod
+
+
+def plot(list_of_data_by_sample: Dict[str, Dict] | List[Dict[str, Dict]], pconfig=None):
+    """
+    Plot a box plot. Expects either:
+    - a dict mapping sample names to data point lists (numbers),
+    - a dict mapping sample names to a dict of statistics (e.g. {min, max, median, mean, std, q1, q3 etc.})
+    """
+    if pconfig is None:
+        pconfig = {}
+
+    # Given one dataset - turn it into a list
+    if not isinstance(list_of_data_by_sample, list):
+        list_of_data_by_sample = [list_of_data_by_sample]
+
+    # Allow user to overwrite any given config for this plot
+    if "id" in pconfig and pconfig["id"] and pconfig["id"] in config.custom_plot_config:
+        for k, v in config.custom_plot_config[pconfig["id"]].items():
+            pconfig[k] = v
+
+    # Validate config if linting
+    if config.strict:
+        # Get module name
+        modname = ""
+        callstack = inspect.stack()
+        for n in callstack:
+            if "multiqc/modules/" in n[1] and "base_module.py" not in n[1]:
+                callpath = n[1].split("multiqc/modules/", 1)[-1]
+                modname = f">{callpath}< "
+                break
+        # Look for essential missing pconfig keys
+        for k in ["id", "title"]:
+            if k not in pconfig:
+                errmsg = f"LINT: {modname}Box plot pconfig was missing key '{k}'"
+                logger.error(errmsg)
+                report.lint_errors.append(errmsg)
+        # Check plot title format
+        if not re.match(r"^[^:]*\S: \S[^:]*$", pconfig.get("title", "")):
+            errmsg = "LINT: {} Box plot title did not match format 'Module: Plot Name' (found '{}')".format(
+                modname, pconfig.get("title", "")
+            )
+            logger.error(errmsg)
+            report.lint_errors.append(errmsg)
+
+    # Make a plot - custom, interactive or flat
+    mod = get_template_mod()
+    if "box" in mod.__dict__ and callable(mod.bargraph):
+        try:
+            return mod.box(list_of_data_by_sample, pconfig)
+        except:  # noqa: E722
+            if config.strict:
+                # Crash quickly in the strict mode. This can be helpful for interactive
+                # debugging of modules
+                raise
+
+    return box.plot(list_of_data_by_sample, pconfig)

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ MultiQC functions to plot a heatmap """
 
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ MultiQC functions to plot a linegraph """
 
 import inspect

--- a/multiqc/plots/plotly/__init__.py
+++ b/multiqc/plots/plotly/__init__.py
@@ -25,3 +25,42 @@ def check_plotly_version():
             f'Please upgrade: pip install "plotly>={LATEST_SUPPORTED}"'
         )
         sys.exit(1)
+
+
+def determine_barplot_height(max_n_samples, max_bars_in_group=1, legend_height=None):
+    """
+    Used in bar and box plots
+    """
+
+    n_bars = max_n_samples
+    n_bars *= max_bars_in_group
+
+    def n_bars_to_size(n: int):
+        if n >= 30:
+            return 15
+        if n >= 20:
+            return 20
+        if n >= 10:
+            return 25
+        if n >= 5:
+            return 30
+        return 35
+
+    # Set height to be proportional to the number of samples
+    height = n_bars * n_bars_to_size(n_bars)
+
+    if legend_height is not None:
+        # expand the plot to fit the legend:
+        height = max(height, max(height, legend_height))
+        # but not too much - if there are only 2 samples, we don't want the plot to be too high:
+        height = min(660, max(height, legend_height))
+
+    height += 140  # Add space for the title and footer
+
+    # now, limit the max and min height (plotly will start to automatically skip
+    # some of the ticks on the left when the plot is too high)
+    MIN_HEIGHT = 300
+    MAX_HEIGHT = 2560
+    height = min(MAX_HEIGHT, height)
+    height = max(MIN_HEIGHT, height)
+    return height

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -9,6 +9,7 @@ import math
 import plotly.graph_objects as go
 import spectra
 
+from multiqc.plots.plotly import determine_barplot_height
 from multiqc.plots.plotly.plot import Plot, PlotType, BaseDataset, split_long_string
 from multiqc.utils import util_functions
 
@@ -128,41 +129,16 @@ class BarPlot(Plot):
 
         max_n_cats = max([len(dataset.cats) for dataset in self.datasets])
 
-        n_bars = max_n_samples
-        # Group mode puts each category in a separate bar, so need to multiply by the number of categories
-        if barmode == "group":
-            n_bars *= max_n_cats
-
-        def n_bars_to_size(n: int):
-            if n >= 30:
-                return 15
-            if n >= 20:
-                return 20
-            if n >= 10:
-                return 25
-            if n >= 5:
-                return 30
-            return 35
-
-        # Set height to be proportional to the number of samples
-        height = n_bars * n_bars_to_size(n_bars)
-
         # Set height to also be proportional to the number of cats to fit a legend
         HEIGHT_PER_LEGEND_ITEM = 19
         legend_height = HEIGHT_PER_LEGEND_ITEM * max_n_cats
-        # expand the plot to fit the legend:
-        height = max(height, max(height, legend_height))
-        # but not too much - if there are only 2 samples, we don't want the plot to be too high:
-        height = min(660, max(height, legend_height))
 
-        height += 140  # Add space for the title and footer
-
-        # now, limit the max and min height (plotly will start to automatically skip
-        # some of the ticks on the left when the plot is too high)
-        MIN_HEIGHT = 300
-        MAX_HEIGHT = 2560
-        height = min(MAX_HEIGHT, height)
-        height = max(MIN_HEIGHT, height)
+        height = determine_barplot_height(
+            max_n_samples=max_n_samples,
+            # Group mode puts each category in a separate bar, so need to multiply by the number of categories
+            max_bars_in_group=max_n_cats if barmode == "group" else 1,
+            legend_height=legend_height,
+        )
 
         self.layout.update(
             height=height,

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -124,7 +124,7 @@ class BarPlot(Plot):
 
         # Set the barmode
         barmode = "relative"  # stacking, but drawing negative values below zero
-        if "stacking" in pconfig and (pconfig["stacking"] in ["group", "normal", None]):
+        if "stacking" in pconfig and (pconfig["stacking"] in ["group", None]):
             barmode = "group"  # side by side
 
         max_n_cats = max([len(dataset.cats) for dataset in self.datasets])

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -1,0 +1,143 @@
+import copy
+import dataclasses
+import logging
+from typing import Dict, List, Union
+
+import plotly.graph_objects as go
+
+from multiqc.plots.plotly import determine_barplot_height
+from multiqc.plots.plotly.plot import Plot, PlotType, BaseDataset
+from multiqc.utils import util_functions
+
+logger = logging.getLogger(__name__)
+
+
+def plot(list_of_data_by_sample: List[Dict[str, Union[Dict, List]]], pconfig: Dict) -> str:
+    """
+    Build and add the plot data to the report, return an HTML wrapper.
+    :param list_of_data_by_sample: each dataset is a dict mapping samples to either:
+        * list of data points,
+        * list of statistics (e.g. {min, max, median, mean, std, q1, q3 etc.})
+    :param pconfig: Plot configuration dictionary
+    :return: HTML with JS, ready to be inserted into the page
+    """
+    p = BoxPlot(
+        pconfig,
+        list_of_data_by_sample,
+        max_n_samples=max(len(d) for d in list_of_data_by_sample),
+    )
+
+    from multiqc.utils import report
+
+    return p.add_to_report(report)
+
+
+class BoxPlot(Plot):
+    @dataclasses.dataclass
+    class Dataset(BaseDataset):
+        data: List[Union[Dict, List]]
+        samples: List[str]
+
+        @staticmethod
+        def create(
+            dataset: BaseDataset,
+            data_by_sample: Dict[str, Union[Dict, List]],
+        ) -> "BoxPlot.Dataset":
+            dataset = BoxPlot.Dataset(
+                **dataset.__dict__,
+                data=list(data_by_sample.values()),
+                samples=list(data_by_sample.keys()),
+            )
+            dataset.trace_params.update(
+                boxpoints="outliers",
+                jitter=0.5,
+                orientation="h",
+            )
+            dataset.layout["yaxis"]["title"] = None
+            return dataset
+
+        def create_figure(
+            self,
+            layout: go.Layout,
+            is_log=False,
+            is_pct=False,
+        ) -> go.Figure:
+            """
+            Create a Plotly figure for a dataset
+            """
+            fig = go.Figure(layout=layout)
+
+            for sname, values in zip(self.samples, self.data):
+                params = copy.deepcopy(self.trace_params)
+                if isinstance(values, list):
+                    # Regular box plot: data provided directly, statistics are calculated dynamically
+                    fig.add_trace(
+                        go.Box(
+                            x=values,
+                            name=sname,
+                            **params,
+                        ),
+                    )
+                else:
+                    # Box plot with pre-calculated statistics, without data points
+                    median = values.get("median", values.get("mean"))
+                    fig.add_trace(
+                        go.Box(
+                            q1=[values.get("q1", median)],
+                            q3=[values.get("q3", median)],
+                            median=[median],
+                            mean=[values.get("mean", median)],
+                            sd=[values.get("std", values.get("stddev", values.get("sd")))],
+                            lowerfence=[values.get("min", values.get("lowerfence"))],
+                            upperfence=[values.get("max", values.get("upperfence"))],
+                            orientation="h",
+                            name=sname,
+                            **params,
+                        )
+                    )
+            return fig
+
+    def __init__(
+        self,
+        pconfig: Dict,
+        list_of_data_by_sample: List[Dict[str, Union[Dict, List]]],
+        max_n_samples: int,
+    ):
+        super().__init__(PlotType.BOX, pconfig, n_datasets=len(list_of_data_by_sample))
+
+        self.datasets: List[BoxPlot.Dataset] = [
+            BoxPlot.Dataset.create(ds, data_by_sample)
+            for ds, data_by_sample in zip(self.datasets, list_of_data_by_sample)
+        ]
+
+        height = determine_barplot_height(max_n_samples)
+
+        self.layout.update(
+            height=height,
+            showlegend=False,
+            boxgroupgap=0.1,
+            boxgap=0.2,
+            yaxis=dict(
+                automargin=True,  # to make sure there is enough space for ticks labels
+                hoverformat=self.layout.xaxis.hoverformat,
+                ticksuffix=self.layout.xaxis.ticksuffix,
+                # Prevent JavaScript from automatically parsing categorical values as numbers:
+                type="category",
+            ),
+            xaxis=dict(
+                title=dict(text=self.layout.yaxis.title.text),
+                hoverformat=self.layout.yaxis.hoverformat,
+                ticksuffix=self.layout.yaxis.ticksuffix,
+            ),
+            hovermode="y unified",
+            hoverlabel=dict(
+                bgcolor="rgba(255, 255, 255, 0.8)",
+                font=dict(color="black"),
+            ),
+        )
+
+    def save_data_file(self, dataset: Dataset) -> None:
+        vals_by_sample = {}
+        for sample, values in zip(dataset.samples, dataset.data):
+            vals_by_sample[sample] = values
+        util_functions.write_data_file(vals_by_sample, dataset.uid)

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -56,6 +56,9 @@ class BoxPlot(Plot):
                 boxpoints="outliers",
                 jitter=0.5,
                 orientation="h",
+                marker=dict(
+                    color="#4899e8",  # just use blue to indicate interactivity
+                ),
             )
             dataset.layout["yaxis"]["title"] = None
             return dataset
@@ -121,6 +124,7 @@ class BoxPlot(Plot):
             showlegend=False,
             boxgroupgap=0.1,
             boxgap=0.2,
+            colorway=[],  # no need to color code
             yaxis=dict(
                 automargin=True,  # to make sure there is enough space for ticks labels
                 categoryorder="trace",  # keep sample order

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -48,6 +48,10 @@ class BoxPlot(Plot):
                 data=list(data_by_sample.values()),
                 samples=list(data_by_sample.keys()),
             )
+            # Need to reverse samples as the box plot will show them reversed
+            dataset.samples = list(reversed(dataset.samples))
+            dataset.data = list(reversed(dataset.data))
+
             dataset.trace_params.update(
                 boxpoints="outliers",
                 jitter=0.5,
@@ -119,6 +123,7 @@ class BoxPlot(Plot):
             boxgap=0.2,
             yaxis=dict(
                 automargin=True,  # to make sure there is enough space for ticks labels
+                categoryorder="trace",  # keep sample order
                 hoverformat=self.layout.xaxis.hoverformat,
                 ticksuffix=self.layout.xaxis.ticksuffix,
                 # Prevent JavaScript from automatically parsing categorical values as numbers:

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -29,6 +29,7 @@ class PlotType(Enum):
     BAR = "bar_graph"
     SCATTER = "scatter"
     HEATMAP = "heatmap"
+    BOX = "box"
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -604,6 +604,7 @@ def _dataset_layout(
     y_hoverformat = f",.{tt_decimals}f" if tt_decimals is not None else None
 
     layout = dict(
+        title=dict(text=pconfig.get("title")),
         xaxis=dict(
             hoverformat=None,
             ticksuffix=xsuffix or "",

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -193,9 +193,15 @@ class ViolinPlot(Plot):
                 hoveron="points",
             )
 
+            # If all violins are grey, make the dots blue to make it more clear that it's interactive
+            # if some violins are color-coded, make the dots black to make them less distracting
+            marker_color = "black" if any(h.get("color") for h in ds.header_by_metric.values()) else "#0b79e6"
             ds.scatter_trace_params = {
                 "mode": "markers",
-                "marker": {"size": 4, "color": "rgba(0,0,0,1)"},
+                "marker": {
+                    "size": 4,
+                    "color": marker_color,
+                },
                 "showlegend": False,
                 "hovertemplate": ds.trace_params["hovertemplate"],
                 "hoverlabel": {"bgcolor": "white"},

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ MultiQC functions to plot a scatter plot """
 
 import logging

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ MultiQC functions to plot a table """
 
 import logging

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+""" MultiQC datatable class, used by tables and violin plots """
 
-""" MultiQC datatable class, used by tables and beeswarm plots """
 import math
 
 import logging

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-""" MultiQC functions to plot a beeswarm group """
+""" MultiQC functions to plot a violin group """
 
 import logging
 from typing import List, Dict, Optional, Union
@@ -27,7 +27,7 @@ def get_template_mod():
 
 
 def plot(data: List[Dict], headers: Optional[Union[List[Dict], Dict]] = None, pconfig=None):
-    """Helper HTML for a beeswarm plot.
+    """Helper HTML for a violin plot.
     :param data: A list of data dicts
     :param headers: A list of dicts with information
                     for the series, such as colour scales, min and

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-""" MultiQC functions to plot a violin group """
+""" MultiQC functions to plot a violin plot """
 
 import logging
 from typing import List, Dict, Optional, Union

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -40,10 +40,19 @@ class BoxPlot extends Plot {
     const maxTicks = (this.layout.height - 140) / 12;
     this.recalculateTicks(this.filteredSettings, this.layout.yaxis, maxTicks);
 
+    let highlighted = this.filteredSettings.filter((s) => s.highlight);
     let traceParams = this.datasets[this.activeDatasetIdx]["trace_params"];
 
     return this.filteredSettings.map((sample, sampleIdx) => {
       let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
+
+      if (highlighted.length > 0) {
+        if (sample.highlight !== null) {
+          params.marker.color = sample.highlight;
+        } else {
+          params.marker.color = "grey";
+        }
+      }
 
       let values = data[sampleIdx];
       // Regular box plot: data provided directly, statistics are calculated dynamically

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -1,0 +1,87 @@
+class BoxPlot extends Plot {
+  constructor(dump) {
+    super(dump);
+    this.filteredSettings = [];
+  }
+
+  activeDatasetSize() {
+    if (this.datasets.length === 0) return 0; // no datasets
+    return this.datasets[this.activeDatasetIdx]["samples"].length;
+  }
+
+  prepData() {
+    let data = this.datasets[this.activeDatasetIdx]["data"];
+    let samples = this.datasets[this.activeDatasetIdx]["samples"];
+
+    let samplesSettings = applyToolboxSettings(samples);
+
+    // Rename and filter samples:
+    this.filteredSettings = samplesSettings.filter((s) => !s.hidden);
+    samples = this.filteredSettings.map((s) => s.name);
+    data = data.filter((_, si) => !samplesSettings[si].hidden);
+
+    return [data, samples];
+  }
+
+  resize(newHeight) {
+    this.layout.height = newHeight;
+
+    const maxTicks = (this.layout.height - 140) / 12;
+    this.recalculateTicks(this.filteredSettings, this.layout.yaxis, maxTicks);
+
+    super.resize(newHeight);
+  }
+
+  // Constructs and returns traces for the Plotly plot
+  buildTraces() {
+    let [data, samples] = this.prepData();
+    if (data.length === 0 || samples.length === 0) return [];
+
+    const maxTicks = (this.layout.height - 140) / 12;
+    this.recalculateTicks(this.filteredSettings, this.layout.yaxis, maxTicks);
+
+    let traceParams = this.datasets[this.activeDatasetIdx]["trace_params"];
+
+    return this.filteredSettings.map((sample, sampleIdx) => {
+      let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
+
+      let values = data[sampleIdx];
+      // Regular box plot: data provided directly, statistics are calculated dynamically
+      if (Array.isArray(values)) {
+        return {
+          type: "box",
+          x: values,
+          name: sample.name,
+          ...params,
+        };
+      } else {
+        // Box plot with pre-calculated statistics, without data points
+        let median = values.median ?? values.mean ?? null;
+        return {
+          type: "box",
+          q1: [values.q1 ?? median],
+          q3: [values.q3 ?? median],
+          median: [median],
+          mean: [values.mean ?? median],
+          sd: [values.std ?? values.stddev ?? values.sd ?? null],
+          lowerfence: [values.min ?? values.lowerfence ?? null],
+          upperfence: [values.max ?? values.upperfence ?? null],
+          name: sample.name,
+          ...params,
+        };
+      }
+    });
+  }
+
+  exportData(format) {
+    let [data, samples] = this.prepData();
+
+    let delim = format === "tsv" ? "\t" : ",";
+
+    let csv = "";
+    for (let i = 0; i < data.length; i++) {
+      csv += samples[i] + delim + data[i].join(delim) + "\n";
+    }
+    return csv;
+  }
+}

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -236,11 +236,11 @@ class ViolinPlot extends Plot {
         let state = sampleSettings[allSamples.indexOf(sample)];
         let params = JSON.parse(JSON.stringify(dataset["scatter_trace_params"])); // deep copy
 
-        let color = "black"; // trace_params["marker"]["color"];
+        let color = params.marker.color;
         let size = params.marker.size;
         if (highlightingEnabled) {
-          color = state.highlight ?? "#cccccc";
-          size = state.highlight !== null ? 10 : size;
+          color = state.highlight ?? "#ddd";
+          size = state.highlight !== null ? 8 : size;
         }
 
         let customData = {

--- a/multiqc/templates/default/assets/js/plotting.js
+++ b/multiqc/templates/default/assets/js/plotting.js
@@ -134,6 +134,7 @@ class Plot {
 function initPlot(dump) {
   if (dump["plot_type"] === "xy_line") return new LinePlot(dump);
   if (dump["plot_type"] === "bar_graph") return new BarPlot(dump);
+  if (dump["plot_type"] === "box") return new BoxPlot(dump);
   if (dump["plot_type"] === "scatter") return new ScatterPlot(dump);
   if (dump["plot_type"] === "heatmap") return new HeatmapPlot(dump);
   if (dump["plot_type"] === "violin") return new ViolinPlot(dump);

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -60,6 +60,7 @@ it prints the contents of these files into the report.
 <script type="text/javascript">{{ include_file('assets/js/tables.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/toolbox.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/plots/bar.js') }}</script>
+<script type="text/javascript">{{ include_file('assets/js/plots/box.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/plots/line.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/plots/scatter.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/plots/heatmap.js') }}</script>


### PR DESCRIPTION
Add a new plot type: `box` plot.

<img width="1125" alt="Screenshot 2024-02-22 at 22 27 19" src="https://github.com/MultiQC/MultiQC/assets/1575412/887dfd80-93c8-421d-bbe5-5e62ad8894e7">

<img width="1133" alt="Screenshot 2024-02-22 at 22 27 42" src="https://github.com/MultiQC/MultiQC/assets/1575412/784f0611-4ba0-452c-94bc-98ba48ba42f1">

<img width="1127" alt="Screenshot 2024-02-22 at 22 27 58" src="https://github.com/MultiQC/MultiQC/assets/1575412/4631aa40-cdd2-4e04-917e-966149877ae0">

The main difference with the violin plot is that the violin plot has rows as metrics, and the data points as samples; whereas the box plot has rows as samples. So it's more like a bar plot by layout. We can even use actual violins here instead of boxes, but using boxes makes the difference more clear.

Todo:
- [x] Documentation
- [x] Same color for each sample
- [x] Implement toolbox highlight

Future:
- [ ] Support "group" mode
- [ ] As the data input is the same as for line plot (except that there is no order of data points), we can add a box plot as another view for line plot, and make a switch between them? https://github.com/MultiQC/MultiQC/issues/2367
- [ ] Support violin view (a switch?)
- [ ] Think about scaling https://github.com/MultiQC/MultiQC/issues/2280
