### PR TITLE
Add export button for table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Refactor: fix unescaped regex strings ([#2384](https://github.com/MultiQC/MultiQC/pull/2384))
 - Heatmap: allow a dict dicts of data ([#2386](https://github.com/MultiQC/MultiQC/pull/2386))
 - Heatmap: add zlab config parameter. Show xlab, ylab, zlab in tooltip ([#2387](https://github.com/MultiQC/MultiQC/pull/2387))
+- Add export button for table ([#2394](https://github.com/MultiQC/MultiQC/pull/2394))
 
 ### New modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -6,7 +6,9 @@ script-src 'self'
     'sha256-bHPK47f6TsuMbS8pR8jVPzEK4orYin9an6P5OkYf+n8=' # class BarPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
     'sha256-yRjvY4tSJ5z2ggAL/i5pJj+peALSAG9PD51Z0Hf7wzQ=' # ////////////////////////////////////////////////// Plotly Plotting Code/////////
     'sha256-gf6XBM6wOXcVJjumRhlnj7J/GEpeABZmKQla1g2feYk=' # class BoxPlot extends Plot {  constructor(dump) {    super(dump);    this.filter
-    'sha256-mVO5Pel/niJHZXAV5BhYrr15QkRTeRFbjRpIVLbBsb4=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
+    'sha256-hT8GW76gPbw230zK0dy6dUPxVfhN9QKm3T8EyNblQjw=' # class ViolinPlot extends Plot {  constructor(dump) {    super(dump);    this.vio
+    'sha256-DrHBQbs5duODlWwXxhFtOOpsMfANjqepi9PBfA4om/8=' # ////////////////////////////////////////////////// MultiQC Table code///////////
+    'sha256-skoLPw9W6GGVScPkzbYwz7laPwL8dOpznqFPCoUHVxA=' # ////////////////////////////////////////////////// MultiQC Report Toolbox Code//
 
     # 1.20
     'sha256-tTUP7XMWeShHDbCfkNfh2MTlcpIsSP6ybV/ChnAPZyo=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//

--- a/multiqc/modules/nonpareil/nonpareil.py
+++ b/multiqc/modules/nonpareil/nonpareil.py
@@ -283,7 +283,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.add_section(
             name="Statistics",
-            anchor="nonpareil-table",
+            anchor="nonpareil-table-section",
             description="""
             Nonpareil uses the redundancy of the reads in metagenomic datasets to
             estimate the average coverage and predict the amount of sequences that

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -324,7 +324,8 @@ class Plot(ABC):
     def _btn(self, cls: str, label: str, data_attrs: Dict[str, str] = None, pressed: bool = False) -> str:
         """Build a switch button for the plot."""
         data_attrs = data_attrs.copy() if data_attrs else {}
-        data_attrs["pid"] = self.id
+        if "pid" not in data_attrs:
+            data_attrs["pid"] = self.id
         data_attrs = " ".join([f'data-{k}="{v}"' for k, v in data_attrs.items()])
         return f'<button class="btn btn-default btn-sm {cls} {"active" if pressed else ""}" {data_attrs}>{label}</button>\n'
 

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -298,6 +298,12 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
             </button>
             """
 
+        html += f"""
+        <button type="button" class="export-plot btn btn-default btn-sm" 
+            data-pid="{violin_id or dt.id}" data-type="table"
+        >Export as TSV</button>
+        """
+
         # "Showing x of y columns" text
         row_visibilities = [all(t_rows_empty[s_name].values()) for s_name in t_rows_empty]
         visible_rows = [x for x in row_visibilities if not x]

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -314,7 +314,7 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
             f"""
         <button type="button" class="export-plot btn btn-default btn-sm" 
             data-pid="{violin_id or dt.id}" data-type="table"
-        >Export as TSV</button>
+        >Export as CSV</button>
         """
         )
 

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -258,51 +258,65 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
     html = ""
     if not config.simple_output:
         # Copy Table Button
-        html += f"""
+        buttons = []
+
+        buttons.append(
+            f"""
         <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="table#{dt.id}">
             <span class="glyphicon glyphicon-copy"></span> Copy table
         </button>
         """
+        )
 
         # Configure Columns Button
         if len(t_headers) > 1:
-            html += f"""
+            buttons.append(
+                f"""
             <button type="button" class="mqc_table_configModal_btn btn btn-default btn-sm" data-toggle="modal" 
                 data-target="#{dt.id}_configModal">
                 <span class="glyphicon glyphicon-th"></span> Configure columns
             </button>
             """
+            )
 
         # Sort By Highlight button
-        html += f"""
+        buttons.append(
+            f"""
         <button type="button" class="mqc_table_sortHighlight btn btn-default btn-sm" 
             data-target="#{dt.id}" data-direction="desc" style="display:none;">
             <span class="glyphicon glyphicon-sort-by-attributes-alt"></span> Sort by highlight
         </button>
         """
+        )
 
         # Scatter Plot Button
         if len(t_headers) > 1:
-            html += f"""
+            buttons.append(
+                f"""
             <button type="button" class="mqc_table_makeScatter btn btn-default btn-sm" 
                 data-toggle="modal" data-target="#tableScatterModal" data-table="#{dt.id}">
                 <span class="glyphicon glyphicon glyphicon-equalizer"></span> Scatter plot
             </button>
             """
+            )
 
         if violin_id is not None:
-            html += f"""
+            buttons.append(
+                f"""
             <button type="button" class="mqc-table-to-violin btn btn-default btn-sm" 
                 data-table-id="{dt.id}" data-violin-id="{violin_id}">
                 <span class="glyphicon glyphicon-align-left"></span> Violin plot
             </button>
             """
+            )
 
-        html += f"""
+        buttons.append(
+            f"""
         <button type="button" class="export-plot btn btn-default btn-sm" 
             data-pid="{violin_id or dt.id}" data-type="table"
         >Export as TSV</button>
         """
+        )
 
         # "Showing x of y columns" text
         row_visibilities = [all(t_rows_empty[s_name].values()) for s_name in t_rows_empty]
@@ -318,8 +332,15 @@ def make_table(dt: DataTable, violin_id: Optional[str] = None) -> Tuple[str, str
             t_showing_cols_txt = f' and <sup id="{dt.id}_numcols" class="mqc_table_numcols">{ncols_vis}</sup>/<sub>{len(t_headers)}</sub> columns'
 
         # Build table header text
-        html += f"""
+        buttons.append(
+            f"""
         <small id="{dt.id}_numrows_text" class="mqc_table_numrows_text">{t_showing_rows_txt}{t_showing_cols_txt}.</small>
+        """
+        )
+
+        panel = "\n".join(buttons)
+        html += f"""
+        <div class='row'>\n<div class='col-xs-12'>\n{panel}\n</div>\n</div>
         """
 
     # Build the table itself

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -473,7 +473,7 @@ class ViolinPlot(Plot):
             html = f"<div id='mqc_violintable_wrapper_{self.id}' {violin_visibility}>{warning}{violin_html}</div>"
 
             table_visibility = "style='display: none;'" if not self.show_table_by_default else ""
-            html += f"<div id='mqc_violintable_wrapper_table_{self.id}' {table_visibility}>{table_html}</div>"
+            html += f"<div id='mqc_violintable_wrapper_{self.dt.id}' {table_visibility}>{table_html}</div>"
 
             html += configuration_modal
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -327,18 +327,19 @@ class ViolinPlot(Plot):
         assert len(list_of_values_by_sample_by_metric) == len(list_of_header_by_metric)
         assert len(list_of_values_by_sample_by_metric) > 0
 
-        self.dt = dt
-        self.no_violin = pconfig.get("no_violin", pconfig.get("no_beeswarm", False))
-        self.show_table = dt is not None
-        self.show_table_by_default = show_table_by_default or self.no_violin
-
         super().__init__(
             PlotType.VIOLIN,
             pconfig,
             n_datasets=len(list_of_values_by_sample_by_metric),
-            # To make sure we use a different ID for the table and the violin plot
-            id=f"violin-{dt.id}" if self.show_table else None,
+            id=dt.id if dt else None,
         )
+
+        self.dt = dt
+        self.no_violin = pconfig.get("no_violin", pconfig.get("no_beeswarm", False))
+        self.show_table = dt is not None
+        self.show_table_by_default = show_table_by_default or self.no_violin
+        if dt:  # to make it different from the violin id
+            dt.id = "table-" + dt.id
 
         self.datasets: List[ViolinPlot.Dataset] = [
             ViolinPlot.Dataset.create(ds, values_by_sample_by_metric, headers_by_metric)
@@ -432,11 +433,6 @@ class ViolinPlot(Plot):
         return ": %{x}"
 
     def add_to_report(self, report) -> str:
-        if not self.no_violin:
-            violin_html = super().add_to_report(report)
-        else:
-            violin_html = ""
-
         warning = ""
         if self.show_table_by_default and not self.show_table:
             warning = (
@@ -463,7 +459,7 @@ class ViolinPlot(Plot):
             # Show violin alone.
             # Note that "no_violin" will be ignored here as we need to render _something_. The only case it can
             # happen if violin.plot() is called directly, and "no_violin" is passed, which doesn't make sense.
-            html = warning + violin_html
+            html = warning + super().add_to_report(report)
         elif self.no_violin:
             # Show table alone
             table_html, configuration_modal = make_table(self.dt)
@@ -471,12 +467,13 @@ class ViolinPlot(Plot):
         else:
             # Render both, add a switch between table and violin
             table_html, configuration_modal = make_table(self.dt, violin_id=self.id)
+            violin_html = super().add_to_report(report)
 
             violin_visibility = "style='display: none;'" if self.show_table_by_default else ""
             html = f"<div id='mqc_violintable_wrapper_{self.id}' {violin_visibility}>{warning}{violin_html}</div>"
 
             table_visibility = "style='display: none;'" if not self.show_table_by_default else ""
-            html += f"<div id='mqc_violintable_wrapper_{self.dt.id}' {table_visibility}>{table_html}</div>"
+            html += f"<div id='mqc_violintable_wrapper_table_{self.id}' {table_visibility}>{table_html}</div>"
 
             html += configuration_modal
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -517,8 +517,9 @@ class ViolinPlot(Plot):
         data = {}
         for metric in dataset.metrics:
             values_by_sample = dataset.violin_values_by_sample_by_metric[metric]
+            title = dataset.header_by_metric[metric]["title"]
             for sample, value in values_by_sample.items():
-                data.setdefault(sample, {})[metric] = value
+                data.setdefault(sample, {})[title] = value
 
         util_functions.write_data_file(data, dataset.uid)
 

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -281,7 +281,8 @@ class ViolinPlot extends Plot {
 
     let sep = format === "tsv" ? "\t" : ",";
     // Export all data points as a table, samples are rows, metrics are columns
-    let csv = "Sample" + sep + metrics.join(sep) + "\n";
+    let titles = metrics.map((metric) => headerByMetric[metric].title);
+    let csv = "Sample" + sep + titles.join(sep) + "\n";
     for (let i = 0; i < allSamples.length; i++) {
       let sample = allSamples[i];
       if (sampleSettings[i].hidden) continue;

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -57,7 +57,7 @@ $(function () {
       e.clearSelection();
     });
     $(".mqc_table_copy_btn").click(function () {
-      var btn = $(this);
+      let btn = $(this);
       btn.addClass("active").html('<span class="glyphicon glyphicon-copy"></span> Copied!');
       setTimeout(function () {
         btn.removeClass("active").html('<span class="glyphicon glyphicon-copy"></span> Copy table');

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -297,7 +297,7 @@ $(function () {
   // EXPORTING PLOTS
   // Change text on download button
   $('#mqc_exportplots a[data-toggle="tab"]').on("shown.bs.tab", function (e) {
-    if ($(e.target).attr("href") == "#mqc_data_download") {
+    if ($(e.target).attr("href") === "#mqc_data_download") {
       $("#mqc-dl-plot-txt").text("Data");
     } else {
       $("#mqc-dl-plot-txt").text("Images");
@@ -494,6 +494,7 @@ $(function () {
     e.preventDefault();
     // Get the id of the span element that was clicked
     let id = e.target.dataset.pid;
+    let isTable = e.target.dataset.type === "table";
     // Tick only this plot in the toolbox and slide out
     $("#mqc_export_selectplots input").prop("checked", false);
     $('#mqc_export_selectplots input[value="' + id + '"]').prop("checked", true);
@@ -501,7 +502,11 @@ $(function () {
     if (id === "tableScatterPlot") {
       $("#tableScatterModal").modal("hide");
     }
-    mqc_toolbox_openclose("#mqc_exportplots", true);
+    mqc_toolbox_openclose(
+      "#mqc_exportplots",
+      true,
+      isTable, // no image export for table, go directly to data download
+    );
   });
 
   /// SAVING STUFF
@@ -674,19 +679,15 @@ function hashCode(str) {
 //////////////////////////////////////////////////////
 // GENERAL TOOLBOX FUNCTIONS
 //////////////////////////////////////////////////////
-function mqc_toolbox_openclose(target, open) {
+function mqc_toolbox_openclose(target, open, dataTab) {
   // Hide any open tooltip so it's not left dangling
   $(".mqc-toolbox-buttons li a").tooltip("hide");
   // Find if what we clicked is already open
-  var btn = $('.mqc-toolbox-buttons li a[href="' + target + '"]');
+  let btn = $('.mqc-toolbox-buttons li a[href="' + target + '"]');
   if (open === undefined) {
-    if (btn.hasClass("active")) {
-      open = false;
-    } else {
-      open = true;
-    }
+    open = !btn.hasClass("active");
   }
-  var already_open = $(".mqc-toolbox").hasClass("active");
+  let already_open = $(".mqc-toolbox").hasClass("active");
   if (open) {
     if (already_open) {
       mqc_toolbox_confirmapply();
@@ -695,18 +696,21 @@ function mqc_toolbox_openclose(target, open) {
     btn.addClass("active");
     $(".mqc-toolbox, " + target).addClass("active");
     $(document).trigger("mqc_toolbox_open");
-    var timeout = already_open ? 0 : 510;
+    let timeout = already_open ? 0 : 510;
     setTimeout(function () {
-      if (target == "#mqc_cols") {
+      if (target === "#mqc_cols") {
         $("#mqc_colour_filter").focus();
       }
-      if (target == "#mqc_renamesamples") {
+      if (target === "#mqc_renamesamples") {
         $("#mqc_renamesamples_from").focus();
       }
-      if (target == "#mqc_hidesamples") {
+      if (target === "#mqc_hidesamples") {
         $("#mqc_hidesamples_filter").focus();
       }
     }, timeout);
+    if (dataTab) {
+      $('#mqc_exportplots a[href="#mqc_data_download"]').tab("show");
+    }
   } else {
     mqc_toolbox_confirmapply();
     btn.removeClass("active");

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -711,7 +711,7 @@ function mqc_toolbox_openclose(target, open, dataTab) {
     if (dataTab) {
       $('#mqc_exportplots a[href="#mqc_data_download"]').tab("show");
     } else {
-      $('#mqc_exportplots a[href="#mqc_data_download"]').tab("hide");
+      $('#mqc_exportplots a[href="#mqc_image_download"]').tab("show");
     }
   } else {
     mqc_toolbox_confirmapply();

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -710,6 +710,8 @@ function mqc_toolbox_openclose(target, open, dataTab) {
     }, timeout);
     if (dataTab) {
       $('#mqc_exportplots a[href="#mqc_data_download"]').tab("show");
+    } else {
+      $('#mqc_exportplots a[href="#mqc_data_download"]').tab("hide");
     }
   } else {
     mqc_toolbox_confirmapply();


### PR DESCRIPTION
Add export button for table as well: 

<img width="1137" alt="Screenshot 2024-02-27 at 18 12 03" src="https://github.com/MultiQC/MultiQC/assets/1575412/1244fab5-a7ea-4cab-a8c9-dda0b05d48e7">

The button brings to the data export modal, the same as for the corresponding violin plot. And matches the TSV exported in Python as well. For the header, use the column `title` field (and the same for the violin).

Partially addresses https://github.com/MultiQC/MultiQC/issues/2389