### PR TITLE
Deprecate old `multiqc.utils.config` and `multiqc.utils.report`

### DIFF
--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -1,0 +1,12 @@
+import warnings
+
+# noinspection PyUnresolvedReferences
+from multiqc.config import *  # noqa: F403
+
+# Issue a deprecation warning
+warnings.warn(
+    "Importing 'config' from 'multiqc.utils' is deprecated and will be removed in a future release. "
+    "Please use 'from multiqc import config' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -1,0 +1,12 @@
+import warnings
+
+# noinspection PyUnresolvedReferences
+from multiqc.report import *  # noqa: F403
+
+# Issue a deprecation warning
+warnings.warn(
+    "Importing 'report' from 'multiqc.utils' is deprecated and will be removed in a future release. "
+    "Please use 'from multiqc import report' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
Support the old way and show a warning saying that `from multiqc import config, report` is now recommended.