### PR TITLE
Exclude plot data for sections in `remove_sections`

### DIFF
--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 
 import markdown
 
+from multiqc.plots.plotly.plot import Plot as PlotABC
 from multiqc.utils import config, report, software_versions, util_functions
 
 logger = logging.getLogger(__name__)
@@ -282,6 +283,11 @@ class BaseMultiqcModule:
         comment = comment.strip()
         helptext = helptext.strip()
 
+        if isinstance(plot, PlotABC):
+            plot_html = plot.add_to_report(report)
+        else:
+            plot_html = plot
+
         self.sections.append(
             {
                 "name": name,
@@ -289,10 +295,10 @@ class BaseMultiqcModule:
                 "description": description,
                 "comment": comment,
                 "helptext": helptext,
-                "plot": plot,
+                "plot": plot_html,
                 "content": content,
                 "print_section": any(
-                    [n is not None and len(n) > 0 for n in [description, comment, helptext, plot, content]]
+                    [n is not None and len(n) > 0 for n in [description, comment, helptext, plot_html, content]]
                 ),
             }
         )

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -1,4 +1,4 @@
-""" MultiQC modules base class, contains helper functions """
+"""MultiQC modules base class, contains helper functions"""
 
 from typing import List, Union, Optional, Dict
 
@@ -14,7 +14,7 @@ from collections import defaultdict
 
 import markdown
 
-from multiqc.plots.plotly.plot import Plot as PlotABC
+from multiqc.plots.plotly.plot import Plot
 from multiqc.utils import config, report, software_versions, util_functions
 
 logger = logging.getLogger(__name__)
@@ -231,7 +231,8 @@ class BaseMultiqcModule:
         description="",
         comment="",
         helptext="",
-        plot="",
+        content_before_plot="",
+        plot: Plot = None,
         content="",
         autoformat=True,
         autoformat_type="markdown",
@@ -282,11 +283,7 @@ class BaseMultiqcModule:
         description = description.strip()
         comment = comment.strip()
         helptext = helptext.strip()
-
-        if isinstance(plot, PlotABC):
-            plot_html = plot.add_to_report(report)
-        else:
-            plot_html = plot
+        plot_html = plot.add_to_report(report) if plot else ""
 
         self.sections.append(
             {
@@ -295,10 +292,14 @@ class BaseMultiqcModule:
                 "description": description,
                 "comment": comment,
                 "helptext": helptext,
+                "content_before_plot": content_before_plot,
                 "plot": plot_html,
                 "content": content,
                 "print_section": any(
-                    [n is not None and len(n) > 0 for n in [description, comment, helptext, plot_html, content]]
+                    [
+                        n is not None and len(n) > 0
+                        for n in [description, comment, helptext, content_before_plot, plot_html, content]
+                    ]
                 ),
             }
         )

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -1,5 +1,4 @@
-""" MultiQC module to parse output from FastQC
-"""
+"""MultiQC module to parse output from FastQC"""
 
 ############################################################
 ######  LOOKING FOR AN EXAMPLE OF HOW MULTIQC WORKS?  ######
@@ -7,7 +6,6 @@
 #### Stop! This is one of the most complicated modules. ####
 #### Have a look at Kallisto for a simpler example.     ####
 ############################################################
-
 
 import io
 import json
@@ -112,32 +110,37 @@ class MultiqcModule(BaseMultiqcModule):
         # Add to the general statistics table
         self.fastqc_general_stats()
 
+        status_checks = getattr(config, "fastqc_config", {}).get("status_checks", True)
+
         # Add the statuses to the intro for multiqc_fastqc.js JavaScript to pick up
         statuses = dict()
-        for s_name in self.fastqc_data:
-            for section, status in self.fastqc_data[s_name]["statuses"].items():
-                try:
-                    statuses[section][s_name] = status
-                except KeyError:
-                    statuses[section] = {s_name: status}
+        if status_checks:
+            for s_name in self.fastqc_data:
+                for section, status in self.fastqc_data[s_name]["statuses"].items():
+                    try:
+                        statuses[section][s_name] = status
+                    except KeyError:
+                        statuses[section] = {s_name: status}
+
         self.intro += '<script type="application/json" class="fastqc_passfails">{}</script>'.format(
             json.dumps([self.anchor.replace("-", "_"), statuses])
         )
-
-        self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
+        if status_checks:
+            self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
 
         # Now add each section in order
         self.read_count_plot()
