### PR TITLE
Fix `--export` when making interactive plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # MultiQC results
 multiqc_config.yaml
 multiqc_report.html
-multiqc_data
+multiqc_data/
+multiqc_plots/
 examples/
 result/
 tmp/

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -258,6 +258,8 @@ class Plot(ABC):
             html = self.flat_plot()
         else:
             html = self.interactive_plot(report)
+            if config.export_plots:
+                self.flat_plot()
         return html
 
     def interactive_plot(self, report) -> str:


### PR DESCRIPTION
Make sure `multiqc --export` always works (without requiring `--flat` as it does now!)

From Slack: https://nfcore.slack.com/archives/C05663US2B0/p1710846896142419