### PR TITLE
Picard WgsMetrics: coverage plot: show % based ≥x, not >x

### DIFF
--- a/multiqc/modules/picard/WgsMetrics.py
+++ b/multiqc/modules/picard/WgsMetrics.py
@@ -165,7 +165,11 @@ def parse_reports(module):
                     cumulative += v
                     data[s_name][k] = v
                     maxval = max(maxval, v)
-                    data_percent[s_name][k] = 100 - (cumulative / total) * 100
+                    pct_bases_cumulative = (cumulative / total) * 100
+                    pct_bases_with_greater_cov = 100 - pct_bases_cumulative
+                    pct_bases_current = (v / total) * 100
+                    pct_bases_with_greater_or_equal_cov = pct_bases_with_greater_cov + pct_bases_current
+                    data_percent[s_name][k] = pct_bases_with_greater_or_equal_cov
                 else:
                     break
 


### PR DESCRIPTION
This resolves a off-by-one error in the histogram plot for the `picard wgsmetrics` submodule. 

This issue is particularly problematic for shallow/low-pass sequencing with a high proportion of bases with zero coverage. The plot below illustrates this problem:

<img width="757" alt="image" src="https://github.com/MultiQC/MultiQC/assets/13511784/b24bef6d-dc9a-454e-83a7-7117b63055da">


The problem is solved by reconfiguring the y-axis to plot 'the percentage of bases greater or equal than the current x-axis coverage value' rather than 'the percentage of bases greater than the current x-axis coverage value'

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)