-        self.sequence_quality_plot()
-        self.per_seq_quality_plot()
+        self.sequence_quality_plot(status_checks)
+        self.per_seq_quality_plot(status_checks)
         self.sequence_content_plot()
-        self.gc_content_plot()
-        self.n_content_plot()
-        self.seq_length_dist_plot()
-        self.seq_dup_levels_plot()
+        self.gc_content_plot(status_checks)
+        self.n_content_plot(status_checks)
+        self.seq_length_dist_plot(status_checks)
+        self.seq_dup_levels_plot(status_checks)
         self.overrepresented_sequences()
-        self.adapter_content_plot()
-        self.status_heatmap()
+        self.adapter_content_plot(status_checks)
+        if status_checks:
+            self.status_heatmap()
 
     def parse_fastqc_report(self, file_contents, s_name=None, f=None):
         """Takes contents from a fastq_data.txt file and parses out required
@@ -396,7 +399,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=bargraph.plot(pdata, pcats, pconfig),
         )
 
-    def sequence_quality_plot(self):
+    def sequence_quality_plot(self, status_checks=True):
         """Create the HTML for the phred quality score plot"""
 
         data = dict()
@@ -421,13 +424,19 @@ class MultiqcModule(BaseMultiqcModule):
             "xmin": 0,
             "xDecimals": False,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}",
-            "colors": self.get_status_cols("per_base_sequence_quality"),
-            "yPlotBands": [
-                {"from": 28, "to": 100, "color": "#c3e6c3"},
-                {"from": 20, "to": 28, "color": "#e6dcc3"},
-                {"from": 0, "to": 20, "color": "#e6c3c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_base_sequence_quality"),
+                    "yPlotBands": [
+                        {"from": 28, "to": 100, "color": "#c3e6c3"},
+                        {"from": 20, "to": 28, "color": "#e6dcc3"},
+                        {"from": 0, "to": 20, "color": "#e6c3c3"},
+                    ],
+                }
+            )
+
         self.add_section(
             name="Sequence Quality Histograms",
             anchor="fastqc_per_base_sequence_quality",
@@ -447,7 +456,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot(data, pconfig),
         )
 
-    def per_seq_quality_plot(self):
+    def per_seq_quality_plot(self, status_checks=True):
         """Create the HTML for the per sequence quality score plot"""
 
         data = dict()
@@ -470,14 +479,19 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "xmin": 0,
             "xDecimals": False,
-            "colors": self.get_status_cols("per_sequence_quality_scores"),
             "tt_label": "<b>Phred {point.x}</b>: {point.y} reads",
-            "xPlotBands": [
-                {"from": 28, "to": 100, "color": "#c3e6c3"},
-                {"from": 20, "to": 28, "color": "#e6dcc3"},
-                {"from": 0, "to": 20, "color": "#e6c3c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_sequence_quality_scores"),
+                    "xPlotBands": [
+                        {"from": 28, "to": 100, "color": "#c3e6c3"},
+                        {"from": 20, "to": 28, "color": "#e6dcc3"},
+                        {"from": 0, "to": 20, "color": "#e6c3c3"},
+                    ],
+                }
+            )
         self.add_section(
             name="Per Sequence Quality Scores",
             anchor="fastqc_per_sequence_quality_scores",
@@ -512,6 +526,8 @@ class MultiqcModule(BaseMultiqcModule):
                 tot = sum([data[s_name][b][base] for base in ["a", "c", "t", "g"]])
                 if tot == 100.0:
                     break  # Stop loop after one iteration if summed to 100 (percentages)
+                elif tot == 0:
+                    continue
                 else:
                     for base in ["a", "c", "t", "g"]:
                         data[s_name][b][base] = (float(data[s_name][b][base]) / float(tot)) * 100.0
@@ -589,7 +605,7 @@ class MultiqcModule(BaseMultiqcModule):
             content=html,
         )
 
-    def gc_content_plot(self):
+    def gc_content_plot(self, status_checks=True):
         """Create the HTML for the FastQC GC content plot"""
 
         data = dict()
@@ -622,12 +638,17 @@ class MultiqcModule(BaseMultiqcModule):
             "xmax": 100,
             "xmin": 0,
             "tt_label": "<b>{point.x}% GC</b>: {point.y}",
-            "colors": self.get_status_cols("per_sequence_gc_content"),
             "data_labels": [
                 {"name": "Percentages", "ylab": "Percentage", "tt_suffix": "%"},
                 {"name": "Counts", "ylab": "Count", "tt_suffix": ""},
             ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_sequence_gc_content"),
+                }
+            )
 
         # Try to find and plot a theoretical GC line
         theoretical_gc = None
@@ -707,7 +728,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot([data_norm, data], pconfig),
         )
 
-    def n_content_plot(self):
+    def n_content_plot(self, status_checks=True):
         """Create the HTML for the per base N content plot"""
 
         data = dict()
@@ -732,14 +753,19 @@ class MultiqcModule(BaseMultiqcModule):
             "y_minrange": 5,
             "ymin": 0,
             "xmin": 0,
-            "colors": self.get_status_cols("per_base_n_content"),
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}%",
-            "y_bands": [
-                {"from": 20, "to": 100, "color": "#e6c3c3"},
-                {"from": 5, "to": 20, "color": "#e6dcc3"},
-                {"from": 0, "to": 5, "color": "#c3e6c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_base_n_content"),
+                    "y_bands": [
+                        {"from": 20, "to": 100, "color": "#e6c3c3"},
+                        {"from": 5, "to": 20, "color": "#e6dcc3"},
+                        {"from": 0, "to": 5, "color": "#c3e6c3"},
+                    ],
+                }
+            )
 
         self.add_section(
             name="Per Base N Content",
@@ -760,7 +786,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot(data, pconfig),
         )
 
-    def seq_length_dist_plot(self):
+    def seq_length_dist_plot(self, status_checks):
         """Create the HTML for the Sequence Length Distribution plot"""
 
         data = dict()
@@ -798,9 +824,14 @@ class MultiqcModule(BaseMultiqcModule):
                 "ylab": "Read Count",
                 "xlab": "Sequence Length (bp)",
                 "ymin": 0,
-                "colors": self.get_status_cols("sequence_length_distribution"),
                 "tt_label": "<b>{point.x} bp</b>: {point.y}",
             }
+            if status_checks:
+                pconfig.update(
+                    {
+                        "colors": self.get_status_cols("sequence_length_distribution"),
+                    }
+                )
             self.add_section(
                 name="Sequence Length Distribution",
                 anchor="fastqc_sequence_length_distribution",
@@ -809,7 +840,7 @@ class MultiqcModule(BaseMultiqcModule):
                 plot=linegraph.plot(data, pconfig),
             )
 
-    def seq_dup_levels_plot(self):
+    def seq_dup_levels_plot(self, status_checks):
         """Create the HTML for the Sequence Duplication Levels plot"""
 
         data = dict()
@@ -839,10 +870,15 @@ class MultiqcModule(BaseMultiqcModule):
             "xlab": "Sequence Duplication Level",
             "ymax": 100 if max_dupval <= 100.0 else None,
             "ymin": 0,
-            "colors": self.get_status_cols("sequence_duplication_levels"),
             "tt_decimals": 2,
             "tt_suffix": "%",
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("sequence_duplication_levels"),
+                }
+            )
 
         self.add_section(
             name="Sequence Duplication Levels",
@@ -928,13 +964,15 @@ class MultiqcModule(BaseMultiqcModule):
             "ylab": "Percentage of Total Sequences",
         }
 
+        plot = None
+        content = None
         # Check if any samples have more than 1% overrepresented sequences, else don't make plot.
         if max([x["total_overrepresented"] for x in data.values()]) < 1:
-            plot_html = '<div class="alert alert-info">{} samples had less than 1% of reads made up of overrepresented sequences</div>'.format(
+            content = '<div class="alert alert-info">{} samples had less than 1% of reads made up of overrepresented sequences</div>'.format(
                 len(data)
             )
         else:
-            plot_html = bargraph.plot(data, cats, pconfig)
+            plot = bargraph.plot(data, cats, pconfig)
 
         self.add_section(
             name="Overrepresented sequences by sample",
@@ -962,7 +1000,8 @@ class MultiqcModule(BaseMultiqcModule):
             to the end of the file. It is therefore possible that a sequence which is overrepresented
             but doesn't appear at the start of the file for some reason could be missed by this module._
             """,
