### PR TITLE
Use Rich console for logging

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -510,7 +510,7 @@ def run(
             sys_exit_code=1,
         )
 
-    console = _init(
+    _init(
         analysis_dir=analysis_dir,
         dirs=dirs,
         dirs_depth=dirs_depth,
@@ -603,7 +603,7 @@ def run(
 
     if report.num_flat_plots > 0 and not config.plots_force_flat:
         if not config.plots_force_interactive:
-            console.print(
+            log.rich_console.print(
                 "[blue]|           multiqc[/] | "
                 "Flat-image plots used. Disable with '--interactive'. "
                 "See [link=https://multiqc.info/docs/#flat--interactive-plots]docs[/link]."
@@ -662,25 +662,15 @@ def _init(
     no_ansi=False,
     custom_css_files=(),
     **kwargs,
-) -> rich.console.Console:
+):
     """
     Set up logging, load config and set up key variables.
     """
     report.init()
 
     # Set up logging
-    log_level = "DEBUG" if verbose > 0 else "INFO"
-    if quiet:
-        log_level = "WARNING"
-        config.quiet = True
-    log.init_log(logger, log_level=log_level, no_ansi=no_ansi)
-    console = rich.console.Console(
-        stderr=True,
-        highlight=False,
-        force_terminal=util_functions.force_term_colors(),
-        color_system=None if no_ansi else "auto",
-    )
-    console.print(
+    log.init_log(logger, verbose=verbose, quiet=quiet, no_ansi=no_ansi)
+    log.rich_console.print(
         f"\n  [dark_orange]///[/] [bold][link=https://multiqc.info]MultiQC[/link][/] :mag: [dim]| v{config.version}\n"
     )
     logger.debug(f"This is MultiQC v{config.version}")
@@ -840,7 +830,6 @@ def _init(
         )
 
     logger.debug("Running Python " + sys.version.replace("\n", " "))
-    return console
 
 
 def _file_search(
@@ -1094,12 +1083,7 @@ def _run_modules(
                     panel_width = max(tb_width, log_width)
                     return rich.console.Measurement(panel_width, panel_width)
 
-            console = rich.console.Console(
-                stderr=True,
-                force_terminal=util_functions.force_term_colors(),
-                color_system=None if config.no_ansi else "auto",
-            )
-            console.print(
+            log.rich_console.print(
                 rich.panel.Panel(
                     CustomTraceback(),
                     title=f"Oops! The '[underline]{this_module}[/]' MultiQC module broke...",

--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -7,16 +7,19 @@ import os
 import shutil
 import sys
 import tempfile
-
-import coloredlogs
+import rich
+from rich.logging import RichHandler
+from rich.theme import Theme
 
 from multiqc.utils import config, util_functions
 
 log_tmp_dir = None
 log_tmp_fn = "/dev/null"
 
+rich_console: rich.console.Console
 
-def init_log(logger, log_level: str, no_ansi: bool = False):
+
+def init_log(logger, verbose: int, quiet: bool, no_ansi: bool = False):
     """
     Initializes logging.
     Prints logs to console with level defined by loglevel
@@ -30,49 +33,92 @@ def init_log(logger, log_level: str, no_ansi: bool = False):
     log_tmp_dir = tempfile.mkdtemp()
     log_tmp_fn = os.path.join(log_tmp_dir, "multiqc.log")
 
-    # Logging templates
-    debug_template = "[%(asctime)s] %(name)-50s [%(levelname)-7s]  %(message)s"
-    info_template = "|%(module)18s | %(message)s"
-
     # Remove log handlers left from previous calls to multiqc.run
     while logger.handlers:
         logger.removeHandler(logger.handlers[0])
 
-    # Base level setup
+    # Base level setup: used both for console and file logging
     logger.setLevel(getattr(logging, "DEBUG"))
+
+    # Console log level
+    log_level = "DEBUG" if verbose > 0 else "INFO"
+    if quiet:
+        log_level = "WARNING"
+        config.quiet = True
 
     # Automatically set no_ansi if not a tty terminal
     if not no_ansi:
         if not sys.stderr.isatty() and not util_functions.force_term_colors():
             no_ansi = True
 
+    # Set up the rich console
+    global rich_console
+    rich_console = rich.console.Console(
+        stderr=True,
+        highlight=False,
+        force_terminal=util_functions.force_term_colors(),
+        color_system=None if no_ansi else "auto",
+        theme=Theme(
+            styles={
+                "logging.level.info": "",
+                "logging.level.debug": "dim",
+                "logging.level.warning": "yellow",
+                "logging.level.error": "red",
+                "repr.number": "",
+                "repr.none": "",
+                "repr.str": "",
+                "repr.bool_true": "",
+                "repr.bool_false": "",
+                "log.time": "green",
+            }
+        ),
+    )
+
     # Set up the console logging stream
-    console = logging.StreamHandler()
-    console.setLevel(getattr(logging, log_level))
-    level_styles = coloredlogs.DEFAULT_LEVEL_STYLES
-    level_styles["debug"] = {"faint": True}
-    field_styles = coloredlogs.DEFAULT_FIELD_STYLES
-    field_styles["module"] = {"color": "blue"}
+    console_handler = RichHandler(
+        level=log_level,
+        console=rich_console,
+        show_level=log_level == "DEBUG",
+        show_time=log_level == "DEBUG",
+        log_time_format="[%Y-%m-%d %H:%M:%S]",
+        markup=True,
+        omit_repeated_times=False,
+        show_path=False,
+    )
+
+    class DebugFormatter(logging.Formatter):
+        def format(self, record):
+            if record.levelno == logging.DEBUG:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.debug]%(message)s[/]")
+            elif record.levelno == logging.WARNING:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.warning]%(message)s[/]")
+            elif record.levelno == logging.ERROR:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.error]%(message)s[/]")
+            else:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  %(message)s")
+            return logging.Formatter.format(self, record)
+
+    class InfoFormatter(logging.Formatter):
+        def format(self, record):
+            if record.levelno == logging.WARNING:
+                self._style = logging.PercentStyle("[blue]|%(module)18s[/] | [logging.level.warning]%(message)s[/]")
+            elif record.levelno == logging.ERROR:
+                self._style = logging.PercentStyle("[blue]|%(module)18s[/] | [logging.level.error]%(message)s[/]")
+            else:
+                self._style = logging.PercentStyle("[blue]|%(module)18s[/] | %(message)s")
+            return logging.Formatter.format(self, record)
+
+    console_handler.setLevel(getattr(logging, log_level))
     if log_level == "DEBUG":
-        if no_ansi:
-            console.setFormatter(logging.Formatter(debug_template))
-        else:
-            console.setFormatter(
-                coloredlogs.ColoredFormatter(fmt=debug_template, level_styles=level_styles, field_styles=field_styles)
-            )
+        console_handler.setFormatter(DebugFormatter())
     else:
-        if no_ansi:
-            console.setFormatter(logging.Formatter(info_template))
-        else:
-            console.setFormatter(
-                coloredlogs.ColoredFormatter(fmt=info_template, level_styles=level_styles, field_styles=field_styles)
-            )
-    logger.addHandler(console)
+        console_handler.setFormatter(InfoFormatter())
+    logger.addHandler(console_handler)
 
     # Now set up the file logging stream if we have a data directory
     file_handler = logging.FileHandler(log_tmp_fn, encoding="utf-8")
     file_handler.setLevel(getattr(logging, "DEBUG"))  # always DEBUG for the file
-    file_handler.setFormatter(logging.Formatter(debug_template))
+    file_handler.setFormatter(logging.Formatter("[%(asctime)s] %(name)-50s [%(levelname)-7s]  %(message)s"))
     logger.addHandler(file_handler)
 
 

--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -10,6 +10,7 @@ import tempfile
 import rich
 from rich.logging import RichHandler
 from rich.theme import Theme
+import rich.jupyter
 
 from multiqc.utils import config, util_functions
 
@@ -52,6 +53,10 @@ def init_log(logger, quiet: bool, verbose: int, no_ansi: bool = False):
     if not no_ansi:
         if not sys.stderr.isatty() and not util_functions.force_term_colors():
             no_ansi = True
+
+    # Reset margin-bottom to remove the gian gap between lines.
+    # See https://github.com/Textualize/rich/issues/3335 for more context
+    rich.jupyter.JUPYTER_HTML_FORMAT = rich.jupyter.JUPYTER_HTML_FORMAT.replace('style="', 'style="margin-bottom:0px;')
 
     # Set up the rich console
     global rich_console

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -337,7 +337,7 @@ def get_filelist(run_module_names):
     for key in sorted(file_search_stats, key=file_search_stats.get, reverse=True):
         if "skipped_" in key and file_search_stats[key] > 0:
             summaries.append(f"{key}: {file_search_stats[key]}")
-    logger.debug(f"Summary of files that were skipped by the search: [{'] // ['.join(summaries)}]")
+    logger.debug(f"Summary of files that were skipped by the search: |{'|, |'.join(summaries)}|")
 
 
 def search_file(pattern, f, module_key):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "multiqc"
 version = "1.22dev"
 dependencies = [
     "click",
-    "coloredlogs",
     "humanize",
     "importlib-metadata",
     "jinja2>=3.0.0",


### PR DESCRIPTION
Stacked on https://github.com/MultiQC/MultiQC/pull/2442, do not merge. 

* Use Rich console for logging
* Drop coloredlogs

The downside is that we can't wrap in square brackets in log messages. On the other hand, we control our log messages, so shouldn't be a problem.