### PR TITLE
Speed up all modules by tackling two performance bottlenecks

### DIFF
--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -218,7 +218,7 @@ def smooth_line_data(data: Dict[str, Dict], numpoints: int) -> Dict[str, Dict[in
             continue
 
         binsize = (len(d) - 1) / (numpoints - 1)
-        first_element_indices = [round(binsize * i) for i in range(numpoints)]
+        first_element_indices = {round(binsize * i) for i in range(numpoints)}
         smoothed_d = {x: y for i, (x, y) in enumerate(d.items()) if i in first_element_indices}
         smoothed_data[s_name] = smoothed_d
 

--- a/multiqc/utils/mqc_colour.py
+++ b/multiqc/utils/mqc_colour.py
@@ -2,11 +2,13 @@
 Helper functions to manipulate colours and colour scales
 """
 
+import functools
 import hashlib
 
 # Default logger will be replaced by caller
 import logging
 import re
+from typing import Tuple
 
 import numpy as np
 import spectra
@@ -14,6 +16,12 @@ import spectra
 from multiqc.utils import config, report
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(128)  # 34 unique colourmaps found using multiqc-test-data
+def cached_spectra_colour_scale(colours: Tuple[str]):
+    """Caches spectra color scale calls as these are expensive"""
+    return spectra.scale(list(colours))
 
 
 class mqc_colour_scale(object):
@@ -401,7 +409,8 @@ class mqc_colour_scale(object):
                     val_float = min(val_float, self.maxval)
 
                 domain_nums = list(np.linspace(self.minval, self.maxval, len(self.colours)))
-                my_scale = spectra.scale(self.colours).domain(domain_nums)
+                my_spectra_scale = cached_spectra_colour_scale(tuple(self.colours))
+                my_scale = my_spectra_scale.domain(domain_nums)
 
                 # Lighten colours
                 thecolour = spectra.rgb(*[rgb_converter(v) for v in my_scale(val_float).rgb])


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

I used the py-spy profiler. My previous PRs did not focus on the module code, as it looked like as if modules were slow or fast on their own accord. However I realized that some common code must be used because of the class inheritance. I did a more careful look at the profile and found a real stinker in the lineplot code that was triggered in multiple modules.

In a dict comprehension it was checked if something was a member of a list. List member checking time is proportional to the length of the list. I converted the list to a set. This one liner fix made a run on multiqc/test-data noticably faster. 

The other one I found was the `spectra.scale` call from the plotly library was expensive. I did some investigation of the input data and found that only 34 unique lists of colours were used, so I used a functools.lru_cache to simply cache the call. This also removed a further 10% of module runtime (on top of the previous savings). 

These are really minor changes codewise but have quite some benefit:

before:
```
|           multiqc |  - 9.59s: Searching files
|           multiqc |  - 8.41s: Running modules
|           multiqc |  - 5.04s: Compressing report data
```

After:
```
|           multiqc |  - 9.64s: Searching files
|           multiqc |  - 6.48s: Running modules
|           multiqc |  - 4.99s: Compressing report data
```

So a roughly 20 decrease in runtime for all module code.