-            plot=plot_html,
+            plot=plot,
+            content=content,
         )
 
         # Add a table of the top overrepresented sequences
@@ -1035,7 +1074,7 @@ class MultiqcModule(BaseMultiqcModule):
             ),
         )
 
-    def adapter_content_plot(self):
+    def adapter_content_plot(self, status_checks=True):
         """Create the HTML for the FastQC adapter plot"""
 
         data = dict()
@@ -1070,17 +1109,24 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}%",
             "hide_empty": True,
-            "y_bands": [
-                {"from": 20, "to": 100, "color": "#e6c3c3"},
-                {"from": 5, "to": 20, "color": "#e6dcc3"},
-                {"from": 0, "to": 5, "color": "#c3e6c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "y_bands": [
+                        {"from": 20, "to": 100, "color": "#e6c3c3"},
+                        {"from": 5, "to": 20, "color": "#e6dcc3"},
+                        {"from": 0, "to": 5, "color": "#c3e6c3"},
+                    ],
+                }
+            )
 
+        plot = None
+        content = None
         if len(data) > 0:
-            plot_html = linegraph.plot(data, pconfig)
+            plot = linegraph.plot(data, pconfig)
         else:
-            plot_html = '<div class="alert alert-info">No samples found with any adapter contamination > 0.1%</div>'
+            content = '<div class="alert alert-info">No samples found with any adapter contamination > 0.1%</div>'
 
         # Note - colours are messy as we've added adapter names here. Not
         # possible to break down pass / warn / fail for each adapter, which
