### PR TITLE
When checking for git SHA, make sure we are not inside another git repo

### DIFF
--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -2,6 +2,7 @@
 
 """ MultiQC config module. Holds a single copy of
 config variables to be used across all other modules """
+from pathlib import Path
 from typing import List, Dict, Optional, Union
 
 import inspect
@@ -25,15 +26,26 @@ logger = logging.getLogger("multiqc")
 # Get the MultiQC version
 version = importlib_metadata.version("multiqc")
 short_version = version
-script_path = os.path.dirname(os.path.realpath(__file__))
 git_hash = None
 git_hash_short = None
+script_dir = Path(__file__).parent
+git_root = None
 try:
-    git_hash = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=script_path, stderr=subprocess.STDOUT, universal_newlines=True
+    git_root = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"], cwd=script_dir, stderr=subprocess.STDOUT, universal_newlines=True
     ).strip()
-    git_hash_short = git_hash[:7]
-    version = f"{version} ({git_hash_short})"
+    git_root = Path(git_root)
+    # .git
+    # multiqc/
+    #   utils/
+    #       config.py  <- __file__
+    expected_git_root = script_dir.parent.parent
+    if git_root == expected_git_root:
+        git_hash = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=script_dir, stderr=subprocess.STDOUT, universal_newlines=True
+        ).strip()
+        git_hash_short = git_hash[:7]
+        version = f"{version} ({git_hash_short})"
 except Exception:
     pass
 


### PR DESCRIPTION
Common use case is to create a virtualenv inside a git clone folder, in which case `git rev-parse HEAD` will trigger on the outer repo even if MultiQC wasn't installed in editable mode.