### PR TITLE
FastQC: add option to ignore FastQC quality thresholds

### DIFF
--- a/docs/modules/fastqc.md
+++ b/docs/modules/fastqc.md
@@ -147,3 +147,14 @@ report_section_order:
   fastqc_status_checks:
     order: -1000
 ```
+
+### Showing FastQC status checks
+
+FastQC uses thresholds to mark samples as "pass", "warn" or "fail" for various checks.
+If you prefer the MultiQC module to ignore those thresholds, and use standard MultiQC
+colors for samples instead, use the following config:
+
+```yaml
+fastqc_config:
+  status_checks: false
+```

--- a/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
+++ b/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
@@ -70,7 +70,6 @@ function fastqc_module(module_element, module_key) {
     $.each(fastqc_seq_content[module_key], function (s_name, data) {
       // rename sample names
       var orig_s_name = s_name;
-      var t_status = fastqc_passfails[module_key]["per_base_sequence_content"][s_name];
       $.each(window.mqc_rename_f_texts, function (idx, f_text) {
         if (window.mqc_rename_regex_mode) {
           var re = new RegExp(f_text, "g");
@@ -80,7 +79,10 @@ function fastqc_module(module_element, module_key) {
         }
       });
       orig_s_names[s_name] = orig_s_name;
-      sample_statuses[s_name] = t_status;
+      if (fastqc_passfails.length !== 0) {
+        let t_status = fastqc_passfails[module_key]["per_base_sequence_content"][s_name];
+        sample_statuses[s_name] = t_status;
+      }
       p_data[s_name] = JSON.parse(JSON.stringify(data)); // clone data
 
       var hide_sample = false;
@@ -96,7 +98,7 @@ function fastqc_module(module_element, module_key) {
           }
         }
       }
-      if (window.mqc_hide_mode == "show") {
+      if (window.mqc_hide_mode === "show") {
         hide_sample = !hide_sample;
       }
       if (!hide_sample) {
@@ -110,7 +112,7 @@ function fastqc_module(module_element, module_key) {
       .find("#fastqc_seq_heatmap_div .samples-hidden-warning, #fastqc_seq_heatmap_div .fastqc-heatmap-no-samples")
       .remove();
     module_element.find("#fastqc_seq_heatmap_div .hc-plot-wrapper").show();
-    if (num_samples == 0) {
+    if (num_samples === 0) {
       module_element.find("#fastqc_seq_heatmap_div .hc-plot-wrapper").hide();
       module_element
         .find("#fastqc_seq_heatmap_div")
@@ -127,7 +129,7 @@ function fastqc_module(module_element, module_key) {
             </div>',
       );
     }
-    if (num_samples == 0) {
+    if (num_samples === 0) {
       return;
     }
 

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -71,7 +71,6 @@ function fastqc_module(module_element, module_key) {
     $.each(fastqc_seq_content[module_key], function (s_name, data) {
       // rename sample names
       var orig_s_name = s_name;
-      var t_status = fastqc_passfails[module_key]["per_base_sequence_content"][s_name];
       $.each(window.mqc_rename_f_texts, function (idx, f_text) {
         if (window.mqc_rename_regex_mode) {
           var re = new RegExp(f_text, "g");
@@ -81,7 +80,10 @@ function fastqc_module(module_element, module_key) {
         }
       });
       orig_s_names[s_name] = orig_s_name;
-      sample_statuses[s_name] = t_status;
+      if (fastqc_passfails[module_key] !== undefined) {
+        let t_status = fastqc_passfails[module_key]["per_base_sequence_content"][s_name];
+        sample_statuses[s_name] = t_status;
+      }
       p_data[s_name] = JSON.parse(JSON.stringify(data)); // clone data
 
       var hide_sample = false;
@@ -97,7 +99,7 @@ function fastqc_module(module_element, module_key) {
           }
         }
       }
-      if (window.mqc_hide_mode == "show") {
+      if (window.mqc_hide_mode === "show") {
         hide_sample = !hide_sample;
       }
       if (!hide_sample) {
@@ -171,16 +173,18 @@ function fastqc_module(module_element, module_key) {
       ypos = 0;
       $.each(sample_names, function (idx, s_name) {
         // Add a 5px wide bar indicating either status or Highlight
-        var status = sample_statuses[s_name];
-        var s_col = "#999999";
-        if (status == "pass") {
-          s_col = "#5cb85c";
-        }
-        if (status == "warn") {
-          s_col = "#f0ad4e";
-        }
-        if (status == "fail") {
-          s_col = "#d9534f";
+        let s_col = "#999999";
+        if (sample_statuses[s_name] !== undefined) {
+          let status = sample_statuses[s_name];
+          if (status === "pass") {
+            s_col = "#5cb85c";
+          }
+          if (status === "warn") {
+            s_col = "#f0ad4e";
+          }
+          if (status === "fail") {
+            s_col = "#d9534f";
+          }
         }
         // Override status colour with highlights
         $.each(window.mqc_highlight_f_texts, function (idx, f_text) {
@@ -195,24 +199,24 @@ function fastqc_module(module_element, module_key) {
         ctx.fillRect(0, ypos + 1, 5, s_height - 2);
 
         // Plot the squares for the heatmap
-        var s = p_data[s_name];
-        var xpos = 6;
-        var last_bp = 0;
+        let s = p_data[s_name];
+        let xpos = 6;
+        let last_bp = 0;
         $.each(s, function (bp, v) {
           bp = parseInt(bp);
-          var this_width = (bp - last_bp) * (c_width / max_bp);
+          let this_width = (bp - last_bp) * (c_width / max_bp);
           last_bp = bp;
           // Very old versions of FastQC give counts instead of percentages
           if (v["t"] > 100) {
-            var t = v["t"] + v["a"] + v["c"] + v["g"];
+            let t = v["t"] + v["a"] + v["c"] + v["g"];
             v["t"] = (v["t"] / t) * 100;
             v["a"] = (v["a"] / t) * 100;
             v["c"] = (v["c"] / t) * 100;
             v["g"] = (v["g"] / t) * 100;
           }
-          var r = Math.round((v["t"] / 100) * 255);
-          var g = Math.round((v["a"] / 100) * 255);
-          var b = Math.round((v["c"] / 100) * 255);
+          let r = Math.round((v["t"] / 100) * 255);
+          let g = Math.round((v["a"] / 100) * 255);
+          let b = Math.round((v["c"] / 100) * 255);
           ctx.fillStyle = "rgb(" + r + "," + g + "," + b + ")";
           // width+1 to avoid vertical white line gaps.
           ctx.fillRect(xpos, ypos, this_width + 1, s_height);
@@ -289,16 +293,16 @@ function fastqc_module(module_element, module_key) {
       return false;
     }
     // Create it
-    var pid = $(this).closest("h3").attr("id");
-    var k = pid.substr(7);
+    let pid = $(this).closest("h3").attr("id");
+    let k = pid.substr(7);
     // Remove suffix when there are multiple fastqc sections
-    var n = k.indexOf("-");
-    k = k.substring(0, n != -1 ? n : k.length);
-    var vals = fastqc_passfails[module_key][k];
-    var passes = $(this).hasClass("progress-bar-success") ? true : false;
-    var warns = $(this).hasClass("progress-bar-warning") ? true : false;
-    var fails = $(this).hasClass("progress-bar-danger") ? true : false;
-    var pclass = "";
+    let n = k.indexOf("-");
+    k = k.substring(0, n !== -1 ? n : k.length);
+    let vals = fastqc_passfails[module_key][k];
+    let passes = $(this).hasClass("progress-bar-success") ? true : false;
+    let warns = $(this).hasClass("progress-bar-warning") ? true : false;
+    let fails = $(this).hasClass("progress-bar-danger") ? true : false;
+    let pclass = "";
     if (passes) {
       pclass = "success";
     }
@@ -308,13 +312,13 @@ function fastqc_module(module_element, module_key) {
     if (fails) {
       pclass = "danger";
     }
-    var samples = Array();
+    let samples = Array();
     $.each(vals, function (s_name, status) {
-      if (status == "pass" && passes) {
+      if (status === "pass" && passes) {
         samples.push(s_name);
-      } else if (status == "warn" && warns) {
+      } else if (status === "warn" && warns) {
         samples.push(s_name);
-      } else if (status == "fail" && fails) {
+      } else if (status === "fail" && fails) {
         samples.push(s_name);
       }
     });
@@ -346,11 +350,11 @@ function fastqc_module(module_element, module_key) {
   module_element.find(".fastqc_passfail_progress").on("click", ".fastqc-status-highlight", function (e) {
     e.preventDefault();
     // Get sample names and highlight colour
-    var samples = $(this).parent().parent().find(".popover-content").html().split("<br>");
-    var f_col = $("#mqc_colour_filter_color").val();
+    let samples = $(this).parent().parent().find(".popover-content").html().split("<br>");
+    let f_col = $("#mqc_colour_filter_color").val();
     // Add sample names to the toolbox
-    for (i = 0; i < samples.length; i++) {
-      var f_text = samples[i];
+    for (let i = 0; i < samples.length; i++) {
+      let f_text = samples[i];
       $("#mqc_col_filters").append(
         '<li style="color:' +
           f_col +
@@ -376,7 +380,7 @@ function fastqc_module(module_element, module_key) {
   module_element.find(".fastqc_passfail_progress").on("click", ".fastqc-status-hideothers", function (e) {
     e.preventDefault();
     // Get sample names
-    var samples = $(this).parent().parent().find(".popover-content").html().split("<br>");
+    let samples = $(this).parent().parent().find(".popover-content").html().split("<br>");
     // Check if we're already hiding anything, remove after confirm if so
     if ($("#mqc_hidesamples_filters li").length > 0) {
       if (!confirm($("#mqc_hidesamples_filters li").length + " Hide filters already exist - discard?")) {
@@ -389,8 +393,8 @@ function fastqc_module(module_element, module_key) {
     $('.mqc_hidesamples_showhide[value="show"]').prop("checked", true);
     $("#mqc_hidesamples .mqc_regex_mode .re_mode").removeClass("on").addClass("off").text("off");
     // Add sample names to the toolbox
-    for (i = 0; i < samples.length; i++) {
-      var f_text = samples[i];
+    for (let i = 0; i < samples.length; i++) {
+      let f_text = samples[i];
       $("#mqc_hidesamples_filters").append(
         '<li><input class="f_text" value="' +
           f_text +
@@ -412,7 +416,7 @@ function fastqc_module(module_element, module_key) {
   module_element.find("#fastqc_per_base_sequence_content_export_btn").click(function (e) {
     e.preventDefault();
     // In case of repeated modules: #fastqc_per_base_sequence_content_plot, #fastqc_per_base_sequence_content_plot-1, ..
-    var plot_id = module_element.find(".fastqc_per_base_sequence_content_plot").attr("id");
+    let plot_id = module_element.find(".fastqc_per_base_sequence_content_plot").attr("id");
     // Tick only this plot in the toolbox and slide out
     $("#mqc_export_selectplots input").prop("checked", false);
     $('#mqc_export_selectplots input[value="' + plot_id + '"]').prop("checked", true);
@@ -438,48 +442,42 @@ function fastqc_module(module_element, module_key) {
   // Seq Content heatmap mouse rollover
   module_element.find("#fastqc_seq_heatmap").mousemove(function (e) {
     // Replace the heading above the heatmap
-    var pos = findPos(this);
-    var x = e.pageX - pos.x + 3;
-    var y = e.pageY - pos.y;
+    let pos = findPos(this);
+    let x = e.pageX - pos.x + 3;
+    let y = e.pageY - pos.y;
 
     // Get label from y position
-    var idx = Math.floor(y / s_height);
-    var s_name = sample_names[idx];
-    var orig_s_name = orig_s_names[sample_names[idx]];
+    let idx = Math.floor(y / s_height);
+    let s_name = sample_names[idx];
+    let orig_s_name = orig_s_names[sample_names[idx]];
     if (s_name === undefined) {
       return false;
     }
 
     // Show the pass/warn/fail status heading for this sample
-    var s_status = sample_statuses[s_name];
-    var s_status_class = "label-default";
-    if (s_status == "pass") {
+    let s_status = sample_statuses[s_name];
+    let s_status_class = "label-default";
+    if (s_status === "pass") {
       s_status_class = "label-success";
     }
-    if (s_status == "warn") {
+    if (s_status === "warn") {
       s_status_class = "label-warning";
     }
-    if (s_status == "fail") {
+    if (s_status === "fail") {
       s_status_class = "label-danger";
     }
-    module_element
-      .find("#fastqc_per_base_sequence_content_plot_div .s_name")
-      .html(
-        '<span class="glyphicon glyphicon-info-sign"></span> ' +
-          s_name +
-          ' <span class="label s_status ' +
-          s_status_class +
-          '">' +
-          s_status +
-          "</span>",
-      );
+    let sampleLabel = '<span class="glyphicon glyphicon-info-sign"></span> ' + s_name;
+    if (s_status !== undefined) {
+      sampleLabel += ' <span class="label s_status ' + s_status_class + '">' + s_status + "</span>";
+    }
+    module_element.find("#fastqc_per_base_sequence_content_plot_div .s_name").html(sampleLabel);
 
     // Update the key with the raw data for this position
-    var hover_bp = Math.max(1, Math.floor((x / c_width) * max_bp));
-    var thispoint = fastqc_seq_content[module_key][orig_s_name][hover_bp];
+    let hover_bp = Math.max(1, Math.floor((x / c_width) * max_bp));
+    let thispoint = fastqc_seq_content[module_key][orig_s_name][hover_bp];
     if (!thispoint) {
-      var nearestkey = 0;
-      var guessdata = null;
+      let nearestkey = 0;
+      let guessdata = null;
       $.each(fastqc_seq_content[module_key][orig_s_name], function (bp, v) {
         bp = parseInt(bp);
         if (bp < hover_bp && bp > nearestkey) {
@@ -517,12 +515,12 @@ function fastqc_module(module_element, module_key) {
   module_element.find("#fastqc_seq_heatmap").click(function (e) {
     e.preventDefault();
     // Get label from y position
-    var pos = findPos(this);
-    var x = e.pageX - pos.x;
-    var y = e.pageY - pos.y;
-    var idx = Math.floor(y / s_height);
-    var s_name = sample_names[idx];
-    var orig_s_name = orig_s_names[sample_names[idx]];
+    let pos = findPos(this);
+    let x = e.pageX - pos.x;
+    let y = e.pageY - pos.y;
+    let idx = Math.floor(y / s_height);
+    let s_name = sample_names[idx];
+    let orig_s_name = orig_s_names[sample_names[idx]];
     if (orig_s_name !== undefined) {
       plot_single_seqcontent(s_name);
     }
@@ -530,7 +528,7 @@ function fastqc_module(module_element, module_key) {
   module_element.on("click", ".fastqc_seqcontent_single_prevnext", function (e) {
     e.preventDefault();
     // Find next / prev sample name
-    var idx = sample_names.indexOf(current_single_plot);
+    let idx = sample_names.indexOf(current_single_plot);
     if ($(this).data("action") === "next") {
       idx++;
     } else {
@@ -542,16 +540,16 @@ function fastqc_module(module_element, module_key) {
     if (idx >= sample_names.length) {
       idx = 0;
     }
-    var s_name = sample_names[idx];
-    var orig_s_name = orig_s_names[sample_names[idx]];
+    let s_name = sample_names[idx];
+    let orig_s_name = orig_s_names[sample_names[idx]];
     current_single_plot = s_name;
     // Prep the new plot data
-    var plot_data = [[], [], [], []];
-    var bases = Object.keys(fastqc_seq_content[module_key][orig_s_name]).sort(function (a, b) {
+    let plot_data = [[], [], [], []];
+    let bases = Object.keys(fastqc_seq_content[module_key][orig_s_name]).sort(function (a, b) {
       return a - b;
     });
-    for (i = 0; i < bases.length; i++) {
-      var base = fastqc_seq_content[module_key][orig_s_name][bases[i]]["base"].toString().split("-");
+    for (let i = 0; i < bases.length; i++) {
+      let base = fastqc_seq_content[module_key][orig_s_name][bases[i]]["base"].toString().split("-");
       base = parseFloat(base[0]);
       plot_data[0].push([base, fastqc_seq_content[module_key][orig_s_name][bases[i]]["t"]]);
       plot_data[1].push([base, fastqc_seq_content[module_key][orig_s_name][bases[i]]["c"]]);
@@ -580,20 +578,20 @@ function fastqc_module(module_element, module_key) {
 
   function plot_single_seqcontent(s_name) {
     current_single_plot = s_name;
-    var orig_s_name = orig_s_names[s_name];
-    var data = fastqc_seq_content[module_key][orig_s_name];
-    var plot_data = [
+    let orig_s_name = orig_s_names[s_name];
+    let data = fastqc_seq_content[module_key][orig_s_name];
+    let plot_data = [
       { name: "% T", data: [] },
       { name: "% C", data: [] },
       { name: "% A", data: [] },
       { name: "% G", data: [] },
     ];
-    var bases = Object.keys(data).sort(function (a, b) {
+    let bases = Object.keys(data).sort(function (a, b) {
       return a - b;
     });
-    for (i = 0; i < bases.length; i++) {
-      var d = bases[i];
-      var base = data[d]["base"].toString().split("-");
+    for (let i = 0; i < bases.length; i++) {
+      let d = bases[i];
+      let base = data[d]["base"].toString().split("-");
       base = parseFloat(base[0]);
       plot_data[0]["data"].push({ x: base, y: data[d]["t"], name: data[d]["base"] });
       plot_data[1]["data"].push({ x: base, y: data[d]["c"], name: data[d]["base"] });
@@ -603,9 +601,9 @@ function fastqc_module(module_element, module_key) {
 
     // Create plot div if it doesn't exist, and hide overview
     if (module_element.find("#fastqc_sequence_content_single_wrapper").length === 0) {
-      var plot_div = module_element.find("#fastqc_per_base_sequence_content_plot_div");
+      let plot_div = module_element.find("#fastqc_per_base_sequence_content_plot_div");
       plot_div.slideUp();
-      var newplot =
+      let newplot =
         '<div id="fastqc_sequence_content_single_wrapper"> \
             <div id="fastqc_sequence_content_single_controls">\
                 <button class="btn btn-primary btn-sm" id="fastqc_sequence_content_single_back">Back to overview heatmap</button> \
@@ -667,7 +665,7 @@ function fastqc_module(module_element, module_key) {
 // Find the position of the mouse cursor over the canvas
 // http://stackoverflow.com/questions/6735470/get-pixel-color-from-canvas-on-mouseover
 function findPos(obj) {
-  var curleft = 0,
+  let curleft = 0,
     curtop = 0;
   if (obj.offsetParent) {
     do {

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -1,5 +1,4 @@
-""" MultiQC module to parse output from FastQC
-"""
+"""MultiQC module to parse output from FastQC"""
 
 ############################################################
 ######  LOOKING FOR AN EXAMPLE OF HOW MULTIQC WORKS?  ######
@@ -7,7 +6,6 @@
 #### Stop! This is one of the most complicated modules. ####
 #### Have a look at Kallisto for a simpler example.     ####
 ############################################################
-
 
 import io
 import json
@@ -112,32 +110,37 @@ class MultiqcModule(BaseMultiqcModule):
         # Add to the general statistics table
         self.fastqc_general_stats()
 
+        status_checks = getattr(config, "fastqc_config", {}).get("status_checks", True)
+
         # Add the statuses to the intro for multiqc_fastqc.js JavaScript to pick up
         statuses = dict()
-        for s_name in self.fastqc_data:
-            for section, status in self.fastqc_data[s_name]["statuses"].items():
-                try:
-                    statuses[section][s_name] = status
-                except KeyError:
-                    statuses[section] = {s_name: status}
+        if status_checks:
+            for s_name in self.fastqc_data:
+                for section, status in self.fastqc_data[s_name]["statuses"].items():
+                    try:
+                        statuses[section][s_name] = status
+                    except KeyError:
+                        statuses[section] = {s_name: status}
+
         self.intro += '<script type="application/json" class="fastqc_passfails">{}</script>'.format(
             json.dumps([self.anchor.replace("-", "_"), statuses])
         )
-
-        self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
+        if status_checks:
+            self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
 
         # Now add each section in order
         self.read_count_plot()
-        self.sequence_quality_plot()
-        self.per_seq_quality_plot()
+        self.sequence_quality_plot(status_checks)
+        self.per_seq_quality_plot(status_checks)
         self.sequence_content_plot()
-        self.gc_content_plot()
-        self.n_content_plot()
-        self.seq_length_dist_plot()
-        self.seq_dup_levels_plot()
+        self.gc_content_plot(status_checks)
+        self.n_content_plot(status_checks)
+        self.seq_length_dist_plot(status_checks)
+        self.seq_dup_levels_plot(status_checks)
         self.overrepresented_sequences()
-        self.adapter_content_plot()
-        self.status_heatmap()
+        self.adapter_content_plot(status_checks)
+        if status_checks:
+            self.status_heatmap()
 
     def parse_fastqc_report(self, file_contents, s_name=None, f=None):
         """Takes contents from a fastq_data.txt file and parses out required
@@ -396,7 +399,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=bargraph.plot(pdata, pcats, pconfig),
         )
 
-    def sequence_quality_plot(self):
+    def sequence_quality_plot(self, status_checks=True):
         """Create the HTML for the phred quality score plot"""
 
         data = dict()
@@ -421,13 +424,19 @@ class MultiqcModule(BaseMultiqcModule):
             "xmin": 0,
             "xDecimals": False,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}",
-            "colors": self.get_status_cols("per_base_sequence_quality"),
-            "yPlotBands": [
-                {"from": 28, "to": 100, "color": "#c3e6c3"},
-                {"from": 20, "to": 28, "color": "#e6dcc3"},
-                {"from": 0, "to": 20, "color": "#e6c3c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_base_sequence_quality"),
+                    "yPlotBands": [
+                        {"from": 28, "to": 100, "color": "#c3e6c3"},
+                        {"from": 20, "to": 28, "color": "#e6dcc3"},
+                        {"from": 0, "to": 20, "color": "#e6c3c3"},
+                    ],
+                }
+            )
+
         self.add_section(
             name="Sequence Quality Histograms",
             anchor="fastqc_per_base_sequence_quality",
@@ -447,7 +456,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot(data, pconfig),
         )
 
-    def per_seq_quality_plot(self):
+    def per_seq_quality_plot(self, status_checks=True):
         """Create the HTML for the per sequence quality score plot"""
 
         data = dict()
@@ -470,14 +479,19 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "xmin": 0,
             "xDecimals": False,
-            "colors": self.get_status_cols("per_sequence_quality_scores"),
             "tt_label": "<b>Phred {point.x}</b>: {point.y} reads",
-            "xPlotBands": [
-                {"from": 28, "to": 100, "color": "#c3e6c3"},
-                {"from": 20, "to": 28, "color": "#e6dcc3"},
-                {"from": 0, "to": 20, "color": "#e6c3c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_sequence_quality_scores"),
+                    "xPlotBands": [
+                        {"from": 28, "to": 100, "color": "#c3e6c3"},
+                        {"from": 20, "to": 28, "color": "#e6dcc3"},
+                        {"from": 0, "to": 20, "color": "#e6c3c3"},
+                    ],
+                }
+            )
         self.add_section(
             name="Per Sequence Quality Scores",
             anchor="fastqc_per_sequence_quality_scores",
@@ -591,7 +605,7 @@ class MultiqcModule(BaseMultiqcModule):
             content=html,
         )
 
-    def gc_content_plot(self):
+    def gc_content_plot(self, status_checks=True):
         """Create the HTML for the FastQC GC content plot"""
 
         data = dict()
@@ -624,12 +638,17 @@ class MultiqcModule(BaseMultiqcModule):
             "xmax": 100,
             "xmin": 0,
             "tt_label": "<b>{point.x}% GC</b>: {point.y}",
-            "colors": self.get_status_cols("per_sequence_gc_content"),
             "data_labels": [
                 {"name": "Percentages", "ylab": "Percentage", "tt_suffix": "%"},
                 {"name": "Counts", "ylab": "Count", "tt_suffix": ""},
             ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_sequence_gc_content"),
+                }
+            )
 
         # Try to find and plot a theoretical GC line
         theoretical_gc = None
@@ -709,7 +728,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot([data_norm, data], pconfig),
         )
 
-    def n_content_plot(self):
+    def n_content_plot(self, status_checks=True):
         """Create the HTML for the per base N content plot"""
 
         data = dict()
@@ -734,14 +753,19 @@ class MultiqcModule(BaseMultiqcModule):
             "y_minrange": 5,
             "ymin": 0,
             "xmin": 0,
-            "colors": self.get_status_cols("per_base_n_content"),
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}%",
-            "y_bands": [
-                {"from": 20, "to": 100, "color": "#e6c3c3"},
-                {"from": 5, "to": 20, "color": "#e6dcc3"},
-                {"from": 0, "to": 5, "color": "#c3e6c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("per_base_n_content"),
+                    "y_bands": [
+                        {"from": 20, "to": 100, "color": "#e6c3c3"},
+                        {"from": 5, "to": 20, "color": "#e6dcc3"},
+                        {"from": 0, "to": 5, "color": "#c3e6c3"},
+                    ],
+                }
+            )
 
         self.add_section(
             name="Per Base N Content",
@@ -762,7 +786,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=linegraph.plot(data, pconfig),
         )
 
-    def seq_length_dist_plot(self):
+    def seq_length_dist_plot(self, status_checks):
         """Create the HTML for the Sequence Length Distribution plot"""
 
         data = dict()
@@ -800,9 +824,14 @@ class MultiqcModule(BaseMultiqcModule):
                 "ylab": "Read Count",
                 "xlab": "Sequence Length (bp)",
                 "ymin": 0,
-                "colors": self.get_status_cols("sequence_length_distribution"),
                 "tt_label": "<b>{point.x} bp</b>: {point.y}",
             }
+            if status_checks:
+                pconfig.update(
+                    {
+                        "colors": self.get_status_cols("sequence_length_distribution"),
+                    }
+                )
             self.add_section(
                 name="Sequence Length Distribution",
                 anchor="fastqc_sequence_length_distribution",
@@ -811,7 +840,7 @@ class MultiqcModule(BaseMultiqcModule):
                 plot=linegraph.plot(data, pconfig),
             )
 
-    def seq_dup_levels_plot(self):
+    def seq_dup_levels_plot(self, status_checks):
         """Create the HTML for the Sequence Duplication Levels plot"""
 
         data = dict()
@@ -841,10 +870,15 @@ class MultiqcModule(BaseMultiqcModule):
             "xlab": "Sequence Duplication Level",
             "ymax": 100 if max_dupval <= 100.0 else None,
             "ymin": 0,
-            "colors": self.get_status_cols("sequence_duplication_levels"),
             "tt_decimals": 2,
             "tt_suffix": "%",
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "colors": self.get_status_cols("sequence_duplication_levels"),
+                }
+            )
 
         self.add_section(
             name="Sequence Duplication Levels",
@@ -1037,7 +1071,7 @@ class MultiqcModule(BaseMultiqcModule):
             ),
         )
 
-    def adapter_content_plot(self):
+    def adapter_content_plot(self, status_checks=True):
         """Create the HTML for the FastQC adapter plot"""
 
         data = dict()
@@ -1072,12 +1106,17 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}%",
             "hide_empty": True,
-            "y_bands": [
-                {"from": 20, "to": 100, "color": "#e6c3c3"},
-                {"from": 5, "to": 20, "color": "#e6dcc3"},
-                {"from": 0, "to": 5, "color": "#c3e6c3"},
-            ],
         }
+        if status_checks:
+            pconfig.update(
+                {
+                    "y_bands": [
+                        {"from": 20, "to": 100, "color": "#e6c3c3"},
+                        {"from": 5, "to": 20, "color": "#e6dcc3"},
+                        {"from": 0, "to": 5, "color": "#c3e6c3"},
+                    ],
+                }
+            )
 
         if len(data) > 0:
             plot_html = linegraph.plot(data, pconfig)


### PR DESCRIPTION
Add an option to ignore FastQC quality thresholds and turn FastQC into a standard MultiQC module:

```yaml
fastqc_config:
  status_checks: false
```

Fixes https://github.com/MultiQC/MultiQC/issues/2483