### PR TITLE
Changelog CI: update PR URLs, fix removing existing entry and determining module addition

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -44,7 +44,7 @@ pr_title = pr_title.removesuffix(f" (#{pr_number})")
 
 changelog_path = workspace_path / "CHANGELOG.md"
 
-if any(
+no_changelog = any(
     line in pr_title.lower()
     for line in [
         "skip changelog",
@@ -53,9 +53,7 @@ if any(
         "no change log",
         "bump version",
     ]
-):
-    print("Skipping changelog update")
-    sys.exit(0)
+)
 
 
 def _run_cmd(cmd):
@@ -258,32 +256,35 @@ def _determine_change_type(pr_title, pr_number) -> tuple[str, dict]:
     return section, {}
 
 
-# Determine the type of the PR: new module, module update, or core update.
-section, mod = _determine_change_type(pr_title, pr_number)
+pr_link = f"([#{pr_number}]({REPO_URL}/pull/{pr_number}))"
 
 # Prepare the change log entry.
 new_lines = []
-pr_link = f"([#{pr_number}]({REPO_URL}/pull/{pr_number}))"
-if comment := comment.removeprefix("@multiqc-bot changelog").strip():
-    pr_title = comment
-else:
-    if section == "### New modules":
+section = None
+if not no_changelog:
+    # Determine the type of the PR: new module, module update, or core update.
+    section, mod = _determine_change_type(pr_title, pr_number)
+
+    if comment := comment.removeprefix("@multiqc-bot changelog").strip():
+        pr_title = comment
+    else:
+        if section == "### New modules":
+            new_lines = [
+                f"- [**{mod['name']}**]({mod['url']}) {pr_link}\n",
+                f"  - {mod['name']} {mod['info']}\n",
+            ]
+        elif section == "### Module updates":
+            assert mod is not None
+            descr = pr_title
+            if ":" in descr:
+                descr = descr.split(":", maxsplit=1)[1].strip()
+            new_lines = [
+                f"- **{mod['name']}**: {descr} {pr_link}\n",
+            ]
+    if not new_lines:
         new_lines = [
-            f"- [**{mod['name']}**]({mod['url']}) {pr_link}\n",
-            f"  - {mod['name']} {mod['info']}\n",
+            f"- {pr_title} {pr_link}\n",
         ]
-    elif section == "### Module updates":
-        assert mod is not None
-        descr = pr_title
-        if ":" in descr:
-            descr = descr.split(":", maxsplit=1)[1].strip()
-        new_lines = [
-            f"- **{mod['name']}**: {descr} {pr_link}\n",
-        ]
-if not new_lines:
-    new_lines = [
-        f"- {pr_title} {pr_link}\n",
-    ]
 
 # Finally, updating the changelog.
 # Read the current changelog lines. We will print them back as is, except for one new
@@ -331,6 +332,10 @@ while orig_lines:
 
     # If the line already contains a link to the PR, don't add it again.
     line = _skip_existing_entry_for_this_pr(line, same_section=False)
+
+    if no_changelog:  # do not add anything, and remove if already added
+        updated_lines.append(line)
+        continue
 
     if line.startswith("## "):  # Version header, e.g. "## MultiQC v1.10dev"
         updated_lines.append(line)

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -173,6 +173,7 @@ def _modules_modified_by_pr(pr_number) -> set[str]:
     altered_files = _files_altered_by_pr(pr_number, {"modified"})
 
     # First, special case for search patterns.
+    keys_added_in_search_patterns = set()
     keys_modified_in_search_patterns = set()
     sp_paths = [f for f in altered_files if f.name == "search_patterns.yaml"]
     if sp_paths:
@@ -195,7 +196,7 @@ def _modules_modified_by_pr(pr_number) -> set[str]:
             for new_skey in new_data:
                 # Added module?
                 if new_skey not in old_data:
-                    keys_modified_in_search_patterns.add(new_skey)
+                    keys_added_in_search_patterns.add(new_skey)
             for old_skey in old_data:
                 # Removed module?
                 if old_skey not in new_data:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### MultiQC updates
 
-- Changelog CI: update PR URLs, fix removing existing entry and determining module addition ([#2412](https://github.com/MultiQC/MultiQC/pull/2412))
-
 ### New modules
 
 ### Module updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Module updates
 
-## [MultiQC v1.21](https://github.com/ewels/MultiQC/releases/tag/v1.21) - 2024-02-28
+## [MultiQC v1.21](https://github.com/MultiQC/MultiQC/releases/tag/v1.21) - 2024-02-28
 
 ### Highlights
 
@@ -131,7 +131,7 @@ Fixes:
 - **UMI-tools**: support new `extract` command ([#2296](https://github.com/MultiQC/MultiQC/pull/2296))
 - **Whatshap**: make robust when a stdout is appended to TSV ([#2361](https://github.com/MultiQC/MultiQC/pull/2361))
 
-## [MultiQC v1.20](https://github.com/ewels/MultiQC/releases/tag/v1.20) - 2024-02-12
+## [MultiQC v1.20](https://github.com/MultiQC/MultiQC/releases/tag/v1.20) - 2024-02-12
 
 ### Highlights
 
@@ -171,14 +171,14 @@ The v1.20 release is also the first release we've had since we moved the MultiQC
   - Moved legacy Highcharts/Matplotlib code under an optional template `highcharts`
     ([#2292](https://github.com/MultiQC/MultiQC/pull/2292))
 - Move GitHub repository to `MultiQC` organisation ([#2243](https://github.com/MultiQC/MultiQC/pull/2243))
-- Update all GitHub actions to their latest versions ([#2242](https://github.com/ewels/MultiQC/pull/2242))
+- Update all GitHub actions to their latest versions ([#2242](https://github.com/MultiQC/MultiQC/pull/2242))
 - Update docs to work with Astro 4 ([#2256](https://github.com/MultiQC/MultiQC/pull/2256))
 - Remove unused dependency on `future` library ([#2258](https://github.com/MultiQC/MultiQC/pull/2258))
 - Fix incorrect scale IDs caught by linting ([#2272](https://github.com/MultiQC/MultiQC/pull/2272))
 - Docs: fix missing `v` prefix in docker image tags ([#2273](https://github.com/MultiQC/MultiQC/pull/2273))
 - Unicode file reading errors: attempt to skip non-unicode characters ([#2275](https://github.com/MultiQC/MultiQC/pull/2275))
 - Heatmap: check if value is numeric when calculating min and max ([#2276](https://github.com/MultiQC/MultiQC/pull/2276))
-- Add `filesearch_file_shared` config option, remove unnecessary per-module `shared` flags in search patterns ([#2227](https://github.com/ewels/MultiQC/pull/2227))
+- Add `filesearch_file_shared` config option, remove unnecessary per-module `shared` flags in search patterns ([#2227](https://github.com/MultiQC/MultiQC/pull/2227))
 - Use alternative method to walk directory using pathlib ([#2277](https://github.com/MultiQC/MultiQC/pull/2277))
 - Export `config.output_dir` in MegaQC JSON ([#2287](https://github.com/MultiQC/MultiQC/pull/2287))
 - Drop support for module tags ([#2278](https://github.com/MultiQC/MultiQC/pull/2278))
@@ -192,7 +192,7 @@ The v1.20 release is also the first release we've had since we moved the MultiQC
   - Bamdst is a lightweight tool to stat the depth coverage of target regions of bam file(s).
 - [**MetaPhlAn**](https://github.com/biobakery/MetaPhlAn) ([#2262](https://github.com/MultiQC/MultiQC/pull/2262))
   - MetaPhlAn is a computational tool for profiling the composition of microbial communities from metagenomic shotgun sequencing data.
-- [**MEGAHIT**](https://github.com/voutcn/megahit) ([#2222](https://github.com/ewels/MultiQC/pull/2222))
+- [**MEGAHIT**](https://github.com/voutcn/megahit) ([#2222](https://github.com/MultiQC/MultiQC/pull/2222))
   - MEGAHIT is an ultra-fast and memory-efficient NGS assembler
 - [**Nonpareil**](https://github.com/lmrodriguezr/nonpareil) ([#2215](https://github.com/MultiQC/MultiQC/pull/2215))
   - Estimate metagenomic coverage and sequence diversity.
@@ -214,41 +214,41 @@ The v1.20 release is also the first release we've had since we moved the MultiQC
 - **Seqera Platform CLI**: updates for v0.9.2 ([#2248](https://github.com/MultiQC/MultiQC/pull/2248))
 - **Seqera Platform CLI**: handle failed tasks ([#2286](https://github.com/MultiQC/MultiQC/pull/2286))
 
-## [MultiQC v1.19](https://github.com/ewels/MultiQC/releases/tag/v1.19) - 2023-12-18
+## [MultiQC v1.19](https://github.com/MultiQC/MultiQC/releases/tag/v1.19) - 2023-12-18
 
 ### MultiQC updates
 
-- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/ewels/MultiQC/pull/2228))
-- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/ewels/MultiQC/pull/2191))
-- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/ewels/MultiQC/pull/2210))
-- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/ewels/MultiQC/pull/1666))
-- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/ewels/MultiQC/pull/2224))
-- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/ewels/MultiQC/pull/1667))
-- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
-- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/ewels/MultiQC/pull/2209))
+- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/MultiQC/MultiQC/pull/2228))
+- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/MultiQC/MultiQC/pull/2191))
+- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/MultiQC/MultiQC/pull/2210))
+- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/MultiQC/MultiQC/pull/1666))
+- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/MultiQC/MultiQC/pull/2224))
+- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/MultiQC/MultiQC/pull/1667))
+- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/MultiQC/MultiQC/pull/2195))
+- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/MultiQC/MultiQC/pull/2209))
 
 ### MultiQC bug fixes
 
-- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
-- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
-- Fix running with the `--no-report` flag ([#2212](https://github.com/ewels/MultiQC/pull/2212))
-- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/ewels/MultiQC/pull/2208))
-- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/ewels/MultiQC/pull/2234))
+- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/MultiQC/MultiQC/pull/2202))
+- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
+- Fix running with the `--no-report` flag ([#2212](https://github.com/MultiQC/MultiQC/pull/2212))
+- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/MultiQC/MultiQC/pull/2208))
+- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/MultiQC/MultiQC/pull/2234))
 
 ### Module updates
 
-- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
-- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/ewels/MultiQC/pull/2229))
-- **Fastp**: search content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
-- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
-- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/ewels/MultiQC/pull/2233))
-- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/ewels/MultiQC/pull/2230))
-- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
-- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))
-- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/ewels/MultiQC/pull/2226))
-- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/ewels/MultiQC/pull/1485))
+- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/MultiQC/MultiQC/pull/2197))
+- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/MultiQC/MultiQC/pull/2229))
+- **Fastp**: search content instead of file name ([#2213](https://github.com/MultiQC/MultiQC/pull/2213))
+- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
+- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/MultiQC/MultiQC/pull/2233))
+- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/MultiQC/MultiQC/pull/2230))
+- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/MultiQC/MultiQC/pull/2205))
+- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/MultiQC/MultiQC/pull/2207))
+- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/MultiQC/MultiQC/pull/2226))
+- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/MultiQC/MultiQC/pull/1485))
 
-## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
+## [MultiQC v1.18](https://github.com/MultiQC/MultiQC/releases/tag/v1.18) - 2023-11-17
 
 ### Highlights
 
@@ -280,40 +280,40 @@ If you were using the Sentieon module in your pipelines, make sure to update any
 
 ### MultiQC updates
 
-- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/ewels/MultiQC/pull/2178))
-- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/ewels/MultiQC/pull/2183))
-- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/ewels/MultiQC/pull/2181))
-- Software versions: allow any string as a version tag ([#2166](https://github.com/ewels/MultiQC/pull/2166))
-- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/ewels/MultiQC/pull/2176))
-- Stricter config variable typing ([#2178](https://github.com/ewels/MultiQC/pull/2178))
-- Remove `position:absolute` CSS from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
-- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/ewels/MultiQC/pull/2143))
-- Fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
-- Fix logging spillover bug ([#2174](https://github.com/ewels/MultiQC/pull/2174))
+- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
+- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/MultiQC/MultiQC/pull/2183))
+- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/MultiQC/MultiQC/pull/2181))
+- Software versions: allow any string as a version tag ([#2166](https://github.com/MultiQC/MultiQC/pull/2166))
+- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/MultiQC/MultiQC/pull/2176))
+- Stricter config variable typing ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
+- Remove `position:absolute` CSS from table values ([#2169](https://github.com/MultiQC/MultiQC/pull/2169))
+- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/MultiQC/MultiQC/pull/2143))
+- Fix custom anchors for kraken ([#2170](https://github.com/MultiQC/MultiQC/pull/2170))
+- Fix logging spillover bug ([#2174](https://github.com/MultiQC/MultiQC/pull/2174))
 
 ### New Modules
 
-- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/ewels/MultiQC/pull/2151))
+- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/MultiQC/MultiQC/pull/2151))
   - Seqera Platform CLI reports statistics generated by the Seqera Platform CLI.
-- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/ewels/MultiQC/pull/1860))
+- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/MultiQC/MultiQC/pull/1860))
   - A tool for classifying reads from xenograft sources.
-- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/ewels/MultiQC/pull/2168))
+- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/MultiQC/MultiQC/pull/2168))
   - xengsort is a fast xenograft read sorter based on space-efficient k-mer hashing
 
 ### Module updates
 
-- **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
-- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
-- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/ewels/MultiQC/pull/2179))
-- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
-- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/ewels/MultiQC/pull/2157))
-- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/ewels/MultiQC/pull/2110))
-- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/ewels/MultiQC/pull/2110))
+- **fastp**: add version parsing ([#2159](https://github.com/MultiQC/MultiQC/pull/2159))
+- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/MultiQC/MultiQC/pull/2139))
+- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/MultiQC/MultiQC/pull/2179))
+- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/MultiQC/MultiQC/pull/2155))
+- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/MultiQC/MultiQC/pull/2157))
+- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
+- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
   - Note that any code that relies on the module name needs to be updated, e.g. `-m sentieon` will no longer work
   - The exported plot and data files will be now be prefixed as `picard` instead of `sentieon`, etc.
   - Note that the Sentieon module used to fetch the sample names from the file names by default, and now it follows the Picard module's logic, and prioritizes the commands recorded in the logs. To override, use the `use_filename_as_sample_name` config flag
 
-## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
+## [MultiQC v1.17](https://github.com/MultiQC/MultiQC/releases/tag/v1.17) - 2023-10-17
 
 ### The one with the new logo
 
@@ -328,45 +328,45 @@ Highlights:
 
 ### MultiQC updates
 
-- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025), [#2102](https://github.com/ewels/MultiQC/pull/2102), [#2115](https://github.com/ewels/MultiQC/pull/2115))
-- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
-- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/ewels/MultiQC/pull/2049))
-- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
-- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/ewels/MultiQC/pull/2101))
-- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/ewels/MultiQC/pull/1632))
-- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/ewels/MultiQC/pull/2124))
-- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/ewels/MultiQC/pull/2109))
+- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/MultiQC/MultiQC/pull/2025), [#2102](https://github.com/MultiQC/MultiQC/pull/2102), [#2115](https://github.com/MultiQC/MultiQC/pull/2115))
+- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/MultiQC/MultiQC/pull/2082))
+- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/MultiQC/MultiQC/pull/2049))
+- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/MultiQC/MultiQC/pull/2081))
+- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/MultiQC/MultiQC/pull/2101))
+- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/MultiQC/MultiQC/pull/1632))
+- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/MultiQC/MultiQC/pull/2124))
+- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/MultiQC/MultiQC/pull/2109))
 - Fixes for python 3.12
-  - Replace removed `distutils` ([#2113](https://github.com/ewels/MultiQC/pull/2113))
-  - Bundle lzstring ([#2119](https://github.com/ewels/MultiQC/pull/2119))
-- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/ewels/MultiQC/pull/2121))
-- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
+  - Replace removed `distutils` ([#2113](https://github.com/MultiQC/MultiQC/pull/2113))
+  - Bundle lzstring ([#2119](https://github.com/MultiQC/MultiQC/pull/2119))
+- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/MultiQC/MultiQC/pull/2121))
+- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/MultiQC/MultiQC/pull/2074))
 - <img src="./multiqc/templates/default/assets/img/favicon-16x16.png" alt="///" width="10px"/> New logo
-- Set name and anchor for the custom content "module" [#2131](https://github.com/ewels/MultiQC/pull/2131)
-- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/ewels/MultiQC/pull/2133))
+- Set name and anchor for the custom content "module" [#2131](https://github.com/MultiQC/MultiQC/pull/2131)
+- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/MultiQC/MultiQC/pull/2133))
 
 ### New Modules
 
 - [**Bracken**](https://ccb.jhu.edu/software/bracken/)
   - A highly accurate statistical method that computes the abundance of species in DNA sequences from a metagenomics sample.
-- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/ewels/MultiQC/pull/1751))
+- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/MultiQC/MultiQC/pull/1751))
   - Truvari is a toolkit for benchmarking, merging, and annotating structural variants
 
 ### Module updates
 
-- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/ewels/MultiQC/pull/2128))
-- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/ewels/MultiQC/pull/2118))
-- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/ewels/MultiQC/pull/2108))
-- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
-- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/ewels/MultiQC/pull/2126))
-- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/ewels/MultiQC/pull/2129))
-- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/ewels/MultiQC/pull/2106))
-- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/ewels/MultiQC/pull/2127))
-- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/ewels/MultiQC/pull/2083), [#2094](https://github.com/ewels/MultiQC/pull/2094))
-- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/ewels/MultiQC/pull/2123))
-- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
+- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/MultiQC/MultiQC/pull/2128))
+- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/MultiQC/MultiQC/pull/2118))
+- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/MultiQC/MultiQC/pull/2108))
+- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/MultiQC/MultiQC/pull/2075))
+- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/MultiQC/MultiQC/pull/2126))
+- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/MultiQC/MultiQC/pull/2129))
+- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/MultiQC/MultiQC/pull/2106))
+- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/MultiQC/MultiQC/pull/2127))
+- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/MultiQC/MultiQC/pull/2083), [#2094](https://github.com/MultiQC/MultiQC/pull/2094))
+- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/MultiQC/MultiQC/pull/2123))
+- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/MultiQC/MultiQC/pull/2095))
 
-## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
+## [MultiQC v1.16](https://github.com/MultiQC/MultiQC/releases/tag/v1.16) - 2023-09-22
 
 ### Highlight: Software versions
 
@@ -384,21 +384,21 @@ See the documentation for more ([writing modules](https://multiqc.info/docs/deve
 [supplying stand-alone](https://multiqc.info/docs/reports/customisation/#listing-software-versions))
 
 Huge thanks to [@pontushojer](https://https://github.com/pontushojer) for the
-contribution ([#1927](https://github.com/ewels/MultiQC/pull/1927)).
-This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/290), made in 2016!
+contribution ([#1927](https://github.com/MultiQC/MultiQC/pull/1927)).
+This idea goes way back to [issue #290](https://github.com/MultiQC/MultiQC/issues/290), made in 2016!
 
 ### MultiQC updates
 
-- Removed `simplejson` unused dependency ([#1973](https://github.com/ewels/MultiQC/pull/1973))
+- Removed `simplejson` unused dependency ([#1973](https://github.com/MultiQC/MultiQC/pull/1973))
 - Give config `custom_plot_config` priority over column-specific settings set by modules
-- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/ewels/MultiQC/pull/1976))
+- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/MultiQC/MultiQC/pull/1976))
 - Fixed parsing of `plot_type: "html"` `data` in json custom content
 - Replace deprecated `pkg_resources`
-- [Fix](https://github.com/ewels/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/ewels/MultiQC/pull/2037)).
-- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/ewels/MultiQC/pull/2055)
-- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/ewels/MultiQC/pull/2058))
-- Fix table column color scaling then there are negative numbers ([1869](https://github.com/ewels/MultiQC/issues/1869))
-- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/ewels/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
+- [Fix](https://github.com/MultiQC/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/MultiQC/MultiQC/pull/2037)).
+- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/MultiQC/MultiQC/pull/2055)
+- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/MultiQC/MultiQC/pull/2058))
+- Fix table column color scaling then there are negative numbers ([1869](https://github.com/MultiQC/MultiQC/issues/1869))
+- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/MultiQC/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
 
 ### New Modules
 
@@ -412,36 +412,36 @@ This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/
 ### Module updates
 
 - **BcfTools**
-  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/ewels/MultiQC/issues/2052))
+  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/MultiQC/MultiQC/issues/2052))
 - **Custom content**
-  - Don't convert sample IDs to floats ([#1883](https://github.com/ewels/MultiQC/issues/1883))
+  - Don't convert sample IDs to floats ([#1883](https://github.com/MultiQC/MultiQC/issues/1883))
 - **DRAGEN**
-  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/ewels/MultiQC/pull/1994))
+  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/MultiQC/MultiQC/pull/1994))
 - **FastQC**:
