### PR TITLE
Busco: fix barplot colors

### DIFF
--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -67,12 +67,12 @@ class Dataset(BaseDataset):
         for cat in cats:
             # Split long category names
             if "name" not in cat:
-                raise ValueError(f"Bar plot {dataset.plot.id}: missing 'name' key in category")
+                raise ValueError(f"Bar plot {dataset.plot_id}: missing 'name' key in category")
             cat["name"] = "<br>".join(split_long_string(cat["name"]))
 
             # Reformat color to be ready to add alpha in Plotly-JS
             color = spectra.html(cat["color"])
-            cat["color"] = ",".join([f"{x:.2f}" for x in color.rgb])
+            cat["color"] = ",".join([f"{int(x * 256)}" for x in color.rgb])
 
             # Check that the number of samples is the same for all categories
             assert len(samples) == len(cat["data"])

--- a/multiqc/templates/default/assets/js/plots/bar.js
+++ b/multiqc/templates/default/assets/js/plots/bar.js
@@ -25,7 +25,7 @@ class BarPlot extends Plot {
       let data = this.pActive ? cat["data_pct"] : cat.data;
       return {
         data: data.filter((_, si) => !samplesSettings[si].hidden),
-        color: cat.color,
+        color: cat.color, // formatted as "r,g,b", to be wrapped with "rgb()" or "rgba()"
         name: cat.name,
       };
     });


### PR DESCRIPTION
The `rgba` color format works with relative RGB values (e.g. 0.1,0.31,0.6), but for some reason not always, and full RGB values are preferred (e.g. 21,86,128).

Fix https://github.com/MultiQC/MultiQC/issues/2450