### PR TITLE
Box plot adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add box plot ([#2358](https://github.com/MultiQC/MultiQC/pull/2358))
 - Generic font family for Plotly ([#2368](https://github.com/MultiQC/MultiQC/pull/2368))
 - Put matplotlib back into main deps ([#2370](https://github.com/MultiQC/MultiQC/pull/2370))
+- Box plot adjustment ([#2374](https://github.com/MultiQC/MultiQC/pull/2374))
 
 ### New modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -5,7 +5,7 @@ script-src 'self'
     # 1.21
     'sha256-bHPK47f6TsuMbS8pR8jVPzEK4orYin9an6P5OkYf+n8=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
     'sha256-yRjvY4tSJ5z2ggAL/i5pJj+peALSAG9PD51Z0Hf7wzQ=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
-    'sha256-OzhPBnFiZsSBpwe4cpwbOg4/dYQSPNXG20bECdDtONM=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
+    'sha256-gf6XBM6wOXcVJjumRhlnj7J/GEpeABZmKQla1g2feYk=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
     'sha256-mVO5Pel/niJHZXAV5BhYrr15QkRTeRFbjRpIVLbBsb4=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
 
     # 1.20

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -365,32 +365,7 @@ data = {
 html = box.plot(data, pconfig=...)
 ```
 
-It is also possible to pass a dictionary of statistics directly, instead of a list:
-
-```python
-from multiqc.plots import box
-data = {
-    "sample 1": box.BoxPlotStats(
-        min=1,
-        q1=3,
-        median=5,
-        q3=7,
-        max=9,
-        mean=5.5,
-    ),
-    "sample 2": box.BoxPlotStats(
-        min=0,
-        q1=2,
-        median=6,
-        q3=6,
-        max=10,
-        mean=4.5,
-    ),
-}
-html = box.plot(data, pconfig=...)
-```
-
-And similar to other plot types, multiple datasets can be passed as `data`, along with
+Similarly to other plot types, multiple datasets can be passed as `data`, along with
 dataset-specific configurations provided with the `pconfig["data_labels"]` option.
 
 ## Scatter Plots

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -368,23 +368,24 @@ html = box.plot(data, pconfig=...)
 It is also possible to pass a dictionary of statistics directly, instead of a list:
 
 ```python
+from multiqc.plots import box
 data = {
-    "sample 1": {
-        "min": 1,
-        "q1": 3,
-        "median": 5,
-        "q3": 7,
-        "max": 9,
-        "mean": 5.5,
-    },
-    "sample 2": {
-        "min": 0,
-        "q1": 2,
-        "median": 6,
-        "q3": 6,
-        "max": 10,
-        "mean": 4.5,
-    },
+    "sample 1": box.BoxPlotStats(
+        min=1,
+        q1=3,
+        median=5,
+        q3=7,
+        max=9,
+        mean=5.5,
+    ),
+    "sample 2": box.BoxPlotStats(
+        min=0,
+        q1=2,
+        median=6,
+        q3=6,
+        max=10,
+        mean=4.5,
+    ),
 }
 html = box.plot(data, pconfig=...)
 ```

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -9,9 +9,6 @@ import re
 from multiqc.plots.plotly.box import BoxT
 from multiqc.utils import config, report
 from multiqc.plots.plotly import box
-from multiqc.plots.plotly.box import BoxPlotStats
-
-__all__ = ["BoxPlotStats", "plot"]
 
 logger = logging.getLogger(__name__)
 

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -6,8 +6,12 @@ import inspect
 import logging
 import re
 
+from multiqc.plots.plotly.box import BoxT
 from multiqc.utils import config, report
 from multiqc.plots.plotly import box
+from multiqc.plots.plotly.box import BoxPlotStats
+
+__all__ = ["BoxPlotStats", "plot"]
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +27,10 @@ def get_template_mod():
     return _template_mod
 
 
-def plot(list_of_data_by_sample: Union[Dict[str, Dict], List[Dict[str, Dict]]], pconfig=None):
+def plot(list_of_data_by_sample: Union[Dict[str, BoxT], List[Dict[str, BoxT]]], pconfig=None):
     """
     Plot a box plot. Expects either:
-    - a dict mapping sample names to data point lists (numbers),
+    - a dict mapping sample names to data point lists or dicts,
     - a dict mapping sample names to a dict of statistics (e.g. {min, max, median, mean, std, q1, q3 etc.})
     """
     if pconfig is None:

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -12,23 +12,8 @@ from multiqc.utils import util_functions
 logger = logging.getLogger(__name__)
 
 
-class BoxPlotStats:
-    """
-    Pre-calculated statistics for a box plot.
-    """
-
-    def __init__(self, **kwargs):
-        self.median = kwargs.get("median", kwargs.get("mean"))
-        self.q1 = kwargs.get("q1", self.median)
-        self.q3 = kwargs.get("q3", self.median)
-        self.mean = kwargs.get("mean", self.median)
-        self.sd = kwargs.get("std", kwargs.get("stddev", kwargs.get("sd")))
-        self.lowerfence = kwargs.get("min", kwargs.get("lowerfence"))
-        self.upperfence = kwargs.get("max", kwargs.get("upperfence"))
-
-
 # Type of single box (matching one sample)
-BoxT = Union[List[Union[int, float]], BoxPlotStats]
+BoxT = List[Union[int, float]]
 
 
 def plot(list_of_data_by_sample: List[Dict[str, BoxT]], pconfig: Dict) -> str:
@@ -103,27 +88,13 @@ class BoxPlot(Plot):
 
             for sname, values in zip(self.samples, self.data):
                 params = copy.deepcopy(self.trace_params)
-                if isinstance(values, list):
-                    fig.add_trace(
-                        go.Box(
-                            x=values,
-                            name=sname,
-                            **params,
-                        ),
-                    )
-                elif isinstance(values, BoxPlotStats):
-                    # Box plot with pre-calculated statistics, without data points
-                    fig.add_trace(
-                        go.Box(
-                            **{k: [v] for k, v in values.__dict__},
-                            name=sname,
-                            **params,
-                        )
-                    )
-                else:
-                    raise ValueError(
-                        f"Unexpected type of box plot data item: {type(values)}. " f"Expected: list or BoxPlotStats"
-                    )
+                fig.add_trace(
+                    go.Box(
+                        x=values,
+                        name=sname,
+                        **params,
+                    ),
+                )
             return fig
 
     def __init__(
@@ -160,7 +131,7 @@ class BoxPlot(Plot):
                 hoverformat=self.layout.yaxis.hoverformat,
                 ticksuffix=self.layout.yaxis.ticksuffix,
             ),
-            hovermode="y unified",
+            hovermode="y",
             hoverlabel=dict(
                 bgcolor="rgba(255, 255, 255, 0.8)",
                 font=dict(color="black"),

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -42,7 +42,7 @@ class BaseDataset(ABC):
     label: str
     uid: str
     dconfig: Dict  # user dataset-specific configuration
-    layout: Dict  # update when a datasets toggle is clicked, or percentage switch is unclicked
+    layout: Dict  # update when a datasets toggle is clicked, or percentage switch is unselected
     trace_params: Dict
     pct_range: Dict
 

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -55,30 +55,12 @@ class BoxPlot extends Plot {
       }
 
       let values = data[sampleIdx];
-      // Regular box plot: data provided directly, statistics are calculated dynamically
-      if (Array.isArray(values)) {
-        return {
-          type: "box",
-          x: values,
-          name: sample.name,
-          ...params,
-        };
-      } else {
-        // Box plot with pre-calculated statistics, without data points
-        let median = values.median ?? values.mean ?? null;
-        return {
-          type: "box",
-          q1: [values.q1 ?? median],
-          q3: [values.q3 ?? median],
-          median: [median],
-          mean: [values.mean ?? median],
-          sd: [values.std ?? values.stddev ?? values.sd ?? null],
-          lowerfence: [values.min ?? values.lowerfence ?? null],
-          upperfence: [values.max ?? values.upperfence ?? null],
-          name: sample.name,
-          ...params,
-        };
-      }
+      return {
+        type: "box",
+        x: values,
+        name: sample.name,
+        ...params,
+      };
     });
   }
 


### PR DESCRIPTION
Some more adjustment of the new box plots:

- [x] Hover text: do not show sample name
- [x] Allow passing labels for data points and show them in hover (probably not possible in plotly) (UPD: confirmed - abandoning the idea)
- [x] More clear passing of statistics (via config? allow passing data and outliers as well?) (it's buggy - when adding q3, it stops showing separate boxes for each sample, instead overlaying them; dropping support for passing stats directly)
