### PR TITLE
Sort filepatterns for faster searching

### DIFF
--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -4,6 +4,7 @@ helper functions to generate markup for report. """
 
 
 import fnmatch
+import functools
 import inspect
 import io
 import json
@@ -219,6 +220,45 @@ def get_filelist(run_module_names):
                 spatterns[3][key] = sps
         else:
             spatterns[0][key] = sps
+
+        # sort patterns for faster access. File searches with less lines or
+        # smaller filesizes go first.
+        def max_on_pattern_key(x, pattern_key=""):
+            key, sps = x
+            num_lines = 0
+            for sp in sps:
+                num_lines = max(num_lines, sp.get(pattern_key, 0))
+            return num_lines
+
+        new_spatterns = [{}, {}, {}, {}, {}, {}, {}]
+        new_spatterns[0] = spatterns[0]  # Only filename matching
+        new_spatterns[1] = dict(
+            sorted(
+                ((key, sps) for key, sps in spatterns[1].items()),
+                key=functools.partial(max_on_pattern_key, pattern_key="num_lines"),
+            )
+        )
+        new_spatterns[2] = dict(
+            sorted(
+                ((key, sps) for key, sps in spatterns[2].items()),
+                key=functools.partial(max_on_pattern_key, pattern_key="max_filesize"),
+            )
+        )
+        new_spatterns[3] = spatterns[3]
+        new_spatterns[4] = dict(
+            sorted(
+                ((key, sps) for key, sps in spatterns[4].items()),
+                key=functools.partial(max_on_pattern_key, pattern_key="num_lines"),
+            )
+        )
+        new_spatterns[5] = dict(
+            sorted(
+                ((key, sps) for key, sps in spatterns[5].items()),
+                key=functools.partial(max_on_pattern_key, pattern_key="max_filesize"),
+            )
+        )
+        new_spatterns[6] = spatterns[6]
+        spatterns = new_spatterns
 
     if len(ignored_patterns) > 0:
         logger.debug(f"Ignored {len(ignored_patterns)} search patterns as didn't match running modules.")


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

Search patterns are already divided into categories to ensure the simplest to match patterns are run first. 

I noticed that the "*.json" files run particularly long. It turns out that that `afterqc` has 10_000 `num_lines`. Sequali, fastp, and cutadapt have 10, 50 and 100 `num_lines` respectively. It seems only fair that these are run first.

Speed as reported by multiqc:
before on the test-data dir: `9.90s: Searching files`
after on the test-data dir: `9.47s: Searching files`
before on a dir with 800 sequali only reports: `3.48s: Searching files`
after on a dir with 800 sequali only reports: `0.38s: Searching files`

As the sequali author, I would be very happy if this gets merged ;-). Also on very slow filesystems such as NFS the differences would be more significant. 

I know a posted a lot of PRs today, but it seemed better to have these all separately evaluated. This is the last of that series.