-  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/ewels/MultiQC/issues/2024))
+  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/MultiQC/MultiQC/issues/2024))
 - **Kaiju**:
-  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/ewels/MultiQC/pull/2023))
+  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/MultiQC/MultiQC/pull/2023))
 - **Kraken**
-  - Parametrize top-N through config ([#2060](https://github.com/ewels/MultiQC/pull/2060))
-  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/ewels/MultiQC/issues/1766)).
+  - Parametrize top-N through config ([#2060](https://github.com/MultiQC/MultiQC/pull/2060))
+  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/MultiQC/MultiQC/issues/1766)).
 - **Mosdepth**
-  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/ewels/MultiQC/issues/1978))
+  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/MultiQC/MultiQC/issues/1978))
   - Added the `perchrom_fraction_cutoff` option into the config to help avoid clutter in contig-level plots
   - Fix a bug happening when both `region` and `global` coverage histograms for a sample are available (i.e. when mosdepth was run with `--by`, see [mosdepth docs](https://github.com/brentp/mosdepth#usage)). In this case, data was effectively merged. Instead, summarise it separately and add a separate report section for the region-based coverage data.
-  - Do not fail when all input samples have no coverage ([#2005](https://github.com/ewels/MultiQC/pull/2005)).
+  - Do not fail when all input samples have no coverage ([#2005](https://github.com/MultiQC/MultiQC/pull/2005)).
 - **NanoStat**
-  - Support new format ([#1997](https://github.com/ewels/MultiQC/pull/1997)).
+  - Support new format ([#1997](https://github.com/MultiQC/MultiQC/pull/1997)).
 - **RSeQC**
-  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/ewels/MultiQC/issues/1985))
-  - Fix division by zero on all-zero input ([#2040](https://github.com/ewels/MultiQC/pull/2040))
+  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/MultiQC/MultiQC/issues/1985))
+  - Fix division by zero on all-zero input ([#2040](https://github.com/MultiQC/MultiQC/pull/2040))
 - **Samtools**
-  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/ewels/MultiQC/pull/1972))
+  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/MultiQC/MultiQC/pull/1972))
 - **Qualimap**
-  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/ewels/MultiQC/issues/2019))
+  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/MultiQC/MultiQC/issues/2019))
 - **WhatsHap**
-  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/ewels/MultiQC/pull/1981))
+  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/MultiQC/MultiQC/pull/1981))
 
-## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
+## [MultiQC v1.15](https://github.com/MultiQC/MultiQC/releases/tag/v1.15) - 2023-08-04
 
 #### Potential breaking change in some edge cases
 
@@ -458,13 +458,13 @@ for more information.
 
 ### MultiQC updates
 
-- Refactor file search for performance improvements ([#1904](https://github.com/ewels/MultiQC/pull/1904))
+- Refactor file search for performance improvements ([#1904](https://github.com/MultiQC/MultiQC/pull/1904))
 - Bump `log_filesize_limit` default (to skip large files in the search) from 10MB to 50MB.
-- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/ewels/MultiQC/issues/1739))
-- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/ewels/MultiQC/issues/1861))
+- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/MultiQC/MultiQC/issues/1739))
+- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/MultiQC/MultiQC/issues/1861))
 - Don't print DOI in module if it's set to an empty string.
-- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/ewels/MultiQC/pull/1891))
-- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/ewels/MultiQC/issues/1866))
+- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/MultiQC/MultiQC/pull/1891))
+- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/MultiQC/MultiQC/issues/1866))
 - New back-end to preview + deploy the new website when the docs are edited.
 - Fixed a _lot_ of broken links in the documentation from the new website change in structure.
 
@@ -478,46 +478,46 @@ for more information.
 ### Module updates
 
 - **Conpair**
-  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/ewels/MultiQC/issues/1851))
+  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/MultiQC/MultiQC/issues/1851))
 - **Cell Ranger**
-  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/ewels/MultiQC/issues/1853), [#1871](https://github.com/ewels/MultiQC/issues/1871))
+  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/MultiQC/MultiQC/issues/1853), [#1871](https://github.com/MultiQC/MultiQC/issues/1871))
 - **DRAGEN**
-  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/ewels/MultiQC/issues/1844))
-  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/ewels/MultiQC/pull/1958))
+  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/MultiQC/MultiQC/issues/1844))
+  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/MultiQC/MultiQC/pull/1958))
 - **filtlong**
-  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/ewels/MultiQC/issues/1843))
+  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/MultiQC/MultiQC/issues/1843))
 - **GATK**
   - Adds support for [AnalyzeSaturationMutagenesis submodule](https://gatk.broadinstitute.org/hc/en-us/articles/360037594771-AnalyzeSaturationMutagenesis-BETA-)
 - **HUMID**
-  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/ewels/MultiQC/issues/1856))
+  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/MultiQC/MultiQC/issues/1856))
 - **Mosdepth**
-  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Fill in missing values for general stats table ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/ewels/MultiQC/issues/1960))
+  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Fill in missing values for general stats table ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/MultiQC/MultiQC/issues/1960))
 - **Picard**
-  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/ewels/MultiQC/issues/1888))
-  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/ewels/MultiQC/pull/1928))
+  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/MultiQC/MultiQC/issues/1888))
+  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/MultiQC/MultiQC/pull/1928))
 - **Porechop**
-  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/ewels/MultiQC/issues/1850))
+  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/MultiQC/MultiQC/issues/1850))
   - Added report section listing samples that had no adapters trimmed
 - **RSeQC**
-  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/ewels/MultiQC/issues/1735))
+  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/MultiQC/MultiQC/issues/1735))
 - **UMI-tools**
-  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/ewels/MultiQC/issues/1845))
+  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/MultiQC/MultiQC/issues/1845))
 
-## [MultiQC v1.14](https://github.com/ewels/MultiQC/releases/tag/v1.14) - 2023-01-08
+## [MultiQC v1.14](https://github.com/MultiQC/MultiQC/releases/tag/v1.14) - 2023-01-08
 
 ### MultiQC new features
 
-- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/ewels/MultiQC/pull/1541), [#1541](https://github.com/ewels/MultiQC/pull/1541))
-- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/ewels/MultiQC/pull/1835))
-- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/ewels/MultiQC/issues/915))
+- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/MultiQC/MultiQC/pull/1541), [#1541](https://github.com/MultiQC/MultiQC/pull/1541))
+- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/MultiQC/MultiQC/pull/1835))
+- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/MultiQC/MultiQC/issues/915))
 - Add CI testing for Python 3.10 and 3.11
-- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/ewels/MultiQC/pull/1668))
+- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/MultiQC/MultiQC/pull/1668))
 - Parsing output file column headers is much faster.
 
 ### MultiQC code cleanup
@@ -529,12 +529,12 @@ for more information.
 
 ### MultiQC updates
 
-- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
-- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
-- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
-- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/ewels/MultiQC/issues/1308))
+- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/MultiQC/MultiQC/issues/1722))
+- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/MultiQC/MultiQC/issues/1642))
+- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/MultiQC/MultiQC/issues/1638))
+- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/MultiQC/MultiQC/issues/1308))
 - Fix sorting of table columns with text values
-- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/ewels/MultiQC/issues/1540))
+- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
 - New logos! MultiQC is now developed and maintained at [Seqera Labs](https://seqera.io/). Updated logos and email addresses accordingly.
 
 ### New Modules
@@ -574,63 +574,63 @@ for more information.
 ### Module updates
 
 - **Bcftools stats**
-  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/ewels/MultiQC/pull/1777))
-  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/ewels/MultiQC/issues/1832))
+  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/MultiQC/MultiQC/pull/1777))
+  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/MultiQC/MultiQC/issues/1832))
 - **BCL Convert**
-  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
-  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/ewels/MultiQC/issues/1774))
+  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/MultiQC/MultiQC/issues/1697))
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/MultiQC/MultiQC/issues/1774))
   - Handle single-index paired-end data correctly
-  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/ewels/MultiQC/pull/1709))
+  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/MultiQC/MultiQC/pull/1709))
 - **BUSCO**
   - Update BUSCO pass/warning/fail scheme to be more clear for users
 - **Bustools**
   - Show median reads per barcode statistic
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
-  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
-  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
+  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
+  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
 - **fastp**
-  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/ewels/MultiQC/issues/1744))
-  - Don't crash for invalid JSON files ([#1652](https://github.com/ewels/MultiQC/issues/1652))
+  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/MultiQC/MultiQC/issues/1744))
+  - Don't crash for invalid JSON files ([#1652](https://github.com/MultiQC/MultiQC/issues/1652))
 - **FastQC**
-  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/ewels/MultiQC/pull/1745))
+  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/MultiQC/MultiQC/pull/1745))
 - **Kaiju**
-  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/ewels/MultiQC/issues/1540))
+  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
 - **Kallisto**
-  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/ewels/MultiQC/issues/1746))
+  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/MultiQC/MultiQC/issues/1746))
 - **Kraken**
-  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/ewels/MultiQC/pull/1779))
+  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/MultiQC/MultiQC/pull/1779))
   - Make heatmap full width
