### PR TITLE
Heatmap: allow a dict dicts of data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Violin plot: filter Inf values ([#2380](https://github.com/MultiQC/MultiQC/pull/2380))
 - Fix use of the `no_violin`/`no_beeswarm` table config flag ([#2376](https://github.com/MultiQC/MultiQC/pull/2376))
 - Refactor: fix unescaped regex strings ([#2384](https://github.com/MultiQC/MultiQC/pull/2384))
+- Heatmap: allow a dict dicts of data ([#2386](https://github.com/MultiQC/MultiQC/pull/2386))
 
 ### New modules
 

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -722,14 +722,36 @@ names = ["one", "two", "three", "four", "five", "six"]
 html = heatmap.plot(data, xcats=names, pconfig=...)
 ```
 
+Alternatively you can supply a dictionary of dictionaries, in which case
+xcats and ycats are optional:
+
+```python
+data = {
+    "sample 1": {
+        "one": 0.9,
+        "two": 0.87,
+        "three": 0.73,
+        "four": 0.6,
+        "five": 0.2,
+    },
+    "sample 2": {
+        "two": 1,
+        "three": 0.7,
+        "four": 0.6,
+        "six": 0.3,
+    },
+}
+html = heatmap.plot(data, pconfig=...)
+```
+
 Much like the other plots, you can change the way that the heatmap looks
 using a config dictionary:
 
 ```python
 pconfig = {
     "title": None,                 # Plot title - should be in format "Module Name: Plot Title"
-    "xTitle": None,                # X-axis title
-    "yTitle": None,                # Y-axis title
+    "xlab": None,                  # X-axis title
+    "ylab": None,                  # Y-axis title
     "min": None,                   # Minimum value (default: auto)
     "max": None,                   # Maximum value (default: auto)
     "square": True,                # Force the plot to stay square? (Maintain aspect ratio)

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -22,9 +22,9 @@ def get_template_mod():
     return _template_mod
 
 
-def plot(data, xcats, ycats=None, pconfig=None):
+def plot(data, xcats=None, ycats=None, pconfig=None):
     """Plot a 2D heatmap.
-    :param data: List of lists, each a representing a row of values.
+    :param data: List of lists, each a representing a row of values; or a dict of dicts
     :param xcats: Labels for x-axis
     :param ycats: Labels for y-axis. Defaults to same as x.
     :param pconfig: optional dict with config key:value pairs.
@@ -52,4 +52,4 @@ def plot(data, xcats, ycats=None, pconfig=None):
                 # debugging of modules
                 raise
 
-    return heatmap.plot(data, xcats, ycats, pconfig)
+    return heatmap.plot(data, pconfig, xcats, ycats)

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -13,10 +13,10 @@ ElemT = Union[str, float, int]
 
 
 def plot(
-    rows: List[List[ElemT]],
-    xcats: List[str],
-    ycats: List[str],
+    rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
     pconfig: Dict,
+    xcats: Optional[List[str]] = None,
+    ycats: Optional[List[str]] = None,
 ) -> str:
     """
     Build and add the plot data to the report, return an HTML wrapper.
@@ -26,7 +26,7 @@ def plot(
     :param pconfig: dict with config key:value pairs. See CONTRIBUTING.md
     :return: HTML with JS, ready to be inserted into the page
     """
-    p = HeatmapPlot(pconfig, rows, xcats, ycats)
+    p = HeatmapPlot(rows, pconfig, xcats, ycats)
 
     from multiqc.utils import report
 
@@ -43,11 +43,23 @@ class HeatmapPlot(Plot):
         @staticmethod
         def create(
             dataset: BaseDataset,
-            pconfig: Dict,
-            rows: List[List[ElemT]],
-            xcats: List[str],
-            ycats: List[str],
+            rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
+            xcats: Optional[List[str]] = None,
+            ycats: Optional[List[str]] = None,
         ) -> "HeatmapPlot.Dataset":
+            if isinstance(rows, dict):
+                # Convert dict to a list of lists
+                found_ycats = list(rows.keys())
+                found_xcats = []
+                for y, value_by_x in rows.items():
+                    for x, value in value_by_x.items():
+                        if x not in found_xcats:
+                            found_xcats.append(x)
+
+                ycats = [y for y in found_ycats if y in ycats] if ycats else found_ycats
+                xcats = [x for x in found_xcats if x in xcats] if xcats else found_xcats
+                rows = [[rows[y].get(x) for x in xcats] for y in ycats]
+
             dataset = HeatmapPlot.Dataset(
                 **dataset.__dict__,
                 rows=rows,
@@ -77,10 +89,10 @@ class HeatmapPlot(Plot):
 
     def __init__(
         self,
+        rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
         pconfig: Dict,
-        rows: List[List[ElemT]],
-        xcats: List[str],
-        ycats: List[str],
+        xcats: Optional[List[str]],
+        ycats: Optional[List[str]],
     ):
         super().__init__(PlotType.HEATMAP, pconfig, n_datasets=1)
 
@@ -93,6 +105,7 @@ class HeatmapPlot(Plot):
                 # Prevent JavaScript from automatically parsing categorical values as numbers:
                 type="category",
             ),
+            showlegend=pconfig.get("legend", True),
         )
 
         self.square = pconfig.get("square", True)  # Keep heatmap cells square
@@ -101,7 +114,6 @@ class HeatmapPlot(Plot):
         self.datasets: List[HeatmapPlot.Dataset] = [
             HeatmapPlot.Dataset.create(
                 self.datasets[0],
-                pconfig=pconfig,
                 rows=rows,
                 xcats=xcats,
                 ycats=ycats,
@@ -113,22 +125,21 @@ class HeatmapPlot(Plot):
             for dataset in self.datasets:
                 for row in dataset.rows:
                     for val in row:
-                        if val is not None:
-                            assert isinstance(val, (int, float))
+                        if val is not None and isinstance(val, (int, float)):
                             self.min = val if self.min is None else min(self.min, val)
         self.max = self.pconfig.get("max", None)
         if self.max is None:
             for dataset in self.datasets:
                 for row in dataset.rows:
                     for val in row:
-                        if val is not None:
+                        if val is not None and isinstance(val, (int, float)):
                             self.max = val if self.max is None else max(self.max, val)
 
         # Determining the size of the plot to reasonably display data without cluttering it too much.
         # For flat plots, we try to make the image large enough to display all samples, but to a limit
         # For interactive plots, we set a lower default height, as it will possible to resize the plot
-        num_rows = len(ycats)
-        num_cols = len(xcats)
+        num_rows = len(self.datasets[0].ycats)
+        num_cols = len(self.datasets[0].xcats)
         MAX_HEIGHT = 900 if self.flat else 500  # smaller number for interactive, as it's resizable
         MAX_WIDTH = 900  # default interactive width can be bigger
 
@@ -141,16 +152,16 @@ class HeatmapPlot(Plot):
             if n >= 20:
                 return 26
             if n >= 15:
-                return 30
+                return 33
             if n >= 10:
-                return 35
+                return 45
             if n >= 5:
-                return 40
+                return 60
             if n >= 3:
-                return 50
-            if n >= 2:
                 return 80
-            return 100
+            if n >= 2:
+                return 100
+            return 120
 
         x_px_per_elem = n_elements_to_size(num_cols)
         y_px_per_elem = n_elements_to_size(num_rows)
@@ -182,11 +193,11 @@ class HeatmapPlot(Plot):
         # For not very large datasets, making sure all ticks are displayed:
         if y_px_per_elem > 12:
             self.layout.yaxis.tickmode = "array"
-            self.layout.yaxis.tickvals = list(range(len(ycats)))
+            self.layout.yaxis.tickvals = list(range(num_rows))
             self.layout.yaxis.ticktext = ycats
         if x_px_per_elem > 18:
             self.layout.xaxis.tickmode = "array"
-            self.layout.xaxis.tickvals = list(range(len(xcats)))
+            self.layout.xaxis.tickvals = list(range(num_cols))
             self.layout.xaxis.ticktext = xcats
         if pconfig.get("angled_xticks", True) is False and x_px_per_elem >= 40:
             # Break up the horizontal ticks by whitespace to make them fit better vertically:

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -96,6 +96,18 @@ class HeatmapPlot(Plot):
     ):
         super().__init__(PlotType.HEATMAP, pconfig, n_datasets=1)
 
+        if isinstance(rows, list):
+            if ycats and not isinstance(ycats, list):
+                raise ValueError(
+                    f"Heatmap plot {self.id}: ycats must be passed as a list when the input data is a 2d list. "
+                    f"The order of that list should match the order of the rows in the input data."
+                )
+            if xcats and not isinstance(xcats, list):
+                raise ValueError(
+                    f"Heatmap plot {self.id}: xcats must be passed as a list when the input data is a 2d list. "
+                    f"The order of that list should match the order of the columns in the input data."
+                )
+
         self.layout.update(
             yaxis=dict(
                 # Prevent JavaScript from automatically parsing categorical values as numbers:


### PR DESCRIPTION
Allow passing a 2d-dict besides a 2d-array as data for heatmap. With a dict of dicts, the categories become optional, however, they can be used to specify a subset of cols and rows.

cc @matthdsm