### PR TITLE
remove superfluous 'samtools' name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - **BBTools**: fix: skip missing values in bbmap qahist ([#2411](https://github.com/MultiQC/MultiQC/pull/2411))
 - **Samtools**: Add support for `markdup` ([#2254](https://github.com/MultiQC/MultiQC/pull/2254))
+- **Samtools**: remove superfluous samtools name ([#2424](https://github.com/MultiQC/MultiQC/pull/2424))
 
 ## [MultiQC v1.21](https://github.com/MultiQC/MultiQC/releases/tag/v1.21) - 2024-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 ### Module updates
 
 - **BBTools**: fix: skip missing values in bbmap qahist ([#2411](https://github.com/MultiQC/MultiQC/pull/2411))
-- **Samtools**: Add support for `markdup` ([#2254](https://github.com/MultiQC/MultiQC/pull/2254))
-- **Samtools**: remove superfluous samtools name ([#2424](https://github.com/MultiQC/MultiQC/pull/2424))
+- **Samtools**: support new `markdup` command ([#2254](https://github.com/MultiQC/MultiQC/pull/2254))
 
 ## [MultiQC v1.21](https://github.com/MultiQC/MultiQC/releases/tag/v1.21) - 2024-02-28
 

--- a/multiqc/modules/samtools/markdup.py
+++ b/multiqc/modules/samtools/markdup.py
@@ -112,7 +112,7 @@ class MarkdupReportMixin:
         self.general_stats_addcols(data=val_by_metric_by_sample, headers=genstats_headers, namespace="markdup")
 
         self.add_section(
-            name="Samtools markdup: stats",
+            name="Markdup: stats",
             anchor="samtools-markdup",
             description=(
                 "Optical duplicates are due to either optical or clustering-based artifacts. "
@@ -163,7 +163,7 @@ class MarkdupReportMixin:
         # Bar plot
         pconfig = {
             "id": "samtools-markdup-fraction",
-            "title": "Samtools markdup: duplicate categories",
+            "title": "Markdup: duplicate categories",
             "ylab": "SAM Records",
         }
 


### PR DESCRIPTION
It's a small thing, but there was one too many "samtools" in the sidebar and my brain doesn't agree with that 😅 

- [ ] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