-  - Handle empty kreports gracefully ([#1637](https://github.com/ewels/MultiQC/issues/1637))
-  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/ewels/MultiQC/pull/1639))
+  - Handle empty kreports gracefully ([#1637](https://github.com/MultiQC/MultiQC/issues/1637))
+  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/MultiQC/MultiQC/pull/1639))
 - **malt**
-  - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
+  - Fixed division by 0 in malt module ([#1683](https://github.com/MultiQC/MultiQC/issues/1683))
 - **miRTop**
-  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/ewels/MultiQC/issues/1778))
+  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/MultiQC/MultiQC/issues/1778))
 - **Mosdepth**
-  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/ewels/MultiQC/pull/1810))
+  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/MultiQC/MultiQC/pull/1810))
 - **Picard**
   - HsMetrics: Allow custom columns in General Stats too, with `HsMetrics_genstats_table_cols` and `HsMetrics_genstats_table_cols_hidden`
 - **Qualimap**
-  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/ewels/MultiQC/pull/1798))
-  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780))
+  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/MultiQC/MultiQC/pull/1798))
+  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/MultiQC/MultiQC/issues/1780))
 - **RSeQC**
-  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/ewels/MultiQC/pull/1792))
+  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/MultiQC/MultiQC/pull/1792))
 - **Sambamba Markdup**
-  - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
+  - Catch zero division in sambamba markdup ([#1654](https://github.com/MultiQC/MultiQC/issues/1654))
 - **Samtools**
-  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/ewels/MultiQC/issues/1733))
+  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/MultiQC/MultiQC/issues/1733))
 - **VEP**
-  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/ewels/MultiQC/issues/1681))
+  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/MultiQC/MultiQC/issues/1681))
 
-## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
+## [MultiQC v1.13](https://github.com/MultiQC/MultiQC/releases/tag/v1.13) - 2022-09-08
 
 ### MultiQC updates
 
 - Major spruce of the command line help, using the new [rich-click](https://github.com/ewels/rich-click) package
 - Drop some of the Python 2k compatability code (eg. custom requirements)
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/ewels/MultiQC/issues/1643))
+  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/MultiQC/MultiQC/issues/1643))
 - Added new config option `custom_table_header_config` to override any config for any table header
 - Fixed edge-case bug in custom content where a `description` that doesn't terminate in `.` gave duplicate section descriptions.
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
@@ -642,53 +642,53 @@ for more information.
 ### Module updates
 
 - **AdapterRemoval**
-  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
+  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/MultiQC/MultiQC/issues/1647))
 - **VEP**
-  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
+  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/MultiQC/MultiQC/pull/1656))
 - **Custom content**
-  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
-  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/ewels/MultiQC/issues/1686))
-  - Fix crash when `info` isn't set ([#1688](https://github.com/ewels/MultiQC/issues/1688))
+  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/MultiQC/MultiQC/issues/1629))
+  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/MultiQC/MultiQC/issues/1686))
+  - Fix crash when `info` isn't set ([#1688](https://github.com/MultiQC/MultiQC/issues/1688))
 - **Nanostat**
-  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
-  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/ewels/MultiQC/issues/1717))
+  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/MultiQC/MultiQC/pull/1659))
+  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/MultiQC/MultiQC/issues/1717))
 - **Pangolin**
-  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
+  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/MultiQC/MultiQC/pull/1660))
 - **Somalier**
-  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
+  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/MultiQC/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
 - **miRTop**
-  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/ewels/MultiQC/issues/1712))
-  - Fix module crashing due to zero division ([#1719](https://github.com/ewels/MultiQC/issues/1719))
+  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/MultiQC/MultiQC/issues/1712))
+  - Fix module crashing due to zero division ([#1719](https://github.com/MultiQC/MultiQC/issues/1719))
 - **FastQC**
-  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/ewels/MultiQC/pull/1725))
+  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/MultiQC/MultiQC/pull/1725))
 
-## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
+## [MultiQC v1.12](https://github.com/MultiQC/MultiQC/releases/tag/v1.12) - 2022-02-08
 
 ### MultiQC - new features
 
-- Added option to customise default plot height in plot config ([#1432](https://github.com/ewels/MultiQC/issues/1432))
-- Added `--no-report` flag to skip report generation ([#1462](https://github.com/ewels/MultiQC/issues/1462))
-- Added support for priting tool DOI in report sections ([#1177](https://github.com/ewels/MultiQC/issues/1177))
-- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/ewels/MultiQC/pull/1573))
-- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/ewels/MultiQC/pull/1576))
-- Added support for customising table column names ([#1255](https://github.com/ewels/MultiQC/issues/1255))
+- Added option to customise default plot height in plot config ([#1432](https://github.com/MultiQC/MultiQC/issues/1432))
+- Added `--no-report` flag to skip report generation ([#1462](https://github.com/MultiQC/MultiQC/issues/1462))
+- Added support for priting tool DOI in report sections ([#1177](https://github.com/MultiQC/MultiQC/issues/1177))
+- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/MultiQC/MultiQC/pull/1573))
+- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/MultiQC/MultiQC/pull/1576))
+- Added support for customising table column names ([#1255](https://github.com/MultiQC/MultiQC/issues/1255))
 
 ### MultiQC - updates
 
-- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/ewels/MultiQC/issues/1463))
+- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/MultiQC/MultiQC/issues/1463))
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/ewels/MultiQC/issues/1141))
-  - Init/reset global state between runs ([#1596](https://github.com/ewels/MultiQC/pull/1596))
-- Added commonly missing functions to several modules ([#1468](https://github.com/ewels/MultiQC/issues/1468))
+  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/MultiQC/MultiQC/issues/1141))
+  - Init/reset global state between runs ([#1596](https://github.com/MultiQC/MultiQC/pull/1596))
+- Added commonly missing functions to several modules ([#1468](https://github.com/MultiQC/MultiQC/issues/1468))
 - Wrote new script to check for the above function calls that should be in every module (`.github/workflows/code_checks.py`), runs on GitHub actions CI
-- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/ewels/MultiQC/issues/761))
-- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/ewels/MultiQC/pull/1579))
-- Fixed a problem with numeric filenames ([#1606](https://github.com/ewels/MultiQC/issues/1606))
-- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/ewels/MultiQC/issues/1568))
-- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/ewels/MultiQC/issues/1598))
-- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/ewels/MultiQC/issues/1539))
+- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/MultiQC/MultiQC/issues/761))
+- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/MultiQC/MultiQC/pull/1579))
+- Fixed a problem with numeric filenames ([#1606](https://github.com/MultiQC/MultiQC/issues/1606))
+- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/MultiQC/MultiQC/issues/1568))
+- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/MultiQC/MultiQC/issues/1598))
+- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/MultiQC/MultiQC/issues/1539))
 
 ### New Modules
 
@@ -704,75 +704,75 @@ for more information.
 ### Module feature additions
 
 - **BBMap**
-  - Added handling for `qchist` output ([#1021](https://github.com/ewels/MultiQC/issues/1021))
+  - Added handling for `qchist` output ([#1021](https://github.com/MultiQC/MultiQC/issues/1021))
 - **bcftools**
-  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/ewels/MultiQC/issues/1087))
+  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/MultiQC/MultiQC/issues/1087))
 - **Mosdepth**
-  - Added mean coverage [#1566](https://github.com/ewels/MultiQC/issues/1566)
+  - Added mean coverage [#1566](https://github.com/MultiQC/MultiQC/issues/1566)
 - **NanoStat**
-  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/ewels/MultiQC/issues/1547))
+  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/MultiQC/MultiQC/issues/1547))
 
 ### Module updates
 
 - **BBMap**
-  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/ewels/MultiQC/issues/1556))
+  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/MultiQC/MultiQC/issues/1556))
 - **BCL Convert**
-  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/ewels/MultiQC/issues/1563))
+  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/MultiQC/MultiQC/issues/1563))
 - **bowtie**
-  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/ewels/MultiQC/issues/1615))
+  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/MultiQC/MultiQC/issues/1615))
 - **CCS**
-  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/ewels/MultiQC/pull/1486))
-  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/ewels/MultiQC/issues/1583))
+  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/MultiQC/MultiQC/pull/1486))
+  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/MultiQC/MultiQC/issues/1583))
 - **Custom content**
-  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/ewels/MultiQC/issues/1515))
-  - Use filename for section header in files with no headers ([#1550](https://github.com/ewels/MultiQC/issues/1550))
-  - Sort custom content bargraph data by default ([#1412](https://github.com/ewels/MultiQC/issues/1412))
-  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/ewels/MultiQC/issues/1194))
+  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/MultiQC/MultiQC/issues/1515))
+  - Use filename for section header in files with no headers ([#1550](https://github.com/MultiQC/MultiQC/issues/1550))
+  - Sort custom content bargraph data by default ([#1412](https://github.com/MultiQC/MultiQC/issues/1412))
+  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/MultiQC/MultiQC/issues/1194))
 - **DRAGEN**
-  - Fixed bug in sample name regular expression ([#1537](https://github.com/ewels/MultiQC/pull/1537))
+  - Fixed bug in sample name regular expression ([#1537](https://github.com/MultiQC/MultiQC/pull/1537))
 - **Fastp**
-  - Fixed % pass filter statistics ([#1574](https://github.com/ewels/MultiQC/issues/1574))
+  - Fixed % pass filter statistics ([#1574](https://github.com/MultiQC/MultiQC/issues/1574))
 - **FastQC**
-  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/ewels/MultiQC/issues/1488), [#1533](https://github.com/ewels/MultiQC/issues/1533))
+  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/MultiQC/MultiQC/issues/1488), [#1533](https://github.com/MultiQC/MultiQC/issues/1533))
   - Clarify general statistics table header for length
 - **goleft/indexcov**
-  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/ewels/MultiQC/issues/1586))
+  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/MultiQC/MultiQC/issues/1586))
 - **HiCPro**
-  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/ewels/MultiQC/issues/1366))
+  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/MultiQC/MultiQC/issues/1366))
 - **Lima**
-  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/ewels/MultiQC/pull/1483))
+  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/MultiQC/MultiQC/pull/1483))
 - **miRTrace**
