### PR TITLE
Reduce memory requirement of MultiQC main functions

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1398,13 +1398,15 @@ def _write_html_and_data(
 
         # Use jinja2 to render the template and overwrite
         config.analysis_dir = [os.path.realpath(d) for d in config.analysis_dir]
-        report_output = j_template.render(report=report, config=config)
+        report_output_generator = j_template.generate(report=report, config=config)
         if filename == "stdout":
-            print(report_output.encode("utf-8"), file=sys.stdout)
+            for report_block in report_output_generator:
+                sys.stdout.write(report_block)
         else:
             try:
                 with io.open(config.output_fn, "w", encoding="utf-8") as f:
-                    print(report_output, file=f)
+                    for report_block in report_output_generator:
+                        f.write(report_block)
             except IOError as e:
                 raise IOError(f"Could not print report to '{config.output_fn}' - {IOError(e)}")
 

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -15,6 +15,7 @@ import plotly.graph_objects as go
 
 from multiqc.plots.plotly import check_plotly_version
 from multiqc.utils import mqc_colour, config, report
+from multiqc.utils.util_functions import compress_number_lists_for_json
 
 logger = logging.getLogger(__name__)
 
@@ -395,18 +396,20 @@ class Plot(ABC):
 
     def dump_for_javascript(self) -> Dict:
         """Serialise the plot data to pick up in plotly-js"""
-        return {
-            "id": self.id,
-            "layout": self.layout.to_plotly_json(),
-            "datasets": [d.dump_for_javascript() for d in self.datasets],
-            "plot_type": self.plot_type.value,
-            "pct_axis_update": self.pct_axis_update,
-            "axis_controlled_by_switches": self._axis_controlled_by_switches,
-            "p_active": self.p_active,
-            "l_active": self.l_active,
-            "square": self.pconfig.get("square"),
-            "config": self.pconfig,  # for megaqc
-        }
+        return compress_number_lists_for_json(
+            {
+                "id": self.id,
+                "layout": self.layout.to_plotly_json(),
+                "datasets": [d.dump_for_javascript() for d in self.datasets],
+                "plot_type": self.plot_type.value,
+                "pct_axis_update": self.pct_axis_update,
+                "axis_controlled_by_switches": self._axis_controlled_by_switches,
+                "p_active": self.p_active,
+                "l_active": self.l_active,
+                "square": self.pconfig.get("square"),
+                "config": self.pconfig,  # for megaqc
+            }
+        )
 
     @abstractmethod
     def save_data_file(self, data: BaseDataset) -> None:

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -703,8 +703,10 @@ def compress_json(data):
     Take a Python data object. Convert to JSON and compress using gzip.
     Represent in base64 format.
     """
-    json_string = dump_json(data)
-    json_bytes = json_string.encode("utf-8")
-    json_gzip = gzip.compress(json_bytes)
-    base64_bytes = base64.b64encode(json_gzip)
+    # Stream to an in-memory buffer rather than compressing the big string
+    # at once. This saves memory.
+    buffer = io.BytesIO()
+    gzip_buffer = gzip.open(buffer, "wt", encoding="utf-8", compresslevel=9)
+    dump_json(data, gzip_buffer)
+    base64_bytes = base64.b64encode(buffer.getvalue())
     return base64_bytes.decode("ascii")

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -706,7 +706,7 @@ def compress_json(data):
     # Stream to an in-memory buffer rather than compressing the big string
     # at once. This saves memory.
     buffer = io.BytesIO()
-    gzip_buffer = gzip.open(buffer, "wt", encoding="utf-8", compresslevel=9)
-    dump_json(data, gzip_buffer)
+    with gzip.open(buffer, "wt", encoding="utf-8", compresslevel=9) as gzip_buffer:
+        dump_json(data, gzip_buffer)
     base64_bytes = base64.b64encode(buffer.getvalue())
     return base64_bytes.decode("ascii")

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -216,7 +216,7 @@ def dump_json(data, filehandle=None, **kwargs):
 
         def default(self, o):
             if isinstance(o, array.array):
-                return o.tolist()
+                return replace_nan(o.tolist())
             return super().default(o)
 
     if filehandle:

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -186,7 +186,7 @@ def choose_emoji():
 def dump_json(data, filehandle=None, **kwargs):
     """
     Recursively replace non-JSON-conforming NaNs and lambdas with None.
-    Note that a custom JSONEncoder would have worked for lambdas, but not for NaNs:
+    Note that a custom JSONEncoder would not work for NaNs:
     https://stackoverflow.com/a/28640141
     """
 
@@ -204,8 +204,6 @@ def dump_json(data, filehandle=None, **kwargs):
             return [replace_nan(v) for v in obj]
         elif isinstance(obj, dict):
             return {k: replace_nan(v) for k, v in obj.items()}
-        elif callable(obj):
-            return None
         return obj
 
     class JsonEncoderWithArraySupport(json.JSONEncoder):
@@ -219,6 +217,8 @@ def dump_json(data, filehandle=None, **kwargs):
         def default(self, o):
             if isinstance(o, array.array):
                 return replace_nan(o.tolist())
+            if callable(o):
+                return None
             return super().default(o)
 
     if filehandle:

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -1,5 +1,4 @@
 """MultiQC Utility functions, used in a variety of places."""
-
 import json
 import logging
 from collections import defaultdict, OrderedDict
@@ -252,7 +251,10 @@ def multiqc_dump_json(report):
                 elif s == "report":
                     d = {f"{s}_{k}": getattr(report, k)}
                 if d:
-                    dump_json(d, ensure_ascii=False)  # Test that exporting to JSON works
+                    with open(os.devnull, "wt") as f:
+                        # Test that exporting to JSON works. Write to
+                        # /dev/null so no memory is required.
+                        dump_json(d, f, ensure_ascii=False)
                     exported_data.update(d)
             except (TypeError, KeyError, AttributeError) as e:
                 log.warning(f"Couldn't export data key '{s}.{k}': {e}")

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -190,19 +190,21 @@ def dump_json(data, filehandle=None, **kwargs):
     https://stackoverflow.com/a/28640141
     """
 
-    # Recursively replace NaNs with None
     def replace_nan(obj):
-        if isinstance(obj, dict):
-            return {k: replace_nan(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
+        """
+        Recursively replace NaNs and Infinities with None
+        """
+        # Do checking in order of likelyhood of occurence
+        if isinstance(obj, float):
+            if math.isnan(obj) or math.isinf(obj):
+                return None
+            return obj
+        elif isinstance(obj, (list, tuple, set)):
+            # JSON only knows list so convert tuples and sets to list.
             return [replace_nan(v) for v in obj]
-        elif isinstance(obj, set):
-            return {replace_nan(v) for v in obj}
-        elif isinstance(obj, tuple):
-            return tuple(replace_nan(v) for v in obj)
+        elif isinstance(obj, dict):
+            return {k: replace_nan(v) for k, v in obj.items()}
         elif callable(obj):
-            return None
-        elif isinstance(obj, float) and math.isnan(obj):
             return None
         return obj
 

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -1,4 +1,5 @@
 """MultiQC Utility functions, used in a variety of places."""
+import array
 import json
 import logging
 from collections import defaultdict, OrderedDict
@@ -205,10 +206,23 @@ def dump_json(data, filehandle=None, **kwargs):
             return None
         return obj
 
+    class JsonEncoderWithArraySupport(json.JSONEncoder):
+        """
+        Encode array.array instances to list. Use the default method
+        for this as it gets called only when an array instance is encountered
+        and is then immediately serialized into a string. This saves memory
+        compared to unpacking all arrays to list at once.
+        """
+
+        def default(self, o):
+            if isinstance(o, array.array):
+                return o.tolist()
+            return super().default(o)
+
     if filehandle:
-        json.dump(replace_nan(data), filehandle, **kwargs)
+        json.dump(replace_nan(data), filehandle, cls=JsonEncoderWithArraySupport, **kwargs)
     else:
-        return json.dumps(replace_nan(data), **kwargs)
+        return json.dumps(replace_nan(data), cls=JsonEncoderWithArraySupport, **kwargs)
 
 
 def multiqc_dump_json(report):
@@ -285,3 +299,57 @@ def replace_defaultdicts(data):
         return obj
 
     return _replace(data)
+
+
+def compress_number_lists_for_json(obj):
+    """
+    Take an object that should be JSON and compress all the lists of integer
+    and lists of float as array.array. This saves space and the arrays can
+    easily be converted back again, using the dump_json function above.
+
+    The technical explanation:
+    A python list is an array of pointers to python objects:
+    {
+        list metadata including length
+        a pointer to an array of pointers: [
+            PyObject *
+            PyObject *
+            etc.
+        ]
+    }
+    A python float is very simple and takes 24 bytes.
+    {
+        PyTypeObject *type
+        Py_ssize_t refcount
+        double the actual floating point.
+    }
+    A python integer is slightly more complicated, but similar to the float. It
+    takes 28 bytes for 32-bit data, 32 bytes for 64-bit, 36 bytes for 96-bit etc.
+
+    An array.array is more simple.
+    {
+        array metadata including length
+        a pointer to an array of machine values: [
+            double,
+            double,
+            double,
+            etc.
+        ]
+        more metadata
+    }
+    Using 8-byte machine values rather than Python objects saves thus
+    24 bytes per float.
+    """
+    if isinstance(obj, (list, tuple)):
+        try:
+            # Try integer list first, because it does not accept floats.
+            return array.array("q", obj)
+        except TypeError:
+            pass
+        try:
+            return array.array("d", obj)
+        except TypeError:
+            return [compress_number_lists_for_json(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: compress_number_lists_for_json(v) for k, v in obj.items()}
+    return obj


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

This PR fixes some of the areas where a lot of data was stored in memory unnecessarily. A lot of the patterns involved writing to an in-memory block and then dumping it at once. This PR streams in these places. 

To make the multiqc plot data more scalable, every time a plot is generated the data is saved as an `array.array` where possible. This approximately halves the memory requirements for the plot data. You could argue whether this particular save is worth it. If the in-memory plot data is 125 MB, then it saves about 60 megabytes. Not exactly a showstopper. On the other hand, very little code is needed to enact this change. 

On the test data provided via the google drive, the PR saves about 100 MiB of memory. This is not a big deal.

The bulk of the memory is used by the modules. The reason why this is the case is that some modules store their data as an object in during class initialization. The data remains alive as long as the module object remains alive. This is not desirable. 
A solution would be to refactor MultiQC to build the report module by module (using an iterator) and in that way discard module objects that are no longer used. That way the memory usage is no longer determined by adding all modules together, but by the worst performing module. 

The worst performing module in the test data set is no doubt FastQC. Which parses all the reports and stores all the data in memory leading to an enormous amount of memory being allocated. 
