### PR TITLE
Drop `full_figure_for_development` the call to avoid Kaleido issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@
 - **DRAGEN**: add few coverage metrics in general stats ([#2341](https://github.com/MultiQC/MultiQC/pull/2341))
 - **DRAGEN**: fix showing the number of found samples ([#2347](https://github.com/MultiQC/MultiQC/pull/2347))
 - **DRAGEN**: support `gvcf_metrics` ([#2327](https://github.com/MultiQC/MultiQC/pull/2327))
-- **fastp**: Improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
+- **fastp**: improve detection of JSON files ([#2334](https://github.com/MultiQC/MultiQC/pull/2334))
 - **Illumina InterOp Statistics**: do not set `'scale': False` as a default ([#2350](https://github.com/MultiQC/MultiQC/pull/2350))
-- **mosdepth**: Fix regression in showing general stats ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
+- **mosdepth**: fix regression in showing general stats ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
+- **Whatshap**: make robust to stdout appended to TSV ([#2361](https://github.com/MultiQC/MultiQC/pull/2361))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Catch non-hashable values in table data ([#2348](https://github.com/MultiQC/MultiQC/pull/2348))
 - Prevent parsing numerical sample names in heatmap ([#2349](https://github.com/MultiQC/MultiQC/pull/2349))
 - Infinite dmax or dmin fail JSON dump load in JavaScript ([#2354](https://github.com/MultiQC/MultiQC/pull/2354))
+- Wrap `full_figure_for_development` in try to handle Kaleido error ([#2359](https://github.com/MultiQC/MultiQC/pull/2359))
 
 ### New modules
 

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -165,15 +165,21 @@ class LinePlot(Plot):
             # before we add the bands, and then force set the calculated range.
             for dataset in self.datasets:
                 layout = go.Layout(self.layout.to_plotly_json()).update(**dataset.layout)
-                dev_fig = dataset.create_figure(layout).full_figure_for_development(warn=False)
-                dataset.layout["yaxis"]["range"] = dev_fig.layout.yaxis.range
-                dataset.layout["xaxis"]["range"] = dev_fig.layout.xaxis.range
-                if y_min_range:
-                    if dataset.layout["yaxis"]["range"][1] - dataset.layout["yaxis"]["range"][0] < y_min_range:
-                        dataset.layout["yaxis"]["range"] = [
-                            dataset.layout["yaxis"]["range"][0],
-                            dataset.layout["yaxis"]["range"][0] + y_min_range,
-                        ]
+                try:
+                    dev_fig = dataset.create_figure(layout).full_figure_for_development(warn=False)
+                except ValueError:
+                    # ValueError: Failed to start Kaleido subprocess
+                    # E.g. https://github.com/MultiQC/MultiQC/issues/2357
+                    continue
+                else:
+                    dataset.layout["yaxis"]["range"] = dev_fig.layout.yaxis.range
+                    dataset.layout["xaxis"]["range"] = dev_fig.layout.xaxis.range
+                    if y_min_range:
+                        if dataset.layout["yaxis"]["range"][1] - dataset.layout["yaxis"]["range"][0] < y_min_range:
+                            dataset.layout["yaxis"]["range"] = [
+                                dataset.layout["yaxis"]["range"][0],
+                                dataset.layout["yaxis"]["range"][0] + y_min_range,
+                            ]
 
         self.layout.shapes = (
             [

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Dict, List, Union, Optional
 import plotly.graph_objects as go
-
+import plotly.io as pio
 
 from multiqc.plots.plotly.plot import Plot, PlotType, BaseDataset
 from multiqc.utils import util_functions, config
@@ -166,6 +166,10 @@ class LinePlot(Plot):
             for dataset in self.datasets:
                 layout = go.Layout(self.layout.to_plotly_json()).update(**dataset.layout)
                 try:
+                    # Get around /tmp write issue https://github.com/plotly/Kaleido/issues/90
+                    pio.kaleido.scope.chromium_args = tuple(
+                        [arg for arg in pio.kaleido.scope.chromium_args if arg != "--disable-dev-shm-usage"]
+                    )
                     dev_fig = dataset.create_figure(layout).full_figure_for_development(warn=False)
                 except ValueError:
                     # ValueError: Failed to start Kaleido subprocess

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -4,7 +4,6 @@ import logging
 import os
 from typing import Dict, List, Union, Optional
 import plotly.graph_objects as go
-import plotly.io as pio
 
 from multiqc.plots.plotly.plot import Plot, PlotType, BaseDataset
 from multiqc.utils import util_functions, config
@@ -159,31 +158,48 @@ class LinePlot(Plot):
         x_bands = pconfig.get("xPlotBands")
         x_lines = pconfig.get("xPlotLines")
         y_lines = pconfig.get("yPlotLines")
-        if y_min_range or y_bands or x_bands or x_lines or y_lines:
-            # We don't want the bands to affect the calculated y-axis range. So we
-            # call `fig.full_figure_for_development` to force-calculate the figure size
-            # before we add the bands, and then force set the calculated range.
+        if y_min_range or y_bands or y_lines:
+            # We don't want the bands to affect the calculated y-axis range, so we
+            # manually calculate the y-axis min and max values and set the autorangeoptions
             for dataset in self.datasets:
-                layout = go.Layout(self.layout.to_plotly_json()).update(**dataset.layout)
-                try:
-                    # Get around /tmp write issue https://github.com/plotly/Kaleido/issues/90
-                    pio.kaleido.scope.chromium_args = tuple(
-                        [arg for arg in pio.kaleido.scope.chromium_args if arg != "--disable-dev-shm-usage"]
-                    )
-                    dev_fig = dataset.create_figure(layout).full_figure_for_development(warn=False)
-                except ValueError:
-                    # ValueError: Failed to start Kaleido subprocess
-                    # E.g. https://github.com/MultiQC/MultiQC/issues/2357
-                    continue
-                else:
-                    dataset.layout["yaxis"]["range"] = dev_fig.layout.yaxis.range
-                    dataset.layout["xaxis"]["range"] = dev_fig.layout.xaxis.range
-                    if y_min_range:
-                        if dataset.layout["yaxis"]["range"][1] - dataset.layout["yaxis"]["range"][0] < y_min_range:
-                            dataset.layout["yaxis"]["range"] = [
-                                dataset.layout["yaxis"]["range"][0],
-                                dataset.layout["yaxis"]["range"][0] + y_min_range,
-                            ]
+                ymin = dataset.layout["yaxis"]["autorangeoptions"]["clipmin"]
+                if ymin is None:
+                    ymin = dataset.layout["yaxis"]["autorangeoptions"]["minallowed"]
+                ymax = dataset.layout["yaxis"]["autorangeoptions"]["clipmax"]
+                if ymax is None:
+                    ymax = dataset.layout["yaxis"]["autorangeoptions"]["maxallowed"]
+                if ymin is None or ymax is None:
+                    for line in dataset.lines:
+                        if len(line["data"]) > 0 and isinstance(line["data"][0], list):
+                            ys = [x[1] for x in line["data"]]
+                        else:
+                            ys = line["data"]
+                        if ymin is None:
+                            ymin = min(ys)
+                        if ymax is None:
+                            ymax = max(ys)
+                            ymax += (ymax - ymin) * 0.05
+                dataset.layout["yaxis"]["range"] = [ymin, ymax]
+
+        if x_bands or x_lines:
+            for dataset in self.datasets:
+                xmin = dataset.layout["xaxis"]["autorangeoptions"]["clipmin"]
+                if xmin is None:
+                    xmin = dataset.layout["xaxis"]["autorangeoptions"]["minallowed"]
+                xmax = dataset.layout["xaxis"]["autorangeoptions"]["clipmax"]
+                if xmax is None:
+                    xmax = dataset.layout["xaxis"]["autorangeoptions"]["maxallowed"]
+                if xmin is None or xmax is None:
+                    for line in dataset.lines:
+                        if len(line["data"]) > 0 and isinstance(line["data"][0], list):
+                            xs = [x[0] for x in line["data"]]
+                        else:
+                            xs = [x for x in range(len(line["data"]))]
+                        if xmin is None:
+                            xmin = min(xs)
+                        if xmax is None:
+                            xmax = max(xs)
+                dataset.layout["xaxis"]["range"] = [xmin, xmax]
 
         self.layout.shapes = (
             [

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -159,8 +159,8 @@ class LinePlot(Plot):
         x_lines = pconfig.get("xPlotLines")
         y_lines = pconfig.get("yPlotLines")
         if y_min_range or y_bands or y_lines:
-            # We don't want the bands to affect the calculated y-axis range, so we
-            # manually calculate the y-axis min and max values and set the autorangeoptions
+            # We don't want the bands to affect the calculated axis range, so we
+            # find the min and the max from data points, and manually set the range
             for dataset in self.datasets:
                 ymin = dataset.layout["yaxis"]["autorangeoptions"]["clipmin"]
                 if ymin is None:
@@ -182,6 +182,7 @@ class LinePlot(Plot):
                 dataset.layout["yaxis"]["range"] = [ymin, ymax]
 
         if x_bands or x_lines:
+            # same as above but for x-axis
             for dataset in self.datasets:
                 xmin = dataset.layout["xaxis"]["autorangeoptions"]["clipmin"]
                 if xmin is None:


### PR DESCRIPTION
To get around: https://github.com/MultiQC/MultiQC/issues/2357

The `full_figure_for_development` call is used here to avoid line plot bands affecting the calculated range. We shouldn't crash if this function fails, ~so wrapping in try-except. Worst case, the plot range will just be bigger than needed.~. Just dropped that call for good, and calculating the range from data points.

TODO

- [x] Properly figure out the Kaleido problem.
- [x] Calcualte manually the max and min data values and set `autorangeoptions.minallowed`/`autorangeoptions.maxallowed` directly.