-  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/ewels/MultiQC/pull/1263))
+  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/MultiQC/MultiQC/pull/1263))
 - **Mosdepth**
-  - Fixed issue [#1568](https://github.com/ewels/MultiQC/issues/1568)
+  - Fixed issue [#1568](https://github.com/MultiQC/MultiQC/issues/1568)
   - Fixed a bug when reporting per contig coverage
 - **Picard**
-  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/ewels/MultiQC/pull/1611))
+  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/MultiQC/MultiQC/pull/1611))
 - **Qualimap**
-  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/ewels/MultiQC/issues/1492))
+  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/MultiQC/MultiQC/issues/1492))
 - **QUAST**
   - Clarify general statistics table header for length
 - **RSeQC**
-  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
-  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/ewels/MultiQC/issues/1582))
-  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/ewels/MultiQC/issues/1604))
-  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/ewels/MultiQC/issues/1571))
+  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/MultiQC/MultiQC/issues/1484))
+  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/MultiQC/MultiQC/issues/1582))
+  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/MultiQC/MultiQC/issues/1604))
+  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/MultiQC/MultiQC/issues/1571))
 - **Sambamba**
-  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/ewels/MultiQC/issues/1617))
+  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/MultiQC/MultiQC/issues/1617))
 - **Skewer**
-  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/ewels/MultiQC/issues/1622))
+  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/MultiQC/MultiQC/issues/1622))
 - **Somalier**
-  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/ewels/MultiQC/issues/1546))
+  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/MultiQC/MultiQC/issues/1546))
 - **VEP**
-  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/ewels/MultiQC/issues/1597))
+  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/MultiQC/MultiQC/issues/1597))
 
-## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
+## [MultiQC v1.11](https://github.com/MultiQC/MultiQC/releases/tag/v1.11) - 2021-07-05
 
 ### MultiQC new features
 
-- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/ewels/MultiQC/issues/1427))
+- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/MultiQC/MultiQC/issues/1427))
 - Added new `--replace-names` / config `sample_names_replace` option to replace sample names during report generation
-- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/ewels/MultiQC/issues/949), [#890](https://github.com/ewels/MultiQC/issues/890), [#864](https://github.com/ewels/MultiQC/issues/864), [#998](https://github.com/ewels/MultiQC/issues/998), [#1390](https://github.com/ewels/MultiQC/issues/1390))
+- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949), [#890](https://github.com/MultiQC/MultiQC/issues/890), [#864](https://github.com/MultiQC/MultiQC/issues/864), [#998](https://github.com/MultiQC/MultiQC/issues/998), [#1390](https://github.com/MultiQC/MultiQC/issues/1390))
   - Forces modules to use the log filename for the sample identifier, even if the module usually takes this from the file contents
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
@@ -783,9 +783,9 @@ for more information.
 - Make the module crash tracebacks much prettier using `rich`
 - Refine the cli log output a little (nicely formatted header line + drop the `[INFO]`)
 - Added docs describing tools for downstream analysis of MultiQC outputs.
-- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/ewels/MultiQC/issues/1413))
-- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/ewels/MultiQC/issues/1416))
-- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/ewels/MultiQC/issues/1254))
+- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/MultiQC/MultiQC/issues/1413))
+- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/MultiQC/MultiQC/issues/1416))
+- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/MultiQC/MultiQC/issues/1254))
 - Fix the `mqc_colours` util function to lighten colours even when passing categorical or single-length lists.
 - Bugfix for Custom Content, using YAML configuration (eg. section headers) for images should now work
 
@@ -813,22 +813,22 @@ for more information.
   - Rapid haploid variant calling and core genome alignment.
 - [**VEP**](https://www.ensembl.org/info/docs/tools/vep/index.html)
   - Added MultiQC module to add summary statistics of Ensembl VEP annotations.
-  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
+  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/MultiQC/MultiQC/issues/1446))
 
 ### Module feature additions
 
 - **Cutadapt**
-  - Added support for linked adapters [#1329](https://github.com/ewels/MultiQC/issues/1329)]
+  - Added support for linked adapters [#1329](https://github.com/MultiQC/MultiQC/issues/1329)]
   - Parse whether trimming was 5' or 3' for _Lengths of Trimmed Sequences_ plot where possible
 - **Mosdepth**
   - Include or exclude contigs based on patterns for coverage-per-contig plots
 - **Picard**
-  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/ewels/MultiQC/pull/1336))
+  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/MultiQC/MultiQC/pull/1336))
   - New `insertsize_xmax` configuration option to limit the plotted maximum insert size for `InsertSizeMetrics`
 - **Qualimap**
-  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/ewels/MultiQC/issues/1258))
+  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
 - **RSeQC**
-  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/ewels/MultiQC/issues/737))
+  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/MultiQC/MultiQC/issues/737))
 
 ### Module updates
 
@@ -839,68 +839,68 @@ for more information.
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
 - **Cutadapt**
-  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/ewels/MultiQC/issues/1328))
-  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/ewels/MultiQC/issues/949))
+  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/MultiQC/MultiQC/issues/1328))
+  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949))
 - **Dragen**
-  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
+  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/MultiQC/MultiQC/issues/1374))
 - **fastp**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/MultiQC/MultiQC/issues/1444))
 - **FastQC**
-  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/ewels/MultiQC/issues/1444))
+  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/MultiQC/MultiQC/issues/1444))
 - **Flexbar**
-  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/ewels/MultiQC/issues/1407))
+  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/MultiQC/MultiQC/issues/1407))
 - **Kraken**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/ewels/MultiQC/issues/1440))
-  - Updated search patterns to handle edge case ([#1428](https://github.com/ewels/MultiQC/issues/1428))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/MultiQC/MultiQC/issues/1440))
+  - Updated search patterns to handle edge case ([#1428](https://github.com/MultiQC/MultiQC/issues/1428))
 - **Mosdepth**
   - Show barplot instead of line graph for coverage-per-contig plot if there is only one contig.
 - **Picard**
-  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
-  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
-  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/ewels/MultiQC/issues/1296))
+  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/MultiQC/MultiQC/issues/1408))
+  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/MultiQC/MultiQC/issues/1414))
+  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/MultiQC/MultiQC/issues/1296))
 - **qc3C**
   - Updated module to not fail on older field names.
 - **Qualimap**
-  - Fixed wrong units in tool tip label ([#1258](https://github.com/ewels/MultiQC/issues/1258))
+  - Fixed wrong units in tool tip label ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
 - **QUAST**
-  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
+  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/MultiQC/MultiQC/issues/1442))
 - **Sentieon**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/MultiQC/MultiQC/issues/1420))
 - **RSEM**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/ewels/MultiQC/issues/1040))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/MultiQC/MultiQC/issues/1040))
 - **RSeQC**
-  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/ewels/MultiQC/issues/1457))
+  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/MultiQC/MultiQC/issues/1457))
 
-## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
+## [MultiQC v1.10.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 
 ### MultiQC updates
 
 - Dropped the `Skipping search pattern` log message from a warning to debug
-- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/ewels/MultiQC/issues/1264))
-- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/ewels/MultiQC/issues/1257))
+- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/MultiQC/MultiQC/issues/1264))
+- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/MultiQC/MultiQC/issues/1257))
 - Allow scientific notation numbers in colour scheme generation
   - Fixed bug with very small minimum numbers that only revelead itself after a bugfix done in the v1.10 release
-- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/ewels/MultiQC/issues/1274))
-- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/ewels/MultiQC/issues/1393))
-- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/ewels/MultiQC/issues/1395))
+- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/MultiQC/MultiQC/issues/1274))
+- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/MultiQC/MultiQC/issues/1393))
+- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/MultiQC/MultiQC/issues/1395))
 
 #### Module updates
 
 - **bcftools**
-  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/ewels/MultiQC/issues/1400))
+  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/MultiQC/MultiQC/issues/1400))
 - **bowtie2**
-  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/ewels/MultiQC/issues/1230))
+  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/MultiQC/MultiQC/issues/1230))
 - **Deeptools**
-  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/ewels/MultiQC/issues/1317))
-  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/ewels/MultiQC/issues/1275))
+  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/MultiQC/MultiQC/issues/1317))
+  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/MultiQC/MultiQC/issues/1275))
 - **FastQC**
-  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/ewels/MultiQC/issues/1246))
+  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/MultiQC/MultiQC/issues/1246))
 - **Picard**
-  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/ewels/MultiQC/issues/1397))
+  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/MultiQC/MultiQC/issues/1397))
 - **Somalier**
-  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/ewels/MultiQC/issues/1234))
+  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/MultiQC/MultiQC/issues/1234))
 
-## [MultiQC v1.10](https://github.com/ewels/MultiQC/releases/tag/v1.10) - 2021-03-08
+## [MultiQC v1.10](https://github.com/MultiQC/MultiQC/releases/tag/v1.10) - 2021-03-08
 
 ### Update for developers: Code linting
 
@@ -935,7 +935,7 @@ For further information, please see the [documentation](https://multiqc.info/doc
     allowes module developers to format table cell values as labels.
 - New CI test looks for git merge markers in files
 - Beautiful new [progress bar](https://rich.readthedocs.io/en/stable/progress.html) from the amazing [willmcgugan/rich](https://github.com/willmcgugan/rich) package.
-- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/ewels/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
+- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/MultiQC/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
 - Added `timeout-minutes: 10` to the CI test workflow to check that changes aren't negatively affecting run time too much.
 - New table header option `bars_zero_centrepoint` to treat `0` as zero width bars and plot bar length based on absolute values
 
@@ -963,29 +963,29 @@ For further information, please see the [documentation](https://multiqc.info/doc
 #### Module updates
 
 - **DRAGEN**
-  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/ewels/MultiQC/issues/1223))
-  - Added support for whole-exome / targetted data ([#1290](https://github.com/ewels/MultiQC/issues/1290))
+  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/MultiQC/MultiQC/issues/1223))
+  - Added support for whole-exome / targetted data ([#1290](https://github.com/MultiQC/MultiQC/issues/1290))
 - **featureCounts**
-  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/ewels/MultiQC/issues/1022))
+  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/MultiQC/MultiQC/issues/1022))
 - **fgbio**
