### PR TITLE
Add option to place bar plot legend on the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Refactor: fix unescaped regex strings ([#2384](https://github.com/MultiQC/MultiQC/pull/2384))
 - Heatmap: allow a dict dicts of data ([#2386](https://github.com/MultiQC/MultiQC/pull/2386))
 - Heatmap: add zlab config parameter. Show xlab, ylab, zlab in tooltip ([#2387](https://github.com/MultiQC/MultiQC/pull/2387))
+- Add option to place bar plot legend on the bottom ([#2397](https://github.com/MultiQC/MultiQC/pull/2397))
 
 ### New modules
 

--- a/docs/core/reports/customisation.md
+++ b/docs/core/reports/customisation.md
@@ -966,6 +966,19 @@ thousandsSep_format: ""
 This formatting currently only applies to the interactive charts. It may be extended
 to apply elsewhere in the future (submit a new issue if you spot somewhere where you'd like it).
 
+## Bar plot legend positioning
+
+By default, the legend for bar plots is placed on the right hand side of the plot.
+If you'd like to move it to the bottom, you can use the following config option:
+
+```yaml
+barplot_legend_on_bottom: true
+```
+
+This is not recommended to set up globally though, as it would look well only
+for medium-sized plot, but would start overlapping with the tick labels on shorter
+plots, or create a large gap on taller plots.
+
 ## Troubleshooting
 
 One tricky bit that caught me out whilst writing this is the different type casting

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -11,7 +11,7 @@ import spectra
 
 from multiqc.plots.plotly import determine_barplot_height
 from multiqc.plots.plotly.plot import Plot, PlotType, BaseDataset, split_long_string
-from multiqc.utils import util_functions
+from multiqc.utils import util_functions, config
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,17 @@ class BarPlot(Plot):
                 font=dict(color="black"),
             ),
         )
+
+        if getattr(config, "barplot_legend_on_bottom", False):
+            self.layout.update(
+                legend=go.layout.Legend(
+                    orientation="h",
+                    x=0.5,
+                    xanchor="center",
+                    y=-0.5,
+                    yanchor="top",
+                ),
+            )
 
         for dataset in self.datasets:
             if barmode == "group":

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -95,6 +95,7 @@ plots_flat_numseries: int
 num_datasets_plot_limit: int
 lineplot_style: str
 lineplot_max_samples: int
+barplot_legend_on_bottom: bool
 violin_downsample_after: int
 violin_min_threshold_outliers: int
 violin_min_threshold_no_points: int

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -62,6 +62,9 @@ plots_force_interactive: false
 plots_flat_numseries: 100
 num_datasets_plot_limit: 50
 lineplot_style: lines # "lines+markers"
+# Place legend at the bottom of the bar plot. Unrecommended, as it would look well only on a medium-sized
+# plot, and would overlap or be too far from the plot on a tinier or taller plots, respectively:
+barplot_legend_on_bottom: false
 lineplot_max_samples: 100 # turn into a violin plot if more than this number
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples
 violin_min_threshold_outliers: 100 # for more than this number of samples, show only outliers

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -62,9 +62,7 @@ plots_force_interactive: false
 plots_flat_numseries: 100
 num_datasets_plot_limit: 50
 lineplot_style: lines # "lines+markers"
-# Place legend at the bottom of the bar plot. Unrecommended, as it would look well only on a medium-sized
-# plot, and would overlap or be too far from the plot on a tinier or taller plots, respectively:
-barplot_legend_on_bottom: false
+barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 lineplot_max_samples: 100 # turn into a violin plot if more than this number
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples
 violin_min_threshold_outliers: 100 # for more than this number of samples, show only outliers


### PR DESCRIPTION
Allow to place legend at the bottom of the bar plot with `barplot_legend_on_bottom`:

```sh
multiqc -fv test_data/data/modules -m star --cl-config "barplot_legend_on_bottom: true"
```

<img width="1136" alt="Screenshot 2024-02-27 at 22 21 46" src="https://github.com/MultiQC/MultiQC/assets/1575412/be4283e7-2c36-4205-ac36-61d7dbffdc6d">

Fixes https://github.com/MultiQC/MultiQC/issues/2390

Default is false and it's not recommended to set it, as it would look well only on medium-sized plots, but would overlap with ticks labels on shorter plots or create a huge gap on taller plots, e.g.:

<img width="1134" alt="Screenshot 2024-02-27 at 22 22 49" src="https://github.com/MultiQC/MultiQC/assets/1575412/7357b87f-0623-41c4-b461-fb27ab54791f">

<img width="1147" alt="Screenshot 2024-02-27 at 22 22 35" src="https://github.com/MultiQC/MultiQC/assets/1575412/9052e4a4-4036-475f-a3ef-92cd0c76f301">

Unfortunately, Plotly doesn't allow to control that gap between the plot and the legend.