@@ -1106,7 +1152,8 @@ class MultiqcModule(BaseMultiqcModule):
             right through to the end of the read so the percentages you see will only
             increase as the read length goes on._
             """,
-            plot=plot_html,
+            plot=plot,
+            content=content,
         )
 
     def status_heatmap(self):

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -971,8 +971,9 @@ def run(
             "save_file": True,
             "raw_data_fn": "multiqc_general_stats",
         }
-        general_stats_table = table.plot(report.general_stats_data, report.general_stats_headers, pconfig)
-        report.general_stats_html = general_stats_table.add_to_report(report)
+        report.general_stats_html = table.plot(
+            report.general_stats_data, report.general_stats_headers, pconfig
+        ).add_to_report(report)
     else:
         config.skip_generalstats = True
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -971,7 +971,8 @@ def run(
             "save_file": True,
             "raw_data_fn": "multiqc_general_stats",
         }
-        report.general_stats_html = table.plot(report.general_stats_data, report.general_stats_headers, pconfig)
+        general_stats_table = table.plot(report.general_stats_data, report.general_stats_headers, pconfig)
+        report.general_stats_html = general_stats_table.add_to_report(report)
     else:
         config.skip_generalstats = True
 

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -1,4 +1,5 @@
 """Plotly bargraph functionality."""
+
 import copy
 import dataclasses
 import logging
@@ -20,7 +21,7 @@ def plot(
     cats_lists: List[List[Dict]],
     samples_lists: List[List[str]],
     pconfig: Dict,
-) -> str:
+) -> Plot:
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param cats_lists: each dataset is a list of dicts with the keys: {name, color, data},

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -32,16 +32,12 @@ def plot(
     :param pconfig: Plot configuration dictionary
     :return: HTML with JS, ready to be inserted into the page
     """