-  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/ewels/MultiQC/pull/1251))
-  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
+  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/MultiQC/MultiQC/pull/1251))
+  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/MultiQC/MultiQC/pull/1304))
 - **Fastp**
-  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/ewels/MultiQC/pull/1313))
+  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/MultiQC/MultiQC/pull/1313))
 - **GATK**
   - Add support for the creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
 - **hap.py**
-  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/ewels/MultiQC/issues/1241))
+  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/MultiQC/MultiQC/issues/1241))
 - **indexcov**
-  - Fixed bug when making the PED file plots ([#1265](https://github.com/ewels/MultiQC/issues/1265))
+  - Fixed bug when making the PED file plots ([#1265](https://github.com/MultiQC/MultiQC/issues/1265))
 - **interop**
   - Added the `% Occupied` metric to `Read Metrics per Lane` table which is reported for NovaSeq and iSeq platforms.
 - **Kaiju**
-  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/ewels/MultiQC/issues/1217))
-  - Rework barplot, add top 5 taxons ([#1219](https://github.com/ewels/MultiQC/issues/1219))
+  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/MultiQC/MultiQC/issues/1217))
+  - Rework barplot, add top 5 taxons ([#1219](https://github.com/MultiQC/MultiQC/issues/1219))
 - **Kraken**
-  - Fix `ZeroDivisionError` ([#1276](https://github.com/ewels/MultiQC/issues/1276))
-  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/ewels/MultiQC/pull/1380))
+  - Fix `ZeroDivisionError` ([#1276](https://github.com/MultiQC/MultiQC/issues/1276))
+  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/MultiQC/MultiQC/pull/1380))
 - **MALT**
   - Fix y-axis labelling in bargraphs
 - **MACS2**
@@ -994,21 +994,21 @@ For further information, please see the [documentation](https://multiqc.info/doc
   - Enable prepending of directory to sample names
   - Display contig names in _Coverage per contig_ plot tooltip
 - **Picard**
-  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/ewels/MultiQC/issues/1212))
-  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/ewels/MultiQC/issues/1310))
+  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/MultiQC/MultiQC/issues/1212))
+  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/MultiQC/MultiQC/issues/1310))
   - Make `WgsMetrics` histogram smoothed if more than 1000 data points (avoids huge plots that crash the browser)
   - Multiple new config options for `WgsMetrics` to customise coverage histogram and speed up MultiQC with very high coverage files.
-  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/ewels/MultiQC/issues/1293))
-  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/ewels/MultiQC/issues/1327))
+  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/MultiQC/MultiQC/issues/1293))
+  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/MultiQC/MultiQC/issues/1327))
 - **PycoQC**
-  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
+  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/MultiQC/MultiQC/issues/1214))
 - **Rockhopper**
-  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/ewels/MultiQC/issues/1333))
+  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
   - Fix issue properly parsing multiple samples within a single Rockhopper summary file
 - **Salmon**
   - Only try to generate a plot for fragment length if the data was found.
 - **verifyBamID**
-  - Fix `CHIP` value detection ([#1316](https://github.com/ewels/MultiQC/pull/1316)).
+  - Fix `CHIP` value detection ([#1316](https://github.com/MultiQC/MultiQC/pull/1316)).
 
 #### New Custom Content features
 
@@ -1019,12 +1019,12 @@ For further information, please see the [documentation](https://multiqc.info/doc
 
 #### Bug Fixes
 
-- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/ewels/MultiQC/issues/1333))
+- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
 - Fixed MatPlotLib warning: `FixedFormatter should only be used together with FixedLocator`
 - Fixed long-standing min/max bug with shared minimum values for table columns using `shared_key`
 - Made table colour schemes work with negative numbers (don't strip `-` from values when making scheme)
 
-## [MultiQC v1.9](https://github.com/ewels/MultiQC/releases/tag/v1.9) - 2020-05-30
+## [MultiQC v1.9](https://github.com/MultiQC/MultiQC/releases/tag/v1.9) - 2020-05-30
 
 #### Dropped official support for Python 2
 
@@ -1056,8 +1056,8 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Still testing on both Linux and Windows, with multiple versions of Python
   - CI tests should now run automatically for anyone who forks the MultiQC repository
 - Linting with `--lint` now checks line graphs as well as bar graphs
-- New `gathered` template with no tool name sections ([#1119](https://github.com/ewels/MultiQC/issues/1119))
-- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/ewels/MultiQC/issues/1125))
+- New `gathered` template with no tool name sections ([#1119](https://github.com/MultiQC/MultiQC/issues/1119))
+- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/MultiQC/MultiQC/issues/1125))
   - Buttons control the report toolbox Show/Hide tool, filtering your samples
   - Allows reports to be pre-configured based on a supplied list of sample names at report-generation time.
 - Line graphs can now have `Log10` buttons (same functionality as bar graphs)
@@ -1070,9 +1070,9 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Should help to prevent duplicates requiring `-1` suffixes when running a module multiple times
 - New heatmap plot config options `xcats_samples` and `ycats_samples`
   - If set to `False`, the report toolbox options (_highlight_, _rename_, _show/hide_) do not affect that axis.
-  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/ewels/MultiQC/issues/1172))
+  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/MultiQC/MultiQC/issues/1172))
 - Report header time and analysis paths can now be hidden
-  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/ewels/MultiQC/issues/1113))
+  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/MultiQC/MultiQC/issues/1113))
 - New search pattern key `skip: true` to skip specific searches when modules look for a lot of different files (eg. Picard).
 - New `--profile-runtime` command line option (`config.profile_runtime`) to give analysis of how long the report takes to be generated
   - Plots of the file search results and durations are added to the end of the MultiQC report as a special module called _Run Time_
@@ -1081,7 +1081,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Defaults to `true`, set to `false` to also show any data columns that are not defined as headers
   - Useful as allows table-wide defaults to be set with column-specific overrides
 - New `module` key allowed for `config.extra_fn_clean_exts` and `config.fn_clean_exts`
-  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/ewels/MultiQC/issues/905))
+  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/MultiQC/MultiQC/issues/905))
 
 #### New Custom Content features
 
@@ -1089,10 +1089,10 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Native handling of HTML snippets as files, no MultiQC config or YAML file required.
   - Also with embedded custom content configuration at the start of the file as a HTML comment.
 - Add ability to group custom-content files into report sections
-  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/ewels/MultiQC/issues/1008))
+  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/MultiQC/MultiQC/issues/1008))
 - Custom Content files can now be configured using `custom_data`, without giving search patterns or data
-  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/ewels/MultiQC/issues/1026))
-  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/ewels/MultiQC/issues/1205))
+  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/MultiQC/MultiQC/issues/1026))
+  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/MultiQC/MultiQC/issues/1205))
 
 #### New Modules
 
@@ -1112,7 +1112,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [**MultiVCFAnalyzer**](https://github.com/alexherbig/multivcfanalyzer)
   - Combining multiple VCF files into one coherent report and format for downstream analysis.
 - **Picard** - new submodules for `QualityByCycleMetrics`, `QualityScoreDistributionMetrics` & `QualityYieldMetrics`
-  - See [#1116](https://github.com/ewels/MultiQC/issues/1114)
+  - See [#1116](https://github.com/MultiQC/MultiQC/issues/1114)
 - [**Rockhopper**](https://cs.wellesley.edu/~btjaden/Rockhopper/)
   - RNA-seq tool for bacteria, includes bar plot showing where features map.
 - [**Sickle**](https://github.com/najoshi/sickle)
@@ -1127,13 +1127,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **BISCUIT**
   - Major rewrite to work with new BISCUIT QC script (BISCUIT `v0.3.16+`)
     - This change breaks backwards-compatability with previous BISCUIT versions. If you are unable to upgrade BISCUIT, please use MultiQC v1.8.
-  - Fixed error when missing data in log files ([#1101](https://github.com/ewels/MultiQC/issues/1101))
+  - Fixed error when missing data in log files ([#1101](https://github.com/MultiQC/MultiQC/issues/1101))
 - **bcl2fastq**
-  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
+  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/MultiQC/MultiQC/issues/1094))
 - **BUSCO**
-  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/ewels/MultiQC/issues/1163))
+  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/MultiQC/MultiQC/issues/1163))
 - **Cutadapt**
-  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/ewels/MultiQC/issues/1198))
+  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/MultiQC/MultiQC/issues/1198))
 - **DamageProfiler**
   - Removes redundant typo in init name. This makes referring to the module's column consistent with other modules when customising general stats table.
 - **DeDup**
@@ -1141,69 +1141,69 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Fixes reporting errors - barplot total represents _mapped_ reads, not total reads in BAM file
   - New: Adds 'Post-DeDup Mapped Reads' column to general stats table.
 - **FastQC**
-  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/ewels/MultiQC/issues/1092))
-  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/ewels/MultiQC/issues/1129))
+  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/MultiQC/MultiQC/issues/1092))
+  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/MultiQC/MultiQC/issues/1129))
 - **FastQ Screen**
-  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
-  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
+  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
+  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
   - New plot for _Bisulfite Reads_, if data is present
   - Categories in main plot are now sorted by the total read count and hidden if 0 across all samples
 - **fgbio**
   - New: Plot error rate by read position from `ErrorRateByReadPosition`
-  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/ewels/MultiQC/pull/1147))
+  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/MultiQC/MultiQC/pull/1147))
 - **FLASh**
-  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/ewels/MultiQC/issues/1173))
+  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/MultiQC/MultiQC/issues/1173))
 - **GATK**
-  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/ewels/MultiQC/issues/1158))
+  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/MultiQC/MultiQC/issues/1158))
 - **MTNucRatioCalculator**
   - Fixed misleading value suffix in general stats table
 - **Picard MarkDuplicates**
   - **Major change** - previously, if multiple libraries (read-groups) were found then only the first would be used and all others ignored. Now, values from all libraries are merged and `PERCENT_DUPLICATION` and `ESTIMATED_LIBRARY_SIZE` are recalculated. Libraries can be kept as separate samples with a new MultiQC configuration option - `picard_config: markdups_merge_multiple_libraries: False`
