### PR TITLE
Bclconvert: show message when no undetermined reads instead of error

### DIFF
--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -182,22 +182,30 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Add section with undetermined barcodes
         if create_undetermined_barplots:
-            self.add_section(
-                name="Undetermined barcodes by lane",
-                anchor="undetermine_by_lane",
-                description="Undetermined barcodes by lanes",
-                plot=bargraph.plot(
-                    self.get_bar_data_from_undetermined(bclconvert_by_lane),
-                    None,
-                    {
-                        "id": "bclconvert_undetermined",
-                        "title": "bclconvert: Undetermined barcodes by lane",
-                        "ylab": "Count",
-                        "use_legend": True,
-                        "tt_suffix": "reads",
-                    },
-                ),
-            )
+            undetermined_data = self.get_bar_data_from_undetermined(bclconvert_by_lane)
+            if undetermined_data:
+                self.add_section(
+                    name="Undetermined barcodes by lane",
+                    anchor="undetermine_by_lane",
+                    description="Undetermined barcodes by lanes",
+                    plot=bargraph.plot(
+                        undetermined_data,
+                        None,
+                        {
+                            "id": "bclconvert_undetermined",
+                            "title": "bclconvert: Undetermined barcodes by lane",
+                            "ylab": "Count",
+                            "use_legend": True,
+                            "tt_suffix": "reads",
+                        },
+                    ),
+                )
+            else:
+                self.add_section(
+                    name="Undetermined barcodes by lane",
+                    anchor="undetermine_by_lane",
+                    content="<div class='alert alert-info'>No undetermined barcodes found</div>",
+                )
 
     @staticmethod
     @functools.lru_cache

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -21,7 +21,7 @@ def plot(
     cats_lists: List[List[Dict]],
     samples_lists: List[List[str]],
     pconfig: Dict,
-) -> Plot:
+) -> "BarPlot":
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param cats_lists: each dataset is a list of dicts with the keys: {name, color, data},


### PR DESCRIPTION
In Bclconvert, when no undetermined reads data found, show just an info message instead of a red error message:

Before:
![CleanShot 2024-05-02 at 03 00 31@2x](https://github.com/MultiQC/MultiQC/assets/1575412/af3b9178-f5ab-43ea-8fe9-8d468d2dde76)

Now:
![CleanShot 2024-05-02 at 03 00 15@2x](https://github.com/MultiQC/MultiQC/assets/1575412/da92e07c-0a4e-4428-9540-213a30a4d308)


Reproduced with this test data: https://github.com/MultiQC/test-data/pull/320