### PR TITLE
Content lines lint

### DIFF
--- a/.github/workflows/code_checks.py
+++ b/.github/workflows/code_checks.py
@@ -1,4 +1,4 @@
-""" Crude code-quality checks for running in CI """
+"""Crude code-quality checks for running in CI"""
 
 import glob
 import os
@@ -10,26 +10,45 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 MODULES_DIR = os.path.join(BASE_DIR, "multiqc", "modules")
 num_errors = 0
 
-checks = {
+must_be_present_after = {
     "self.add_data_source": "self.find_log_files",
     "self.write_data_file": "self.find_log_files",
     "doi=": "super(MultiqcModule, self).__init__(",
     "self.add_software_version": "self.find_log_files",
 }
 
+must_be_avoided_after = {
+    'f["contents_lines"]': "self.find_log_files",
+}
+
 # Check that add_data_source() is called for each module
-for function, search_term in checks.items():
-    print(f"[bold black on yellow]  Checking for function call '{function}'  [/]")
+for must_be_present, search_term in must_be_present_after.items():
+    print(f"[bold black on yellow]  Checking for '{must_be_present}'  [/]")
     missing_files = []
     for fn in glob.glob(os.path.join(MODULES_DIR, "*", "*.py")):
         with open(fn, "r") as fh:
-            modfile = fh.read()
-            if search_term in modfile and function not in modfile:
+            contents = fh.read()
+            if search_term in contents and must_be_present not in contents:
                 relpath = os.path.relpath(fn, MODULES_DIR)
-                missing_files.append((relpath, f"Can't find '{function}' in /{relpath}"))
+                missing_files.append((relpath, f"Can't find '{must_be_present}' in /{relpath}"))
                 num_errors += 1
 
     for file in sorted(missing_files, key=lambda x: x[0]):
+        print(file[1])
+    print("\n\n")
+
+for must_be_avoided, search_term in must_be_avoided_after.items():
+    print(f"[bold black on yellow]  Checking that '{must_be_avoided}' is not found  [/]")
+    found_files = []
+    for fn in glob.glob(os.path.join(MODULES_DIR, "*", "*.py")):
+        with open(fn, "r") as fh:
+            contents = fh.read()
+            if search_term in contents and must_be_avoided in contents:
+                relpath = os.path.relpath(fn, MODULES_DIR)
+                found_files.append((relpath, f"Found '{must_be_avoided}' in /{relpath}"))
+                num_errors += 1
+
+    for file in sorted(found_files, key=lambda x: x[0]):
         print(file[1])
     print("\n\n")
 

--- a/multiqc/modules/bakta/bakta.py
+++ b/multiqc/modules/bakta/bakta.py
@@ -1,5 +1,4 @@
-""" MultiQC module to parse output from Bakta """
-
+"""MultiQC module to parse output from Bakta"""
 
 import logging
 
@@ -116,7 +115,7 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
         data = {}
-        for line in f["contents_lines"]:
+        for line in f["f"].splitlines():
             s = line.strip().split(": ")
             if s[0] in metrics:
                 data[s[0].replace(" ", "_")] = int(s[1])

--- a/multiqc/modules/humid/clusters.py
+++ b/multiqc/modules/humid/clusters.py
@@ -31,7 +31,7 @@ def parse_log_files(self):
 
         # process the file content
         d = {}
-        for line in f["contents_lines"]:
+        for line in f["f"].splitlines():
             cluster_size, count = line.strip("\n").split(" ")
             d[int(cluster_size)] = int(count)
 

--- a/multiqc/modules/humid/counts.py
+++ b/multiqc/modules/humid/counts.py
@@ -27,7 +27,7 @@ def parse_log_files(self):
 
         # process the file content
         d = {}
-        for line in f["contents_lines"]:
+        for line in f["f"].splitlines():
             nr_reads, count = line.strip("\n").split(" ")
             d[int(nr_reads)] = int(count)
 

--- a/multiqc/modules/humid/neighbours.py
+++ b/multiqc/modules/humid/neighbours.py
@@ -27,7 +27,7 @@ def parse_log_files(self):
 
         # process the file content
         d = {}
-        for line in f["contents_lines"]:
+        for line in f["f"].splitlines():
             nr_neighbours, count = line.strip("\n").split(" ")
             d[int(nr_neighbours)] = int(count)
 

--- a/multiqc/modules/samtools/markdup.py
+++ b/multiqc/modules/samtools/markdup.py
@@ -1,5 +1,6 @@
 # coding: utf-8
-""" MultiQC submodule to parse output from Samtools markdup """
+"""MultiQC submodule to parse output from Samtools markdup"""
+
 import json
 import logging
 import re
@@ -28,7 +29,7 @@ class MarkdupReportMixin:
 
         for f in self.find_log_files("samtools/markdup_txt"):
             raw_d = dict()
-            for line in f["contents_lines"]:
+            for line in f["f"].splitlines():
                 if ":" in line:
                     key, value = line.split(":")
                     try:

--- a/multiqc/modules/xenome/xenome.py
+++ b/multiqc/modules/xenome/xenome.py
@@ -1,4 +1,4 @@
-""" MultiQC module to parse log output from Xenome Classify """
+"""MultiQC module to parse log output from Xenome Classify"""
 
 from collections import defaultdict
 
@@ -74,7 +74,7 @@ class MultiqcModule(BaseMultiqcModule):
         """
         s_name = f["s_name"]
 
-        lines = iter(f["contents_lines"])
+        lines = iter(f["f"].splitlines())
         try:
             detail_percents, detail_counts = self._parse_xenome_section(lines, "Statistics")
             summary_percents, summary_counts = self._parse_xenome_section(lines, "Summary")


### PR DESCRIPTION
A few modules use `f["content_lines"]`, which is dangerous as this field is only collected for file search to match contents, and contains only the first 1000 lines of the file. 

This can be refactored better if we separate file search from module run, but for now adding linting linting to prevent the use of `f["content_lines"]` in the modules.