### PR TITLE
Stream json data to a file to  save 30% of the memory.

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1177,7 +1177,7 @@ def _write_json_dump() -> None:
 
     if config.development:
         with open(os.path.join(config.data_dir, "multiqc_plots.js"), "w") as f:
-            f.write(json.dumps(report.plot_data))
+            json.dump(report.plot_data, f)
 
 
 def _write_html_and_data(

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -1,7 +1,6 @@
-""" MultiQC report module. Holds the output from each
+"""MultiQC report module. Holds the output from each
 module. Is available to subsequent modules. Contains
-helper functions to generate markup for report. """
-
+helper functions to generate markup for report."""
 
 import fnmatch
 import inspect
@@ -22,7 +21,7 @@ import yaml
 from multiqc.utils import lzstring
 
 from . import config
-from .util_functions import replace_defaultdicts
+from .util_functions import replace_defaultdicts, dump_json
 
 logger = config.logger
 
@@ -486,9 +485,10 @@ def data_sources_tofile():
     fn = f"multiqc_sources.{config.data_format_extensions[config.data_format]}"
     with io.open(os.path.join(config.data_dir, fn), "w", encoding="utf-8") as f:
         if config.data_format == "json":
-            jsonstr = json.dumps(data_sources, indent=4, ensure_ascii=False)
-            print(jsonstr.encode("utf-8", "ignore").decode("utf-8"), file=f)
+            json.dump(data_sources, f, indent=4, ensure_ascii=False)
         elif config.data_format == "yaml":
+            # Unlike JSON, YAML represents defaultdicts as objects, so need to convert
+            # them to normal dicts
             yaml.dump(replace_defaultdicts(data_sources), f, default_flow_style=False)
         else:
             lines = [["Module", "Section", "Sample Name", "Source"]]
@@ -509,11 +509,12 @@ def dois_tofile(modules_output):
             dois[mod.anchor] = mod.doi
     # Write to a file
     fn = f"multiqc_citations.{config.data_format_extensions[config.data_format]}"
-    with io.open(os.path.join(config.data_dir, fn), "w", encoding="utf-8") as f:
+    with open(os.path.join(config.data_dir, fn), "w") as f:
         if config.data_format == "json":
-            jsonstr = json.dumps(dois, indent=4, ensure_ascii=False)
-            print(jsonstr.encode("utf-8", "ignore").decode("utf-8"), file=f)
+            json.dump(dois, f, indent=4, ensure_ascii=False)
         elif config.data_format == "yaml":
+            # Unlike JSON, YAML represents defaultdicts as objects, so need to convert
+            # them to normal dicts
             yaml.dump(replace_defaultdicts(dois), f, default_flow_style=False)
         else:
             body = ""
@@ -575,24 +576,11 @@ def save_htmlid(html_id, skiplint=False):
 
 
 def compress_json(data):
-    """Take a Python data object. Convert to JSON and compress using lzstring"""
-    json_string = json.dumps(data).encode("utf-8", "ignore").decode("utf-8")
-    json_string = sanitise_json(json_string)
+    """
+    Take a Python data object. Convert to JSON and compress using lzstring
+    """
+    # Using the dump_json helper that removes NaNs and Infinity thst can crash
+    # the browser when parsing the JSON.
+    json_string = dump_json(data)
     x = lzstring.LZString()
     return x.compressToBase64(json_string)
-
-
-def sanitise_json(json_string):
-    """
-    The Python json module uses a bunch of values which are valid JavaScript
-    but invalid JSON. These crash the browser when parsing the JSON.
-    Nothing in the MultiQC front-end uses these values, so instead we just
-    do a find-and-replace for them and switch them with `null`, which works fine.
-
-    Side effect: Any string values that include the word "Infinity"
-    (case-sensitive) will have it switched for "null". Hopefully that doesn't happen
-    a lot, otherwise we'll have to do this in a more complicated manner.
-    """
-    json_string = re.sub(r"\bNaN\b", "null", json_string)
-    json_string = re.sub(r"\b-?Infinity\b", "null", json_string)
-    return json_string

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -1,6 +1,5 @@
 """MultiQC Utility functions, used in a variety of places."""
 
-import io
 import json
 import logging
 from collections import defaultdict, OrderedDict
@@ -120,7 +119,7 @@ def write_data_file(
     # Add relevant file extension to filename, save file.
     fn = f"{fn}.{config.data_format_extensions[data_format]}"
     fpath = os.path.join(config.data_dir, fn)
-    with io.open(fpath, "w", encoding="utf-8", errors="ignore") as f:
+    with open(fpath, "w", encoding="utf-8", errors="ignore") as f:
         if data_format == "json":
             dump_json(data, f, indent=4, ensure_ascii=False)
         elif data_format == "yaml":
@@ -187,7 +186,8 @@ def choose_emoji():
 def dump_json(data, filehandle=None, **kwargs):
     """
     Recursively replace non-JSON-conforming NaNs and lambdas with None.
-    Note that a custom JSONEncoder would have worked for lambdas, but not for NaNs: https://stackoverflow.com/a/28640141
+    Note that a custom JSONEncoder would have worked for lambdas, but not for NaNs:
+    https://stackoverflow.com/a/28640141
     """
 
     # Recursively replace NaNs with None
@@ -198,6 +198,8 @@ def dump_json(data, filehandle=None, **kwargs):
             return [replace_nan(v) for v in obj]
         elif isinstance(obj, set):
             return {replace_nan(v) for v in obj}
+        elif isinstance(obj, tuple):
+            return tuple(replace_nan(v) for v in obj)
         elif callable(obj):
             return None
         elif isinstance(obj, float) and math.isnan(obj):
@@ -276,6 +278,8 @@ def replace_defaultdicts(data):
             return [_replace(v) for v in obj]
         elif isinstance(obj, set):
             return {_replace(v) for v in obj}
+        elif isinstance(obj, tuple):
+            return tuple(_replace(v) for v in obj)
         return obj
 
     return _replace(data)

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -120,10 +120,9 @@ def write_data_file(
     # Add relevant file extension to filename, save file.
     fn = f"{fn}.{config.data_format_extensions[data_format]}"
     fpath = os.path.join(config.data_dir, fn)
-    with io.open(fpath, "w", encoding="utf-8") as f:
+    with io.open(fpath, "w", encoding="utf-8", errors="ignore") as f:
         if data_format == "json":
-            jsonstr = dump_json(data, indent=4, ensure_ascii=False)
-            print(jsonstr.encode("utf-8", "ignore").decode("utf-8"), file=f)
+            dump_json(data, f, indent=4, ensure_ascii=False)
         elif data_format == "yaml":
             yaml.dump(replace_defaultdicts(data), f, default_flow_style=False)
         elif body:
@@ -185,7 +184,7 @@ def choose_emoji():
     return "mag"
 
 
-def dump_json(data, **kwargs):
+def dump_json(data, filehandle=None, **kwargs):
     """
     Recursively replace non-JSON-conforming NaNs and lambdas with None.
     Note that a custom JSONEncoder would have worked for lambdas, but not for NaNs: https://stackoverflow.com/a/28640141
@@ -205,7 +204,10 @@ def dump_json(data, **kwargs):
             return None
         return obj
 
-    return json.dumps(replace_nan(data), **kwargs)
+    if filehandle:
+        json.dump(replace_nan(data), filehandle, **kwargs)
+    else:
+        return json.dumps(replace_nan(data), **kwargs)
 
 
 def multiqc_dump_json(report):


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

I noticed that using --no-data-dir saved more than 300 MiB when working with the multiqc/test-data. This is odd. Turns out the internal data is serialized into a string before it is written. Using a streaming method saves the memory.

before:
```
/usr/bin/time bash -c "multiqc --force ../test-data/ 2>/dev/null"
26.09user 3.37system 0:28.28elapsed 104%CPU (0avgtext+0avgdata 1030072maxresident)k
320inputs+558480outputs (5major+327488minor)pagefaults 0swaps
```

After:
```
/usr/bin/time bash -c "multiqc --force ../test-data/ 2>/dev/null"
25.82user 3.61system 0:28.29elapsed 104%CPU (0avgtext+0avgdata 674052maxresident)k
464inputs+558440outputs (5major+356765minor)pagefaults 0swaps
```

I would love to reduce the memory further, but a lot of the memory profile shows stuff that has already been touched by other PRs. As stated before the LZ compression is a major culprit, using 200 MiB. If it could be replaced with gzip that usage would simply vanish. Another culprit is reading and storing lines from files, but that is already touched upon by #2505 and I suspect that that will have much better memory use as lines are not saved permanently. I added the profile report.
[memray-flamegraph-multiqc.9194.html.zip](https://github.com/MultiQC/MultiQC/files/15137625/memray-flamegraph-multiqc.9194.html.zip)


This change is pretty small. While I do not like that it can dump to file (returning None) and dump to string (returning str) it is good that the replace_nan function is still used.

