### PR TITLE
Faster LZ compression by code refactoring and a faster bit by bit writer.

### DIFF
--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -93,13 +93,12 @@ def _compress(uncompressed):
             context_w = context_wc
         else:
             if context_w in context_dictionaryToCreate:
+                value = ord(context_w[0])
                 if ord(context_w[0]) < 256:
                     context_data.write(0, context_numBits)
-                    value = ord(context_w[0])
                     context_data.write(value, 8)
                 else:
                     context_data.write(1, context_numBits)
-                    value = ord(context_w[0])
                     context_data.write(value, 16)
                 context_enlargeIn -= 1
                 if context_enlargeIn == 0:
@@ -122,13 +121,12 @@ def _compress(uncompressed):
     # Output the code for w.
     if context_w != "":
         if context_w in context_dictionaryToCreate:
+            value = ord(context_w[0])
             if ord(context_w[0]) < 256:
                 context_data.write(0, context_numBits)
-                value = ord(context_w[0])
                 context_data.write(value, 8)
             else:
                 context_data.write(1, context_numBits)
-                value = ord(context_w[0])
                 context_data.write(value, 16)
             context_enlargeIn -= 1
             if context_enlargeIn == 0:
@@ -145,7 +143,6 @@ def _compress(uncompressed):
         context_numBits += 1
 
     # Mark the end of the stream
-    value = 2
     context_data.write(2, context_numBits)
 
     return context_data.getvalue()

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -44,7 +44,7 @@ class BitWriter:
             value >>= 1
             bits_remaining -= 1
             if bits_remaining == 0:
-                self.buffer.write(struct.pack("B", self.bit_store))
+                self.buffer.write(struct.pack("B", bit_store))
                 bit_store = 0
                 bits_remaining = 8
         self.bit_store = bit_store

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -116,7 +116,7 @@ def _compress(uncompressed):
         else:
             if context_w in context_dictionaryToCreate:
                 value = ord(context_w[0])
-                if ord(context_w[0]) < 256:
+                if value < 256:
                     context_data.write(0, context_numBits)
                     context_data.write(value, 8)
                 else:
@@ -144,7 +144,7 @@ def _compress(uncompressed):
     if context_w != "":
         if context_w in context_dictionaryToCreate:
             value = ord(context_w[0])
-            if ord(context_w[0]) < 256:
+            if value < 256:
                 context_data.write(0, context_numBits)
                 context_data.write(value, 8)
             else:

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -34,15 +34,21 @@ class BitWriter:
         self.buffer = io.BytesIO()
 
     def write(self, value: int, bits: int):
+        # Retrieve values from self to save later. This saves a lot of
+        # dictionary lookups.
+        bit_store = self.bit_store
+        bits_remaining = self.bits_remaining
         for i in range(bits):
-            self.bit_store <<= 1
-            self.bit_store |= value & 1
+            bit_store <<= 1
+            bit_store |= value & 1
             value >>= 1
-            self.bits_remaining -= 1
-            if self.bits_remaining == 0:
+            bits_remaining -= 1
+            if bits_remaining == 0:
                 self.buffer.write(struct.pack("B", self.bit_store))
-                self.bit_store = 0
-                self.bits_remaining = 8
+                bit_store = 0
+                bits_remaining = 8
+        self.bit_store = bit_store
+        self.bits_remaining = bits_remaining
 
     def getvalue(self):
         value = self.buffer.getvalue()

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -111,7 +111,7 @@ def _compress(uncompressed):
                 context_data.write(value, context_numBits)
             context_enlargeIn -= 1
             if context_enlargeIn == 0:
-                context_enlargeIn = math.pow(2, context_numBits)
+                context_enlargeIn = 1 << context_numBits
                 context_numBits += 1
 
             # Add wc to the dictionary.
@@ -132,7 +132,7 @@ def _compress(uncompressed):
                 context_data.write(value, 16)
             context_enlargeIn -= 1
             if context_enlargeIn == 0:
-                context_enlargeIn = math.pow(2, context_numBits)
+                context_enlargeIn = 1 << context_numBits
                 context_numBits += 1
             del context_dictionaryToCreate[context_w]
         else:
