### PR TITLE
Picard: Crosscheck Fingerprints: add LOD heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@
 - **HTSeq Count**: robust file reading loop, ignore `.parquet` files ([#2364](https://github.com/MultiQC/MultiQC/pull/2364))
 - **Illumina InterOp Statistics**: do not set `'scale': False` as a default ([#2350](https://github.com/MultiQC/MultiQC/pull/2350))
 - **mosdepth**: fix regression in showing general stats ([#2346](https://github.com/MultiQC/MultiQC/pull/2346))
+- **Picard**: Crosscheck Fingerprints: add LOD heatmap ([#2388](https://github.com/MultiQC/MultiQC/pull/2388))
+- **PURPLE**: support v4.0.1 output without `version` column ([#2366](https://github.com/MultiQC/MultiQC/pull/2366))
 - **Samtools**: support `coverage` command ([#2356](https://github.com/MultiQC/MultiQC/pull/2356))
 - **UMI-tools**: support `extract` command ([#2296](https://github.com/MultiQC/MultiQC/pull/2296))
 - **Whatshap**: make robust to stdout appended to TSV ([#2361](https://github.com/MultiQC/MultiQC/pull/2361))
-- **PURPLE**: support v4.0.1 output without `version` column ([#2366](https://github.com/MultiQC/MultiQC/pull/2366))
 
 ## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12
 

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -146,7 +146,7 @@ def parse_reports(module):
     module.add_section(
         name="Crosscheck Fingerprints",
         anchor=f"{module.anchor}-crosscheckfingerprints-table",
-        description="Pairwise identity checking between samples and groups." + (f"\n{warning}" if warning else ""),
+        description="Pairwise identity checking between samples and groups." + (f"<br>{warning}" if warning else ""),
         helptext="""
         Checks that all data in the set of input files comes from the same individual, based on the selected group granularity.
         """,
@@ -164,7 +164,7 @@ def parse_reports(module):
         ),
     )
 
-    return len(data_by_sample)
+    return len(heatmap_data.keys())
 
 
 def _take_till(iterator, fn):

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -75,6 +75,11 @@ def parse_reports(module):
 
             module.add_data_source(f, section="CrosscheckFingerprints")
 
+    # Sort the data by the left sample, then right sample
+    data_by_sample = OrderedDict(
+        sorted(data_by_sample.items(), key=lambda x: (x[1]["LEFT_SAMPLE"], x[1]["RIGHT_SAMPLE"]))
+    )
+
     # Only add sections if we found data
     if len(data_by_sample) == 0:
         return 0
@@ -115,6 +120,7 @@ def parse_reports(module):
         description="Pairwise identity checking between samples and groups: heatmap of LOD scores.",
         plot=heatmap.plot(
             heatmap_data,
+            xcats=list(heatmap_data.keys()),
             pconfig={
                 "id": "picard-crosscheckfingerprints-lod-heatmap",
                 "title": f"{module.name}: Crosscheck Fingerprints",

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -124,8 +124,6 @@ def parse_reports(module):
             pconfig={
                 "id": "picard-crosscheckfingerprints-lod-heatmap",
                 "title": f"{module.name}: Crosscheck Fingerprints",
-                "ylab": "Left sample",
-                "xlab": "Right sample",
                 "zlab": "LOD score",
                 "xcats_samples": True,
                 "ycats_samples": True,

--- a/multiqc/modules/picard/picard.py
+++ b/multiqc/modules/picard/picard.py
@@ -89,7 +89,7 @@ class MultiqcModule(BaseMultiqcModule):
             if func is not None:
                 n[tool] = func(self)
                 if n[tool] > 0:
-                    log.info(f"Found {n[tool]} {tool} samples")
+                    log.info(f"Found {n[tool]} {tool} reports")
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/modules/picard/picard.py
+++ b/multiqc/modules/picard/picard.py
@@ -89,7 +89,7 @@ class MultiqcModule(BaseMultiqcModule):
             if func is not None:
                 n[tool] = func(self)
                 if n[tool] > 0:
-                    log.info(f"Found {n[tool]} {tool} reports")
+                    log.info(f"Found {n[tool]} {tool} samples")
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -958,8 +958,15 @@ def run(
                 f"mqc-generalstats-{ns_html}-{h[k]['rid']}"
             )
 
+    all_hidden = True
+    for headers in report.general_stats_headers:
+        for h in headers.values():
+            if not h.get("hidden", False):
+                all_hidden = False
+                break
+
     # Generate the General Statistics HTML & write to file
-    if len(report.general_stats_data) > 0 and not config.skip_generalstats:
+    if len(report.general_stats_data) > 0 and not config.skip_generalstats and not all_hidden:
         pconfig = {
             "id": "general_stats_table",
             "table_title": "General Statistics",

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -49,16 +49,15 @@ class HeatmapPlot(Plot):
         ) -> "HeatmapPlot.Dataset":
             if isinstance(rows, dict):
                 # Convert dict to a list of lists
-                found_ycats = list(rows.keys())
-                found_xcats = []
-                for y, value_by_x in rows.items():
-                    for x, value in value_by_x.items():
-                        if x not in found_xcats:
-                            found_xcats.append(x)
-
-                ycats = [y for y in found_ycats if y in ycats] if ycats else found_ycats
-                xcats = [x for x in found_xcats if x in xcats] if xcats else found_xcats
-                rows = [[rows[y].get(x) for x in xcats] for y in ycats]
+                if not ycats:
+                    ycats = list(rows.keys())
+                if not xcats:
+                    xcats = []
+                    for y, value_by_x in rows.items():
+                        for x, value in value_by_x.items():
+                            if x not in xcats:
+                                xcats.append(x)
+                rows = [[rows.get(y, {}).get(x) for x in xcats] for y in ycats]
 
             dataset = HeatmapPlot.Dataset(
                 **dataset.__dict__,

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -211,7 +211,7 @@ class Plot(ABC):
             dconfig = dconfig if isinstance(dconfig, dict) else {"name": dconfig}
             dataset.label = dconfig.get("name", dconfig.get("label", idx + 1))
             if "ylab" not in dconfig and "ylab" not in self.pconfig:
-                dconfig["ylab"] = dataset.label
+                dconfig["ylab"] = dconfig.get("name", dconfig.get("label"))
 
             dataset.layout, dataset.trace_params = _dataset_layout(pconfig, dconfig, self.tt_label())
             dataset.dconfig = dconfig


### PR DESCRIPTION
cc @matthdsm

- [x] Add heatmap for LOD values in addition to the table
- [x] If too many pairs in table, skip those with `Expected` status and show a warning
- [x] Use the `warn` status if  there are `Inconclusive` instead of `fail`
- [x] Add a separate sample-wise table instead of general stats, sort it by status
- [x] Sort pairwise table by status
- [x] Add a column "Best match" and "Best match LOD" for the sample-wise table and for unexpected mismatched pairs in pairwise table
- [x] Hide LOD Threshold column
- [x] Minor fixes and column name standartization