-    p = BarPlot(
+    return BarPlot(
         pconfig,
         cats_lists,
         samples_lists,
         max_n_samples=max([len(samples) for samples in samples_lists]),
     )
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 BoxT = List[Union[int, float]]
 
 
-def plot(list_of_data_by_sample: List[Dict[str, BoxT]], pconfig: Dict) -> str:
+def plot(list_of_data_by_sample: List[Dict[str, BoxT]], pconfig: Dict) -> Plot:
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param list_of_data_by_sample: each dataset is a dict mapping samples to either:

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -25,15 +25,11 @@ def plot(list_of_data_by_sample: List[Dict[str, BoxT]], pconfig: Dict) -> str:
     :param pconfig: Plot configuration dictionary
     :return: HTML with JS, ready to be inserted into the page
     """
-    p = BoxPlot(
+    return BoxPlot(
         pconfig,
         list_of_data_by_sample,
         max_n_samples=max(len(d) for d in list_of_data_by_sample),
     )
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -26,11 +26,7 @@ def plot(
     :param pconfig: dict with config key:value pairs. See CONTRIBUTING.md
     :return: HTML with JS, ready to be inserted into the page
     """
-    p = HeatmapPlot(rows, pconfig, xcats, ycats)
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
+    return HeatmapPlot(rows, pconfig, xcats, ycats)
 
 
 @dataclasses.dataclass
@@ -300,16 +296,16 @@ class HeatmapPlot(Plot):
             <div class="mqc_hcplot_range_sliders">
                 <div>
                     <label for="{self.id}_range_slider_min_txt">Min:</label>
-                    <input id="{self.id}_range_slider_min_txt" type="number" class="form-control" 
+                    <input id="{self.id}_range_slider_min_txt" type="number" class="form-control"
                         value="{self.min}" data-target="{self.id}" data-minmax="min" min="{self.min}" max="{self.max}" />
-                    <input id="{self.id}_range_slider_min" type="range" 
+                    <input id="{self.id}_range_slider_min" type="range"
                         value="{self.min}" data-target="{self.id}" data-minmax="min" min="{self.min}" max="{self.max}" step="any" />
                 </div>
                 <div style="margin-left: 30px;">
                     <label for="{self.id}_range_slider_max_txt">Max:</label>
-                    <input id="{self.id}_range_slider_max_txt" type="number" class="form-control" 
+                    <input id="{self.id}_range_slider_max_txt" type="number" class="form-control"
                         value="{self.max}" data-target="{self.id}" data-minmax="max" min="{self.min}" max="{self.max}" />
-                    <input id="{self.id}_range_slider_max" type="range" 
+                    <input id="{self.id}_range_slider_max" type="range"
                         value="{self.max}" data-target="{self.id}" data-minmax="max" min="{self.min}" max="{self.max}" step="any" />
                 </div>
             </div>

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -17,7 +17,7 @@ def plot(
     pconfig: Dict,
     xcats: Optional[List[str]] = None,
     ycats: Optional[List[str]] = None,
-) -> str:
+) -> Plot:
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param rows: One dataset. A dataset is a list of rows of values
@@ -181,12 +181,12 @@ class HeatmapPlot(Plot):
         height = pconfig.get("height") or int(num_rows * y_px_per_elem)
 
         if not self.square and width < MAX_WIDTH and x_px_per_elem < 40:  # can fit more columns on the screen
-            logger.debug(f"Resizing width from {width} to {MAX_WIDTH} to fit horizontal column text on the screen")
+            # logger.debug(f"Resizing width from {width} to {MAX_WIDTH} to fit horizontal column text on the screen")
             width = MAX_WIDTH
             x_px_per_elem = width / num_cols
 
         if height > MAX_HEIGHT or width > MAX_WIDTH:
-            logger.debug(f"Resizing from {width}x{height} to fit the maximum size {MAX_WIDTH}x{MAX_HEIGHT}")
+            # logger.debug(f"Resizing from {width}x{height} to fit the maximum size {MAX_WIDTH}x{MAX_HEIGHT}")
             if self.square:
                 px_per_elem = min(MAX_WIDTH / num_cols, MAX_HEIGHT / num_rows)
                 width = height = int(num_rows * px_per_elem)
@@ -196,7 +196,7 @@ class HeatmapPlot(Plot):
                 width = int(num_cols * x_px_per_elem)
                 height = int(num_rows * y_px_per_elem)
 
-        logger.debug(f"Heatmap size: {width}x{height}, px per element: {x_px_per_elem:.2f}x{y_px_per_elem:.2f}")
+        # logger.debug(f"Heatmap size: {width}x{height}, px per element: {x_px_per_elem:.2f}x{y_px_per_elem:.2f}")
 
         # For not very large datasets, making sure all ticks are displayed:
         if y_px_per_elem > 12:
@@ -296,16 +296,16 @@ class HeatmapPlot(Plot):
             <div class="mqc_hcplot_range_sliders">
                 <div>
                     <label for="{self.id}_range_slider_min_txt">Min:</label>
-                    <input id="{self.id}_range_slider_min_txt" type="number" class="form-control"
+                    <input id="{self.id}_range_slider_min_txt" type="number" class="form-control" 
                         value="{self.min}" data-target="{self.id}" data-minmax="min" min="{self.min}" max="{self.max}" />
-                    <input id="{self.id}_range_slider_min" type="range"
+                    <input id="{self.id}_range_slider_min" type="range" 
                         value="{self.min}" data-target="{self.id}" data-minmax="min" min="{self.min}" max="{self.max}" step="any" />
                 </div>
                 <div style="margin-left: 30px;">
                     <label for="{self.id}_range_slider_max_txt">Max:</label>