-  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/ewels/MultiQC/issues/1142))
+  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/MultiQC/MultiQC/issues/1142))
 - **Picard HsMetrics**
-  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/ewels/MultiQC/issues/831))
+  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/MultiQC/MultiQC/issues/831))
 - **Picard WgsMetrics**
-  - Updated parsing code to recognise new java class string ([#1114](https://github.com/ewels/MultiQC/issues/1114))
+  - Updated parsing code to recognise new java class string ([#1114](https://github.com/MultiQC/MultiQC/issues/1114))
 - **QualiMap**
-  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/ewels/MultiQC/issues/1082), [#1077](https://github.com/ewels/MultiQC/issues/1082)
+  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/MultiQC/MultiQC/issues/1082), [#1077](https://github.com/MultiQC/MultiQC/issues/1082)
 - **RSeqC**
-  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/ewels/MultiQC/issues/844))
-  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/ewels/MultiQC/issues/1133))
+  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/MultiQC/MultiQC/issues/844))
+  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/MultiQC/MultiQC/issues/1133))
 - **RNASeQC2**
   - Updated to handle the parsing metric files from the [newer rewrite of RNA-SeqQC](https://github.com/broadinstitute/rnaseqc).
 - **Samblaster**
-  - Improved parsing to handle variable whitespace ([#1176](https://github.com/ewels/MultiQC/issues/1176))
+  - Improved parsing to handle variable whitespace ([#1176](https://github.com/MultiQC/MultiQC/issues/1176))
 - **Samtools**
-  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
-  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
+  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/MultiQC/MultiQC/issues/1076](https://github.com/MultiQC/MultiQC/issues/1076)).
+  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/MultiQC/MultiQC/issues/1118))
   - Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
 - **sortmerna**
-  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
+  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/MultiQC/MultiQC/issues/1121))
 - **sexdeterrmine**
   - Added a scatter plot of relative X- vs Y-coverage to the generated report.
 - **VerifyBAMID**
-  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/ewels/MultiQC/issues/1112))
+  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/MultiQC/MultiQC/issues/1112))
 
 #### Bug Fixes
 
 - Added a new test to check that modules work correctly with `--ignore-samples`. A lot of them didn't:
   - `Mosdepth`, `conpair`, `Qualimap BamQC`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
   - These modules have now all been fixed and `--ignore-samples` should work as you expect for whatever data you have.
-- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/ewels/MultiQC/issues/1130))
+- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/MultiQC/MultiQC/issues/1130))
 - Made folder naming behaviour of `multiqc_plots` consistent with `multiqc_data`
   - Incremental numeric suffixes now added if folder already exists
   - Plots folder properly renamed if using `-n`/`--filename`
-- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/ewels/MultiQC/issues/1136))
+- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/MultiQC/MultiQC/issues/1136))
 - Plot config `logswitch_active` now works as advertised
-- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/ewels/MultiQC/issues/1175))
+- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/MultiQC/MultiQC/issues/1175))
 - Fixed minor bug where tables could report negative numbers of columns in their header text
-- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/ewels/MultiQC/issues/1091))
-- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/ewels/MultiQC/issues/1071))
+- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/MultiQC/MultiQC/issues/1091))
+- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/MultiQC/MultiQC/issues/1071))
 - Replaced deprecated 'warn()' with 'warning()' of the logging module
 - Custom content now supports `section_extra` config key to add custom HTML after description.
 - Barplots with `ymax` set now ignore this when you click the _Percentages_ tab.
 
-## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
+## [MultiQC v1.8](https://github.com/MultiQC/MultiQC/releases/tag/v1.8) - 2019-11-20
 
 #### New Modules
 
@@ -1235,16 +1235,16 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **damageprofiler**
   - Added writing metrics to data output file.
 - **DeepTools**
-  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/ewels/MultiQC/issues/1057))
-  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/ewels/MultiQC/issues/1011))
+  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/MultiQC/MultiQC/issues/1057))
+  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/MultiQC/MultiQC/issues/1011))
   - Fixed bug that prevented running on only plotProfile files when no other deepTools files found.
 - **fastp**
-  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/ewels/MultiQC/issues/936))
+  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/MultiQC/MultiQC/issues/936))
 - **FastQC**
   - When including a FastQC section multiple times in one report, the Per Base Sequence Content heatmaps now behave as you would expect.
   - Added heatmap showing FastQC status checks for every section report across all samples
-  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/ewels/MultiQC/issues/777))
-  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/ewels/MultiQC/issues/742))
+  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/MultiQC/MultiQC/issues/777))
+  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/MultiQC/MultiQC/issues/742))
 - **FastQ Screen**
   - When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
   - Fixed MultiQC linting errors
@@ -1258,18 +1258,18 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Updated the format of the report to fits the changes which have been applied to the QC report of hicexplorer v3.3
   - Updated code to save parsed results to `multiqc_data`
 - **HTSeq**
-  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/ewels/MultiQC/issues/1006))
+  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/MultiQC/MultiQC/issues/1006))
 - **LongRanger**
   - Added support for the LongRanger Align pipeline.
 - **miRTrace**
-  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/ewels/MultiQC/issues/932))
+  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/MultiQC/MultiQC/issues/932))
 - **Peddy**
-  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/ewels/MultiQC/issues/1024))
+  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/MultiQC/MultiQC/issues/1024))
   - All plots (including _Het Check_ and _Sex Check_) now hidden if no data
 - **Picard**
   - Modified `OxoGMetrics` so that it will find files created with GATK `CollectMultipleMetrics` and `ConvertSequencingArtifactToOxoG`.
 - **QoRTs**
-  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/ewels/MultiQC/issues/821))
+  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/MultiQC/MultiQC/issues/821))
 - **Qualimap**
   - Added in mean coverage computation for general statistics report
   - Creates now tables of collected data in `multiqc_data`
@@ -1278,13 +1278,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **RSeQC**
   - Fixed bug where Junction Saturation plot when clicking a single sample was mislabelling the lines.
   - When including a RSeQC section multiple times in one report, clicking Junction Saturation plot now behaves as you would expect.
-  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/ewels/MultiQC/issues/1017))
+  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/MultiQC/MultiQC/issues/1017))
 - **Samtools**
   - Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 - **SnpEff**
   - Increased the default summary csv file-size limit from 1MB to 5MB.
 - **Stacks**
-  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/ewels/MultiQC/issues/906))
+  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/MultiQC/MultiQC/issues/906))
 - **TopHat**
   - Fixed bug where TopHat would try to run with files from Bowtie2 or HiSAT2 and crash
 - **VCFTools**
@@ -1309,22 +1309,22 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Windows support for base `multiqc` command
   - Support for running as a python module: `python -m multiqc .`
   - Support for running within a script: `import multiqc` and `multiqc.run('/path/to/files')`
-- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/ewels/MultiQC/issues/1044))
-- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/ewels/MultiQC/issues/541))
+- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/MultiQC/MultiQC/issues/1044))
+- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/MultiQC/MultiQC/issues/541))
 
 #### Bug Fixes
 
 - MultiQC now ignores all `.md5` files
 - Use `SafeLoader` for PyYaml load calls, avoiding recent warning messages.
 - Hide `multiqc_config_example.yaml` in the `test` directory to stop people from using it without modification.
-- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/ewels/MultiQC/issues))
-- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/ewels/MultiQC/issues/835))
+- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/MultiQC/MultiQC/issues))
+- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/MultiQC/MultiQC/issues/835))
 - Sample name cleaning: All sample names are now truncated to their basename, without a path.
   - This includes for `regex` and `replace` (before was only the default `truncate`).
   - Only affects modules that take sample names from file contents, such as cutadapt.
-  - See [#897](https://github.com/ewels/MultiQC/issues/897) for discussion.
+  - See [#897](https://github.com/MultiQC/MultiQC/issues/897) for discussion.
 
-## [MultiQC v1.7](https://github.com/ewels/MultiQC/releases/tag/v1.7) - 2018-12-21
+## [MultiQC v1.7](https://github.com/MultiQC/MultiQC/releases/tag/v1.7) - 2018-12-21
 
 #### New Modules
 
@@ -1350,7 +1350,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 #### Module updates
 
 - **AdapterRemoval**
-  - Handle error when zero bases are trimmed. See [#838](https://github.com/ewels/MultiQC/issues/838).
+  - Handle error when zero bases are trimmed. See [#838](https://github.com/MultiQC/MultiQC/issues/838).
 - **Bcl2fastq**
   - New plot showing the top twenty of undetermined barcodes by lane.
   - Informations for R1/R2 are now separated in the General Statistics table.
@@ -1362,12 +1362,12 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - New sequence distribution profiles around genes, from the `plotProfile` function (written by [@chuan-wang](https://github.com/chuan-wang/))
   - Reordered sections
 - **Fastp**
-  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/ewels/MultiQC/issues/845).
+  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/MultiQC/MultiQC/issues/845).
 - **FastQC**
-  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/ewels/MultiQC/issues/812).
+  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/MultiQC/MultiQC/issues/812).
   - When including a FastQC section multiple times in one report, the summary progress bars now behave as you would expect.
 - **FastQ Screen**
-  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/ewels/MultiQC/issues/829).
+  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/MultiQC/MultiQC/issues/829).
 - **InterOp**
   - Fixed bug where read counts and base pair yields were not displaying in tables correctly.
   - Number formatting for these fields can now be customised in the same way as with other modules, as described [in the docs](http://multiqc.info/docs/#number-base-multiplier)
@@ -1380,14 +1380,14 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Properly clean sample names
 - **Trimmomatic**
   - Updated Trimmomatic module documentation to be more helpful
-  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/ewels/MultiQC/issues/864).
+  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/MultiQC/MultiQC/issues/864).
 
 #### New MultiQC Features
 
 - Embed your custom images with a new Custom Content feature! Just add `_mqc` to the end of the filename for `.png`, `.jpg` or `.jpeg` files.
 - Documentation for Custom Content reordered to make it a little more sane
 - You can now add or override any config parameter for any MultiQC plot! See [the documentation](http://multiqc.info/docs/#customising-plots) for more info.
-- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/ewels/MultiQC/issues/841).
+- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/MultiQC/MultiQC/issues/841).
 - Improved visual spacing between grouped bar plots
 
 #### Bug Fixes
