### PR TITLE
Set missing values to None for bbmap qahist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Module updates
 
+- **BBTools**: Set missing values to None for bbmap qahist ([#2411](https://github.com/MultiQC/MultiQC/pull/2411))
+
 ## [MultiQC v1.21](https://github.com/ewels/MultiQC/releases/tag/v1.21) - 2024-02-28
 
 ### Highlights

--- a/multiqc/modules/bbmap/plot_qahist.py
+++ b/multiqc/modules/bbmap/plot_qahist.py
@@ -40,16 +40,23 @@ def plot_qahist(samples, file_type, **plot_args):
 
     plot_data = []
     for column_type in columns_to_plot:
-        plot_data.append(
-            {
-                sample + "." + column_name: {
-                    x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
-                }
-                for sample in samples
-                for column, column_name in columns_to_plot[column_type].items()
-            }
-        )
+        column_data = {}
+        for column, column_name in columns_to_plot[column_type].items():
+            for sample in samples:
+                sample_dict = {}
+                for x in all_x:
+                    if x in samples[sample]["data"]:
+                        try:
+                            sample_dict[x] = samples[sample]["data"][x][column]
+                        except IndexError:
+                            # This can happen if the data is missing columns.
+                            # Which happens if e.g. a certain quality value is not present in the data.
+                            sample_dict[x] = None
+                    else:
+                        sample_dict[x] = 0
+                column_data[sample + "." + column_name] = sample_dict
 
+        plot_data.append(column_data)
     plot_params = {
         "id": "bbmap-" + file_type + "_plot",
         "title": "BBTools: " + plot_args["plot_title"],

--- a/multiqc/modules/bbmap/plot_qahist.py
+++ b/multiqc/modules/bbmap/plot_qahist.py
@@ -1,17 +1,31 @@
 from itertools import chain
+from typing import Dict
 
 from multiqc.plots import linegraph
 
 
-def plot_qahist(samples, file_type, **plot_args):
-    """Create line graph plot of histogram data for BBMap 'qahist' output.
+def plot_qahist(data_by_sample: Dict[str, Dict[str, Dict]], file_type, **plot_args):
+    """
+    Create line graph plot of histogram data for BBMap 'qahist' output.
 
     The 'samples' parameter could be from the bbmap mod_data dictionary:
     samples = bbmap.MultiqcModule.mod_data[file_type]
+
+    samples:
+        sample1:
+            data:
+                0: [128, 0, 0, 60]
+                1: ...
+            kv:
+                Deviation: '13.882'
+                DeviationSub: '13.056'
+                ...
+        sample2:
+            ...
     """
 
     all_x = set()
-    for item in sorted(chain(*[samples[sample]["data"].items() for sample in samples])):
+    for item in sorted(chain(*[sample_data["data"].items() for sample, sample_data in data_by_sample.items()])):
         # Skip plotting values for this x if missing columns.
         if len(item[1]) < 6:
             continue
@@ -40,23 +54,20 @@ def plot_qahist(samples, file_type, **plot_args):
 
     plot_data = []
     for column_type in columns_to_plot:
-        column_data = {}
+        y_by_x_by_sample = {}
         for column, column_name in columns_to_plot[column_type].items():
-            for sample in samples:
-                sample_dict = {}
+            for sample, sample_data in data_by_sample.items():
+                y_by_x = {}
                 for x in all_x:
-                    if x in samples[sample]["data"]:
-                        try:
-                            sample_dict[x] = samples[sample]["data"][x][column]
-                        except IndexError:
-                            # This can happen if the data is missing columns.
-                            # Which happens if e.g. a certain quality value is not present in the data.
-                            sample_dict[x] = None
+                    if x not in sample_data["data"] or column >= len(sample_data["data"][x]):
+                        # This can happen if the data is missing columns.
+                        # Which happens if e.g. a certain quality value is not present in the data.
+                        pass
                     else:
-                        sample_dict[x] = 0
-                column_data[sample + "." + column_name] = sample_dict
+                        y_by_x[x] = sample_data["data"][x][column]
+                y_by_x_by_sample[sample] = y_by_x
 
-        plot_data.append(column_data)
+        plot_data.append(y_by_x_by_sample)
     plot_params = {
         "id": "bbmap-" + file_type + "_plot",
         "title": "BBTools: " + plot_args["plot_title"],
@@ -68,8 +79,10 @@ def plot_qahist(samples, file_type, **plot_args):
             {"name": "Insertion", "ylab": "Insertion count"},
             {"name": "Deletion", "ylab": "Deletion count"},
             {"name": "TrueQuality", "ylab": "Count"},
-            {"name": "TrueQualitySubtitution", "ylab": "Count"},
+            {"name": "TrueQualitySubstitution", "ylab": "Count"},
         ],
+        "xmin": 0,
+        "ymin": 0,
     }
 
     plot_params.update(plot_args["plot_params"])


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

Attempting to fix the issue #2410 and assign missing values with None.

I'm not entirely decided if None or 0 is the most appropriate. I'm leaning towards None since the real value in this case is rather undefined than 0. However, the line plot is not handling these singular values very well. See screenshots for using 0 and None respectively. Happily accepting suggestions.

<img width="3086" alt="Screenshot 2024-02-29 at 14 27 54" src="https://github.com/MultiQC/MultiQC/assets/1250075/830dc314-a14c-4cc2-b417-66c939bd893d">

<img width="3075" alt="Screenshot 2024-02-29 at 14 27 44" src="https://github.com/MultiQC/MultiQC/assets/1250075/ad5cb9df-cbb2-4e9d-9bbf-d35e59f49b8c">


Also, sorry for ruining the pretty nested implicit for loop, but it was a bit tricky to debug.

- [x] This comment contains a description of changes (with reason)