-                    <input id="{self.id}_range_slider_max_txt" type="number" class="form-control"
+                    <input id="{self.id}_range_slider_max_txt" type="number" class="form-control" 
                         value="{self.max}" data-target="{self.id}" data-minmax="max" min="{self.min}" max="{self.max}" />
-                    <input id="{self.id}_range_slider_max" type="range"
+                    <input id="{self.id}_range_slider_max" type="range" 
                         value="{self.max}" data-target="{self.id}" data-minmax="max" min="{self.min}" max="{self.max}" step="any" />
                 </div>
             </div>

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 LineT = Dict[str, Union[str, List[Tuple[Union[float, int, str], Union[float, int]]]]]
 
 
-def plot(lists_of_lines: List[List[LineT]], pconfig: Dict) -> str:
+def plot(lists_of_lines: List[List[LineT]], pconfig: Dict) -> Plot:
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param lists_of_lines: each dataset is a 2D dict, first keys as sample names, then x:y data pairs
@@ -152,8 +152,8 @@ class LinePlot(Plot):
             # We don't want the bands to affect the calculated axis range, so we
             # find the min and the max from data points, and manually set the range.
             for dataset in self.datasets:
-                minval = None
-                maxval = None
+                minval = dataset.layout["yaxis"]["autorangeoptions"]["minallowed"]
+                maxval = dataset.layout["yaxis"]["autorangeoptions"]["maxallowed"]
                 for line in dataset.lines:
                     ys = [x[1] for x in line["data"]]
                     if len(ys) > 0:
@@ -161,10 +161,6 @@ class LinePlot(Plot):
                         maxval = max(ys) if maxval is None else max(maxval, max(ys))
                 if maxval is not None and minval is not None:
                     maxval += (maxval - minval) * 0.05
-                if minval is None:
-                    minval = dataset.layout["yaxis"]["autorangeoptions"]["minallowed"]
-                if maxval is None:
-                    maxval = dataset.layout["yaxis"]["autorangeoptions"]["maxallowed"]
                 clipmin = dataset.layout["yaxis"]["autorangeoptions"]["clipmin"]
                 clipmax = dataset.layout["yaxis"]["autorangeoptions"]["clipmax"]
                 if clipmin is not None and minval is not None and clipmin > minval:
@@ -181,17 +177,13 @@ class LinePlot(Plot):
         if not pconfig.get("categories", False) and x_minrange or x_bands or x_lines:
             # same as above but for x-axis
             for dataset in self.datasets:
-                minval = None
-                maxval = None
+                minval = dataset.layout["xaxis"]["autorangeoptions"]["minallowed"]
+                maxval = dataset.layout["xaxis"]["autorangeoptions"]["maxallowed"]
                 for line in dataset.lines:
                     xs = [x[0] for x in line["data"]]
                     if len(xs) > 0:
                         minval = min(xs) if minval is None else min(minval, min(xs))
                         maxval = max(xs) if maxval is None else max(maxval, max(xs))
-                if minval is None:
-                    minval = dataset.layout["xaxis"]["autorangeoptions"]["minallowed"]
-                if maxval is None:
-                    maxval = dataset.layout["xaxis"]["autorangeoptions"]["maxallowed"]
                 clipmin = dataset.layout["xaxis"]["autorangeoptions"]["clipmin"]
                 clipmax = dataset.layout["xaxis"]["autorangeoptions"]["clipmax"]
                 if clipmin is not None and minval is not None and clipmin > minval:

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -32,11 +32,7 @@ def plot(lists_of_lines: List[List[LineT]], pconfig: Dict) -> str:
     # Create a violin of median values in each sample, showing dots for outliers
     # Clicking on a dot of a violin will show the line plot for that sample
 
-    p = LinePlot(pconfig, lists_of_lines)
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
+    return LinePlot(pconfig, lists_of_lines)
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 PointT = Dict[str, Union[str, float, int]]
 
 
-def plot(points_lists: List[List[PointT]], pconfig: Dict) -> str:
+def plot(points_lists: List[List[PointT]], pconfig: Dict) -> Plot:
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param points_lists: each dataset is a 2D dict, first keys as sample names, then x:y data pairs
@@ -94,7 +94,7 @@ class Dataset(BaseDataset):
                 threshold = 1.0
                 while threshold <= 6.0:
                     n_outliers = np.count_nonzero((x_z_scores > threshold) | (y_z_scores > threshold))