@@ -1397,7 +1397,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [Sample name directory prefixes](https://multiqc.info/docs/#sample-names-prefixed-with-directories) are now added _after_ cleanup.
 - If a module is run multiple times in one report, it's CSS and JS files will only be included once (`default` template)
 
-## [MultiQC v1.6](https://github.com/ewels/MultiQC/releases/tag/v1.6) - 2018-08-04
+## [MultiQC v1.6](https://github.com/MultiQC/MultiQC/releases/tag/v1.6) - 2018-08-04
 
 Some of these updates are thanks to the efforts of people who attended the [NASPM](https://twitter.com/NordicGenomics) 2018 MultiQC hackathon session. Thanks to everyone who attended!
 
@@ -1477,10 +1477,10 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Fix linegraph and scatter plots data conversion (sporadically the incorrect `ymax` was used to drop data points) ([@cpavanrun](https://github.com/cpavanrun))
 - Adjusted behavior of ceiling and floor axis limits
 - Adjusted multiple file search patterns to make them more specific
-  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/ewels/MultiQC/pull/727))
-- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/ewels/MultiQC/issues/801))
+  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/MultiQC/MultiQC/pull/727))
+- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/MultiQC/MultiQC/issues/801))
 
-## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15
+## [MultiQC v1.5](https://github.com/MultiQC/MultiQC/releases/tag/v1.5) - 2018-03-15
 
 #### New Modules
 
@@ -1540,7 +1540,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Locked the `matplotlib` version to `v2.1.0` and below
   - Due to [two](https://github.com/matplotlib/matplotlib/issues/10476) [bugs](https://github.com/matplotlib/matplotlib/issues/10784) that appeared in `v2.2.0` - will remove this constraint when there's a new release that works again.
 
-## [MultiQC v1.4](https://github.com/ewels/MultiQC/releases/tag/v1.4) - 2018-01-11
+## [MultiQC v1.4](https://github.com/MultiQC/MultiQC/releases/tag/v1.4) - 2018-01-11
 
 A slightly earlier-than-expected release due to a new problem with dependency packages that is breaking MultiQC installations since 2018-01-11.
 
@@ -1594,7 +1594,7 @@ A slightly earlier-than-expected release due to a new problem with dependency pa
 - Updated pandoc command used in `--pdf` to work with new releases of Pandoc
 - Made config `table_columns_visible` module name key matching case insensitive to make less frustrating
 
-## [MultiQC v1.3](https://github.com/ewels/MultiQC/releases/tag/v1.3) - 2017-11-03
+## [MultiQC v1.3](https://github.com/MultiQC/MultiQC/releases/tag/v1.3) - 2017-11-03
 
 #### Breaking changes - custom search patterns
 
@@ -1655,7 +1655,7 @@ string beginning with the name of your module, anything you like after the first
 #### New MultiQC Features
 
 - New MultiQC docker image
-  - Ready to use docker image now available at <https://hub.docker.com/r/ewels/multiqc/> (200 MB)
+  - Ready to use docker image now available at <https://hub.docker.com/r/MultiQC/MultiQC/> (200 MB)
   - Uses automated builds - pull `:latest` to get the development version, future releases will have stable tags.
   - Written by [@MaxUlysse](https://github.com/MaxUlysse/)
 - New `module_order` config options allow modules to be run multiple times
@@ -1679,7 +1679,7 @@ string beginning with the name of your module, anything you like after the first
 - Don't prepend the directory separator (`|`) to sample names with `-d` when there are no subdirs
 - `yPlotLines` now works even if you don't set `width`
 
-## [MultiQC v1.2](https://github.com/ewels/MultiQC/releases/tag/v1.2) - 2017-08-16
+## [MultiQC v1.2](https://github.com/MultiQC/MultiQC/releases/tag/v1.2) - 2017-08-16
 
 #### CodeFest 2017 Contributions
 
@@ -1775,7 +1775,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.1](https://github.com/ewels/MultiQC/releases/tag/v1.1) - 2017-07-18
+## [MultiQC v1.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.1) - 2017-07-18
 
 #### New Modules
 
@@ -1857,7 +1857,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.0](https://github.com/ewels/MultiQC/releases/tag/v1.0) - 2017-05-17
+## [MultiQC v1.0](https://github.com/MultiQC/MultiQC/releases/tag/v1.0) - 2017-05-17
 
 Version 1.0! This release has been a long time coming and brings with it some fairly
 major improvements in speed, report filesize and report performance. There's also
@@ -2019,13 +2019,13 @@ To see what changes need to applied to your custom plugin code, please see the [
   - If limits are specified, data exceeding this is no longer saved in report
   - Visually identical, but can make report file sizes considerable smaller in some cases
 - Creating multiple plots without a config dict now works (previously just gave grey boxes in report)
-- All changes are now tested on a Windows system, using [AppVeyor](https://ci.appveyor.com/project/ewels/multiqc/)
+- All changes are now tested on a Windows system, using [AppVeyor](https://ci.appveyor.com/project/MultiQC/MultiQC/)
 - Fixed rare error where some reports could get empty General Statistics tables when no data present.
 - Fixed minor bug where config option `force: true` didn't work. Now you don't have to always specify `-f`!
 
 ---
 
-## [MultiQC v0.9](https://github.com/ewels/MultiQC/releases/tag/v0.9) - 2016-12-21
+## [MultiQC v0.9](https://github.com/MultiQC/MultiQC/releases/tag/v0.9) - 2016-12-21
 
 A major new feature is released in v0.9 - support for _custom content_. This means
 that MultiQC can now easily include output from custom scripts within reports without
@@ -2118,7 +2118,7 @@ the need for a new module or plugin. For more information, please see the
 
 ---
 
-## [MultiQC v0.8](https://github.com/ewels/MultiQC/releases/tag/v0.8) - 2016-09-26
+## [MultiQC v0.8](https://github.com/MultiQC/MultiQC/releases/tag/v0.8) - 2016-09-26
 
 #### New Modules
 
@@ -2194,7 +2194,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.7](https://github.com/ewels/MultiQC/releases/tag/v0.7) - 2016-07-04
+## [MultiQC v0.7](https://github.com/MultiQC/MultiQC/releases/tag/v0.7) - 2016-07-04
 
 #### Module updates
 
@@ -2263,7 +2263,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.6](https://github.com/ewels/MultiQC/releases/tag/v0.6) - 2016-04-29
+## [MultiQC v0.6](https://github.com/MultiQC/MultiQC/releases/tag/v0.6) - 2016-04-29
 
 #### Module updates
 
@@ -2303,7 +2303,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.5](https://github.com/ewels/MultiQC/releases/tag/v0.5) - 2016-03-29
+## [MultiQC v0.5](https://github.com/MultiQC/MultiQC/releases/tag/v0.5) - 2016-03-29
 
 #### Module updates
 
@@ -2336,7 +2336,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.4](https://github.com/ewels/MultiQC/releases/tag/v0.4) - 2016-02-16
+## [MultiQC v0.4](https://github.com/MultiQC/MultiQC/releases/tag/v0.4) - 2016-02-16
 
 - New `multiqc_sources.txt` which identifies the paths used to collect all report data for each sample
 - Export parsed data as tab-delimited text, `JSON` or `YAML` using the new `-k`/`--data-format` command line option
@@ -2356,7 +2356,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.2](https://github.com/ewels/MultiQC/releases/tag/v0.3.2) - 2016-02-08
+## [MultiQC v0.3.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.2) - 2016-02-08
 
 - All modules now load their log file search parameters from a config
   file, allowing you to overwrite them using your user config file
@@ -2402,7 +2402,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.1](https://github.com/ewels/MultiQC/releases/tag/v0.3.1) - 2015-11-04
+## [MultiQC v0.3.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.1) - 2015-11-04
 
 - Hotfix patch to fix broken FastQC module (wasn't finding `.zip` files properly)
 - General Stats table colours now flat. Should improve browser speed.
@@ -2411,7 +2411,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3](https://github.com/ewels/MultiQC/releases/tag/v0.3) - 2015-11-04
+## [MultiQC v0.3](https://github.com/MultiQC/MultiQC/releases/tag/v0.3) - 2015-11-04
 
 - Lots of lovely new documentation!
 - Child templates - easily customise specific parts of the default report template
@@ -2448,11 +2448,11 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.2](https://github.com/ewels/MultiQC/releases/tag/v0.2) - 2015-09-18
+## [MultiQC v0.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.2) - 2015-09-18
 
 - Code restructuring for nearly all modules. Common base module
   functions now handle many more functions (plots, config, file import)
-  - See the [contributing notes](https://github.com/ewels/MultiQC/blob/master/CONTRIBUTING.md)
+  - See the [contributing notes](https://github.com/MultiQC/MultiQC/blob/master/CONTRIBUTING.md)
     for instructions on how to use these new helpers to make your own module
 - New report toolbox - sample highlighting, renaming, hiding
   - Config is autosaved by default, can also export to a file for sharing
@@ -2471,7 +2471,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.1](https://github.com/ewels/MultiQC/releases/tag/v0.1) - 2015-09-01
+## [MultiQC v0.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.1) - 2015-09-01
 
 - The first public release of MultiQC, after a month of development. Basic
   structure in place and modules for FastQC, FastQ Screen, Cutadapt, Bismark,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Changelog CI: update PR URLs, fix removing existing entry and determining module addition ([#2412](https://github.com/MultiQC/MultiQC/pull/2412))
+
 ### New modules
 
 ### Module updates


### PR DESCRIPTION
Changelog CI improvements:

- [x] Remove existing entry if `[no changelog]` was appended to the PR later.
- [x] Count as module change if a search pattern section was changed, but not if added.
- [x] Replace ewels->MultiQC in PR URLs to fix the existing entry check.