### PR TITLE
Violin plot: filter Inf values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix: infinite `dmax` or `dmin` fail JSON dump load in JavaScript ([#2354](https://github.com/MultiQC/MultiQC/pull/2354))
 - Fix: wrap `full_figure_for_development` in try to handle Kaleido error ([#2359](https://github.com/MultiQC/MultiQC/pull/2359))
 - Generic font family for Plotly ([#2368](https://github.com/MultiQC/MultiQC/pull/2368))
+- Violin plot: filter Inf values ([#2380](https://github.com/MultiQC/MultiQC/pull/2380))
 
 ### New modules
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -91,10 +91,10 @@ class ViolinPlot(Plot):
                 values_are_numeric = all(isinstance(v, (int, float)) for v in value_by_sample.values())
                 values_are_integer = all(isinstance(v, int) for v in value_by_sample.values())
                 if values_are_numeric:
-                    # Remove NaN values
-                    value_by_sample = {s: v for s, v in value_by_sample.items() if not math.isnan(v)}
+                    # Remove NaN and Inf values
+                    value_by_sample = {s: v for s, v in value_by_sample.items() if np.isfinite(v)}
                     if not value_by_sample:
-                        logger.warning(f"All values are NaN for metric: {header['title']}")
+                        logger.warning(f"All values are NaN or Inf for metric: {header['title']}")
                         continue
 
                 header["show_points"] = len(value_by_sample) <= config.violin_min_threshold_no_points


### PR DESCRIPTION
We fixed the [issue](https://github.com/MultiQC/MultiQC/issues/2328) before caused by DRAGEN setting `Inf` in `wgs_coverage_metrics.csv`, e.g.:

```
COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,inf
```

However, the `Inf`s were still passed down to the violin plot, where they don't make much sense. They also caused a runtime warning in the outlier calculation stage, as numpy didn't handle `Inf`s there. So filtering them out in violins.

Fixes https://github.com/MultiQC/MultiQC/issues/2377