### PR TITLE
Fastp: when could not parse sample name from command (i.e. stdin), use filename and proceed

### DIFF
--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -192,7 +192,6 @@ class MultiqcModule(BaseMultiqcModule):
                     f"Falling back to extracting it from the file name: "
                     f"\"{f['fn']}\" -> \"{s_name}\""
                 )
-                return None, {}
 
         self.add_data_source(f, s_name)
         return s_name, parsed_json


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2527