### PR TITLE
qc3C: fix detecting sname for relative path

### DIFF
--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -1,5 +1,4 @@
-""" MultiQC module to parse output from qc3C """
-
+"""MultiQC module to parse output from qc3C"""
 
 import itertools
 import json
@@ -844,7 +843,7 @@ class MultiqcModule(BaseMultiqcModule):
             log.warning(f"Could not parse qc3C JSON: '{f['fn']}'")
             return
 
-        s_name = self.clean_s_name(os.path.basename(f["root"]), f, root=os.path.dirname(f["root"]))
+        s_name = self.clean_s_name(os.path.basename(os.path.abspath(f["root"])), f, root=os.path.dirname(f["root"]))
         if s_name in self.qc3c_data:
             log.debug(f"Duplicate sample name found! Overwriting: {f['s_name']}")
 


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2500

The `qc3C` module takes the sample name from the parent folder name. However, if the analysis dir is `.`, the `f["root"]` becomes `.` as well, and `basename(".")` is just `"."`:

```
cd test_data/data/modules/qc3C/bam_out/DRR177157
multiqc -fv .
# sample name is just "." instead of DRR177157
```

Fix this by taking the absolute path first.