@@ -141,7 +141,7 @@ def _compress(uncompressed):
 
     context_enlargeIn -= 1
     if context_enlargeIn == 0:
-        context_enlargeIn = math.pow(2, context_numBits)
+        context_enlargeIn = 1 << context_numBits
         context_numBits += 1
 
     # Mark the end of the stream

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -9,7 +9,7 @@ lz-string for python v1.0.4 (https://github.com/gkovacs/lz-string-python)
 
 License: https://github.com/gkovacs/lz-string-python/blob/master/LICENSE.md
 """
-
+import io
 import math
 from dataclasses import dataclass
 
@@ -37,6 +37,9 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
     if uncompressed is None:
         return ""
 
+    if isinstance(uncompressed, bytes):
+        uncompressed = uncompressed.decode()
+
     context_dictionary = {}
     context_dictionaryToCreate = {}
     context_c = ""
@@ -45,15 +48,11 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
     context_enlargeIn = 2  # Compensate for the first entry which should not count
     context_dictSize = 3
     context_numBits = 2
-    context_data = []
+    context_data = io.StringIO()
     context_data_val = 0
     context_data_position = 0
 
-    for ii in range(len(uncompressed)):
-        if isinstance(uncompressed, (bytes)):
-            context_c = chr(uncompressed[ii])
-        else:
-            context_c = uncompressed[ii]
+    for context_c in uncompressed:
         if context_c not in context_dictionary:
             context_dictionary[context_c] = context_dictSize
             context_dictSize += 1
@@ -69,7 +68,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                         context_data_val = context_data_val << 1
                         if context_data_position == bitsPerChar - 1:
                             context_data_position = 0
-                            context_data.append(getCharFromInt(context_data_val))
+                            context_data.write(getCharFromInt(context_data_val))
                             context_data_val = 0
                         else:
                             context_data_position += 1
@@ -78,7 +77,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                         context_data_val = (context_data_val << 1) | (value & 1)
                         if context_data_position == bitsPerChar - 1:
                             context_data_position = 0
-                            context_data.append(getCharFromInt(context_data_val))
+                            context_data.write(getCharFromInt(context_data_val))
                             context_data_val = 0
                         else:
                             context_data_position += 1
@@ -90,7 +89,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                         context_data_val = (context_data_val << 1) | value
                         if context_data_position == bitsPerChar - 1:
                             context_data_position = 0
-                            context_data.append(getCharFromInt(context_data_val))
+                            context_data.write(getCharFromInt(context_data_val))
                             context_data_val = 0
                         else:
                             context_data_position += 1
@@ -100,7 +99,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                         context_data_val = (context_data_val << 1) | (value & 1)
                         if context_data_position == bitsPerChar - 1:
                             context_data_position = 0
-                            context_data.append(getCharFromInt(context_data_val))
+                            context_data.write(getCharFromInt(context_data_val))
                             context_data_val = 0
                         else:
                             context_data_position += 1
@@ -116,7 +115,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                     context_data_val = (context_data_val << 1) | (value & 1)
                     if context_data_position == bitsPerChar - 1:
                         context_data_position = 0
-                        context_data.append(getCharFromInt(context_data_val))
+                        context_data.write(getCharFromInt(context_data_val))
                         context_data_val = 0
                     else:
                         context_data_position += 1
@@ -140,7 +139,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                     context_data_val = context_data_val << 1
                     if context_data_position == bitsPerChar - 1:
                         context_data_position = 0
-                        context_data.append(getCharFromInt(context_data_val))
+                        context_data.write(getCharFromInt(context_data_val))
                         context_data_val = 0
                     else:
                         context_data_position += 1
@@ -149,7 +148,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                     context_data_val = (context_data_val << 1) | (value & 1)
                     if context_data_position == bitsPerChar - 1:
                         context_data_position = 0
-                        context_data.append(getCharFromInt(context_data_val))
+                        context_data.write(getCharFromInt(context_data_val))
                         context_data_val = 0
                     else:
                         context_data_position += 1
@@ -160,7 +159,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                     context_data_val = (context_data_val << 1) | value
                     if context_data_position == bitsPerChar - 1:
                         context_data_position = 0
-                        context_data.append(getCharFromInt(context_data_val))
+                        context_data.write(getCharFromInt(context_data_val))
                         context_data_val = 0
                     else:
                         context_data_position += 1
@@ -170,7 +169,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                     context_data_val = (context_data_val << 1) | (value & 1)
                     if context_data_position == bitsPerChar - 1:
                         context_data_position = 0
-                        context_data.append(getCharFromInt(context_data_val))
+                        context_data.write(getCharFromInt(context_data_val))
                         context_data_val = 0
                     else:
                         context_data_position += 1
@@ -186,7 +185,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
                 context_data_val = (context_data_val << 1) | (value & 1)
                 if context_data_position == bitsPerChar - 1:
                     context_data_position = 0
-                    context_data.append(getCharFromInt(context_data_val))
+                    context_data.write(getCharFromInt(context_data_val))
                     context_data_val = 0
                 else:
                     context_data_position += 1
@@ -203,7 +202,7 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
         context_data_val = (context_data_val << 1) | (value & 1)
         if context_data_position == bitsPerChar - 1:
             context_data_position = 0
-            context_data.append(getCharFromInt(context_data_val))
+            context_data.write(getCharFromInt(context_data_val))
             context_data_val = 0
         else:
             context_data_position += 1
@@ -213,12 +212,12 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
     while True:
         context_data_val = context_data_val << 1
         if context_data_position == bitsPerChar - 1:
-            context_data.append(getCharFromInt(context_data_val))
+            context_data.write(getCharFromInt(context_data_val))
             break
         else:
             context_data_position += 1
 
-    return "".join(context_data)
+    return context_data.getvalue()
 
 
 def _decompress(length, resetValue, getNextValue):

--- a/multiqc/utils/lzstring.py
+++ b/multiqc/utils/lzstring.py
@@ -384,7 +384,7 @@ class LZString:
     def compressToBase64(uncompressed):
         if uncompressed is None:
             return ""
-        res = _compress(uncompressed, 6, lambda a: keyStrBase64[a])
+        res = _compress(uncompressed, 6, keyStrBase64.__getitem__)
         # To produce valid Base64
         end = len(res) % 4
         if end > 0:

--- a/scripts/lz-compress.py
+++ b/scripts/lz-compress.py
@@ -1,0 +1,10 @@
+import sys
+
+from multiqc.utils import lzstring
+
+
+if __name__ == "__main__":
+    lz_string = lzstring.LZString()
+    with open(sys.argv[1], "rt") as f:
+        data = f.read()
+    print(lz_string.compressToBase64(data), end="")

--- a/scripts/lz-decompress.py
+++ b/scripts/lz-decompress.py
@@ -1,0 +1,10 @@
+import sys
+
+from multiqc.utils import lzstring
+
+
+if __name__ == "__main__":
+    lz_string = lzstring.LZString()
+    with open(sys.argv[1], "rt") as f:
+        data = f.read()
+    print(lz_string.decompressFromBase64(data), end="")


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

This PR does the following. 
- Remove all encode methods except base64 for lzstring. It is the only encoding used by MultiQC.
- Refactor the lz encoding function to return bytes. Any other encodings can be added later, such as base64 encoding with the    base64 module.
- Remove duplicated for-loops in the lz encoding functions that were meant to write a bitstream. Create a separate bitwriter class and call its write function instead. 
- Optimize the bitwriter to write only 64-bit chunks of data and use python tricks to only require two python function calls for the bit reversal. This is in contrast to the old code, which did a bit by bit reversal using shifts. 
- Some minor javascript-esque code was replaced with pythonic code. (For example, not using indexes to iterate over sequences).
- EDIT: Add the context state variables to the bitwriter, to further simplify the code.

For the multiqc-test-data report this has a significant impact on speed (40% reduction in runtime) on my PC. EDIT: here are the times as reported by multiqc. Before: `5.10s: Compressing report data`, after: `2.64s: Compressing report data`.


The remaining runtime is mainly the dictionary lookup. The LZ compression stores a huge dictionary, and accessing such a huge dictionary is very slow, as it does not fit in the CPU cache. This cannot be optimized without changing the algorithm.

NOTE: I also made #2504 , because gzip is much superior for the use case. Except that I cannot get it to work with the javascript. So I made this instead.