-                    logger.debug(f"Scatter plot outlier threshold: {threshold:.2f}, outliers: {n_outliers}")
+                    # logger.debug(f"Scatter plot outlier threshold: {threshold:.2f}, outliers: {n_outliers}")
                     if n_annotated + n_outliers <= MAX_ANNOTATIONS:
                         break
                     # If there are too many outliers, we increase the threshold until we have less than 10

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -24,11 +24,7 @@ def plot(points_lists: List[List[PointT]], pconfig: Dict) -> str:
     :param pconfig: dict with config key:value pairs. See CONTRIBUTING.md
     :return: HTML with JS, ready to be inserted into the page
     """
-    p = ScatterPlot(pconfig, points_lists)
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
+    return ScatterPlot(pconfig, points_lists)
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -2,13 +2,14 @@ import logging
 from collections import defaultdict
 from typing import Tuple, Optional, List
 
+from multiqc.plots.plotly.plot import Plot
 from multiqc.plots.table_object import DataTable
 from multiqc.utils import config, mqc_colour, util_functions, report
 
 logger = logging.getLogger(__name__)
 
 
-def plot(dt: List[DataTable]) -> str:
+def plot(dt: List[DataTable]) -> Plot:
     from multiqc.plots.plotly import violin
 
     return violin.plot(dt, show_table_by_default=True)

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -17,13 +17,9 @@ logger = logging.getLogger(__name__)
 
 def plot(dts: List[DataTable], show_table_by_default=False) -> str:
     """
-    Build and add the plot data to the report, return an HTML wrapper.
+    Build and add the plot data to the report, return the ViolinPlot
     """
-    p = ViolinPlot.from_dt(dts, show_table_by_default)
-
-    from multiqc.utils import report
-
-    return p.add_to_report(report)
+    return ViolinPlot.from_dt(dts, show_table_by_default)
 
 
 @dataclasses.dataclass

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -15,9 +15,9 @@ from multiqc.plots.plotly.table import make_table
 logger = logging.getLogger(__name__)
 
 
-def plot(dts: List[DataTable], show_table_by_default=False) -> str:
+def plot(dts: List[DataTable], show_table_by_default=False) -> Plot:
     """
-    Build and add the plot data to the report, return the ViolinPlot
+    Build and add the plot data to the report, return an HTML wrapper.
     """
     return ViolinPlot.from_dt(dts, show_table_by_default)
 

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -56,6 +56,7 @@ the output from each module and print it in sections.
                 <div class="well">{{ s['helptext'] }}</div>
               </div>
             {% endif %}
+            {{ s['content_before_plot'] if s['content_before_plot'] }}
             {% if s['plot'] is not none %}<div class="mqc-section-plot">{{ s['plot'] }}</div>{% endif %}
             {{ s['content'] if s['content'] }}
 


### PR DESCRIPTION
I noticed some really big multiqc reports, which didn't make sense to me given the contents.

Digging in, I realized that multiqc adds plot data for all plots generated, but does not _remove_ plot data for plots in `remove_sections`.

The cause is that calling `plottype.plot(...)` actually adds the data to the report, e.g. https://github.com/MultiQC/MultiQC/blob/a0e05da08e58f5f3d4e717fcae00e1ea609ec312/multiqc/plots/plotly/line.py#L39

But the mechanism in which `remove_sections` is implemented [requires that .plot(...) already be called](https://github.com/MultiQC/MultiQC/blob/a0e05da08e58f5f3d4e717fcae00e1ea609ec312/multiqc/modules/base_module.py#L259) (and hence added to the report data).

Using `fastp` as an example module, it [generates a plot and then calls `add_section`](https://github.com/MultiQC/MultiQC/blob/a0e05da08e58f5f3d4e717fcae00e1ea609ec312/multiqc/modules/fastp/fastp.py#L135). When the plot is omitted, the plot data is not.

Naively, I figured that plot data should be added to the report in lockstep with when the plot is actually added to the report. I took a stab at implementing that.

It passes for me on a local test case with a bunch of inputs. However this feels like a broad change so I don't know how to build confidence that it won't break anything. Also, let me know if you feel there's a better approach. I don't love how `add_section` now relies on `is_instance`... feels bad.

Anyway, for my simple test case, a report went from 30mb to 4mb.
