### PR TITLE
Plot config validation: avoid `sys.exit()`, better deprecation messages

### DIFF
--- a/multiqc/core/exceptions.py
+++ b/multiqc/core/exceptions.py
@@ -1,5 +1,4 @@
 import logging
-from multiqc import config, report
 
 logger = logging.getLogger("multiqc")
 
@@ -10,16 +9,11 @@ class RunResult:
 
     * appropriate error code (e.g. 1 if a module broke, 0 on success)
     * error message if a module broke
-    * report instance
-    * config instance
-
     """
 
     def __init__(self, sys_exit_code: int = 0, message: str = ""):
         self.sys_exit_code = sys_exit_code
         self.message = message
-        self.report = report
-        self.config = config
 
 
 class RunError(Exception):

--- a/multiqc/core/exceptions.py
+++ b/multiqc/core/exceptions.py
@@ -3,19 +3,6 @@ import logging
 logger = logging.getLogger("multiqc")
 
 
-class RunResult:
-    """
-    Returned by a MultiQC run for interactive use. Contains the following information:
-
-    * appropriate error code (e.g. 1 if a module broke, 0 on success)
-    * error message if a module broke
-    """
-
-    def __init__(self, sys_exit_code: int = 0, message: str = ""):
-        self.sys_exit_code = sys_exit_code
-        self.message = message
-
-
 class RunError(Exception):
     """
     Used internally in `run` to pass errors from sub-steps.

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -83,15 +83,9 @@ def exec_modules(
                 logger.debug(msg)
             logger.debug(f"No samples found: {this_module}")
         except KeyboardInterrupt:
-            if clean_up:
-                shutil.rmtree(report.tmp_dir)
-            logger.critical(
-                "User Cancelled Execution!\n{eq}\n{tb}{eq}\n".format(eq=("=" * 60), tb=traceback.format_exc())
-                + "User Cancelled Execution!\nExiting MultiQC..."
-            )
-            sys.exit(1)
+            raise
         except PConfigValidationError:
-            sys.exit(f"{this_module}: invalid plot configuration, see errors above.")
+            raise
         except:  # noqa: E722
             if config.strict:
                 # Crash quickly in the strict mode. This can be helpful for interactive debugging of modules.

--- a/multiqc/core/init_log.py
+++ b/multiqc/core/init_log.py
@@ -85,115 +85,114 @@ def init_log():
     )
 
     debug_template = "[%(asctime)s] %(name)-50s [%(levelname)-7s]  %(message)s"
-
-    if util_functions.is_running_in_notebook() or os.getenv("PYCHARM_HOSTED") or os.getenv("CI"):
-        # Use coloredlogs as Rich is breaking output formatting
-        info_template = "%(module)18s | %(message)s"
-
-        # Set up the console logging stream
-        console = logging.StreamHandler(sys.stdout)
-        console.setLevel(log_level)
-        level_styles = coloredlogs.DEFAULT_LEVEL_STYLES
-        level_styles["debug"] = {"faint": True}
-        field_styles = coloredlogs.DEFAULT_FIELD_STYLES
-        field_styles["module"] = {"color": "blue"}
-        field_styles["name"] = {"color": "blue"}
-
-        if log_level == "DEBUG":
-            if config.no_ansi is True:
-                console.setFormatter(logging.Formatter(debug_template))
-            else:
-                console.setFormatter(
-                    coloredlogs.ColoredFormatter(
-                        fmt=debug_template, level_styles=level_styles, field_styles=field_styles
-                    )
-                )
-        else:
-            if config.no_ansi is True:
-                console.setFormatter(logging.Formatter(info_template))
-            else:
-                console.setFormatter(
-                    coloredlogs.ColoredFormatter(
-                        fmt=info_template, level_styles=level_styles, field_styles=field_styles
-                    )
-                )
-        logger.addHandler(console)
-
-        # Google Colab notebooks duplicate log messages without this, see
-        # https://stackoverflow.com/a/55877763/341474
-        logger.propagate = False
-
-        if not config.quiet:
-            # Print intro
-            if config.no_ansi is False:
-                BOLD = "\033[1m"
-                DIM = "\033[2m"
-                DARK_ORANGE = "\033[38;5;208m"  # ANSI code for dark orange color
-                RESET = "\033[0m"
-            else:
-                BOLD = ""
-                DIM = ""
-                DARK_ORANGE = ""
-                RESET = ""
-            emoji = util_functions.choose_emoji()
-            emoji = f" {emoji}" if emoji else ""
-            intro = f"{DARK_ORANGE}///{RESET} {BOLD}https://multiqc.info{RESET}{emoji} {DIM}v{config.version}{RESET}"
-            if not util_functions.is_running_in_notebook():
-                intro = f"\n{intro}\n"
-            print(intro)
-
-    else:
-        # Set up the console logging stream
-        console_handler = RichHandler(
-            level=log_level,
-            console=rich_console,
-            show_level=log_level == "DEBUG",
-            show_time=log_level == "DEBUG",
-            log_time_format="[%Y-%m-%d %H:%M:%S]",
-            markup=True,
-            omit_repeated_times=False,
-            show_path=False,
-        )
-
-        class DebugFormatter(logging.Formatter):
-            def format(self, record):
-                if record.levelno == logging.DEBUG:
-                    self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.debug]%(message)s[/]")
-                elif record.levelno == logging.WARNING:
-                    self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.warning]%(message)s[/]")
-                elif record.levelno == logging.ERROR:
-                    self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.error]%(message)s[/]")
-                elif record.levelno == logging.CRITICAL:
-                    self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.critical]%(message)s[/]")
-                else:
-                    self._style = logging.PercentStyle("[blue]%(name)-50s[/]  %(message)s")
-                return logging.Formatter.format(self, record)
-
-        class InfoFormatter(logging.Formatter):
-            def format(self, record):
-                if record.levelno == logging.WARNING:
-                    self._style = logging.PercentStyle("[blue]%(module)18s[/] | [logging.level.warning]%(message)s[/]")
-                elif record.levelno == logging.ERROR:
-                    self._style = logging.PercentStyle("[blue]%(module)18s[/] | [logging.level.error]%(message)s[/]")
-                else:
-                    self._style = logging.PercentStyle("[blue]%(module)18s[/] | %(message)s")
-                return logging.Formatter.format(self, record)
-
-        console_handler.setLevel(log_level)
-        if log_level == "DEBUG":
-            console_handler.setFormatter(DebugFormatter())
-        else:
-            console_handler.setFormatter(InfoFormatter())
-        logger.addHandler(console_handler)
-
-        if not config.quiet:
-            rich_console.print(f"\n{rich_click.rich_click.HEADER_TEXT}\n")
+    _setup_coloredlogs(log_level, logger, debug_template)
 
     # Now set up the file logging stream if we have a data directory
     file_handler = logging.FileHandler(log_tmp_fn, encoding="utf-8")
     file_handler.setLevel(logging.DEBUG)  # always DEBUG for the file
     file_handler.setFormatter(logging.Formatter(debug_template))
     logger.addHandler(file_handler)
+
+
+def _setup_coloredlogs(log_level, logger, debug_template):
+    # Use coloredlogs as Rich is breaking output formatting
+    info_template = "%(module)18s | %(message)s"
+
+    # Set up the console logging stream
+    console = logging.StreamHandler(sys.stdout)
+    console.setLevel(log_level)
+    level_styles = coloredlogs.DEFAULT_LEVEL_STYLES
+    level_styles["debug"] = {"faint": True}
+    field_styles = coloredlogs.DEFAULT_FIELD_STYLES
+    field_styles["module"] = {"color": "blue"}
+    field_styles["name"] = {"color": "blue"}
+
+    if log_level == "DEBUG":
+        if config.no_ansi is True:
+            console.setFormatter(logging.Formatter(debug_template))
+        else:
+            console.setFormatter(
+                coloredlogs.ColoredFormatter(fmt=debug_template, level_styles=level_styles, field_styles=field_styles)
+            )
+    else:
+        if config.no_ansi is True:
+            console.setFormatter(logging.Formatter(info_template))
+        else:
+            console.setFormatter(
+                coloredlogs.ColoredFormatter(fmt=info_template, level_styles=level_styles, field_styles=field_styles)
+            )
+    logger.addHandler(console)
+
+    # Google Colab notebooks duplicate log messages without this, see
+    # https://stackoverflow.com/a/55877763/341474
+    logger.propagate = False
+
+    if not config.quiet:
+        # Print intro
+        if config.no_ansi is False:
+            BOLD = "\033[1m"
+            DIM = "\033[2m"
+            DARK_ORANGE = "\033[38;5;208m"  # ANSI code for dark orange color
+            RESET = "\033[0m"
+        else:
+            BOLD = ""
+            DIM = ""
+            DARK_ORANGE = ""
+            RESET = ""
+        emoji = util_functions.choose_emoji()
+        emoji = f" {emoji}" if emoji else ""
+        intro = f"{DARK_ORANGE}///{RESET} {BOLD}https://multiqc.info{RESET}{emoji} {DIM}v{config.version}{RESET}"
+        if not util_functions.is_running_in_notebook():
+            intro = f"\n{intro}\n"
+        print(intro)
+
+
+def _setup_rich_handler(log_level, logger):
+    # Set up the console logging stream
+    console_handler = RichHandler(
+        level=log_level,
+        console=rich_console,
+        show_level=log_level == "DEBUG",
+        show_time=log_level == "DEBUG",
+        log_time_format="[%Y-%m-%d %H:%M:%S]",
+        markup=True,
+        omit_repeated_times=False,
+        show_path=False,
+    )
+
+    class DebugFormatter(logging.Formatter):
+        def format(self, record):
+            if record.levelno == logging.DEBUG:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.debug]%(message)s[/]")
+            elif record.levelno == logging.WARNING:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.warning]%(message)s[/]")
+            elif record.levelno == logging.ERROR:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.error]%(message)s[/]")
+            elif record.levelno == logging.CRITICAL:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  [logging.level.critical]%(message)s[/]")
+            else:
+                self._style = logging.PercentStyle("[blue]%(name)-50s[/]  %(message)s")
+            return logging.Formatter.format(self, record)
+
+    class InfoFormatter(logging.Formatter):
+        def format(self, record):
+            if record.levelno == logging.WARNING:
+                self._style = logging.PercentStyle("[blue]%(module)18s[/] | [logging.level.warning]%(message)s[/]")
+            elif record.levelno == logging.ERROR:
+                self._style = logging.PercentStyle("[blue]%(module)18s[/] | [logging.level.error]%(message)s[/]")
+            else:
+                self._style = logging.PercentStyle("[blue]%(module)18s[/] | %(message)s")
+            return logging.Formatter.format(self, record)
+
+    console_handler.setLevel(log_level)
+    if log_level == "DEBUG":
+        console_handler.setFormatter(DebugFormatter())
+    else:
+        console_handler.setFormatter(InfoFormatter())
+    logger.addHandler(console_handler)
+
+    if not config.quiet:
+        rich_console.print(f"\n{rich_click.rich_click.HEADER_TEXT}\n")
 
 
 def move_tmp_log():

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -5,17 +5,14 @@ import json
 import logging
 import os
 import re
-import sys
 from collections import defaultdict
 from typing import List, Dict
 
 import yaml
-from pydantic import ValidationError
 
 from multiqc import config, report
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
-from multiqc.plots import bargraph, violin, heatmap, linegraph, scatter, table, box
-from multiqc.plots.plotly.plot import PConfig, pconfig_validation_errors
+from multiqc.plots import bargraph, violin, heatmap, linegraph, scatter, table
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -326,37 +323,6 @@ class MultiqcModule(BaseMultiqcModule):
         # This needs overwriting again as it has already run on init
         if self.info or self.extra:
             self.intro = f"<p>{self.info}</p>{self.extra}"
-
-    @staticmethod
-    def validate_pconfig(pconfig: Dict, plot_type, c_id) -> PConfig:
-        try:
-            if plot_type == "bargraph":
-                return bargraph.BarPlotConfig(**pconfig)
-            if plot_type == "linegraph":
-                return linegraph.LinePlotConfig(**pconfig)
-            if plot_type == "box":
-                return box.BoxPlotConfig(**pconfig)
-            if plot_type == "scatter":
-                return scatter.ScatterConfig(**pconfig)
-            if plot_type == "heatmap":
-                return heatmap.HeatmapConfig(**pconfig)
-            if plot_type in ["violin", "beeswarm"]:
-                return violin.TableConfig(**pconfig)
-            if plot_type == "table":
-                return table.TableConfig(**pconfig)
-            else:
-                raise ValueError(f"Plot type '{plot_type}' not recognised")
-
-        except ValidationError as e:
-            print(e)
-            pass  # errors are already added into plot.pconfig_validation_errors by a custom validator
-
-        if pconfig_validation_errors:
-            msg = f'Error parsing configuration for heatmap plot "{c_id}":'
-            for error in pconfig_validation_errors:
-                msg += f"\n{error}"
-            log.error(msg)
-            sys.exit(1)
 
     def add_cc_section(self, c_id, mod):
         section_name = mod["config"].get("section_name", c_id.replace("_", " ").title())

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -21,7 +21,7 @@ from multiqc.core.file_search import file_search
 from multiqc.core.update_config import update_config, ClConfig
 from multiqc.core.version_check import check_version
 from multiqc.core.write_results import write_results
-from multiqc.core.exceptions import RunError, RunResult
+from multiqc.core.exceptions import RunError
 from multiqc.plots.plotly.plot import PConfigValidationError
 from multiqc.utils import util_functions
 
@@ -452,6 +452,19 @@ def run_cli(analysis_dir: Tuple[str], clean_up: bool, **kwargs):
 
     # End execution using the exit code returned from MultiQC
     sys.exit(result.sys_exit_code)
+
+
+class RunResult:
+    """
+    Returned by a MultiQC run for interactive use. Contains the following information:
+
+    * appropriate error code (e.g. 1 if a module broke, 0 on success)
+    * error message if a module broke
+    """
+
+    def __init__(self, sys_exit_code: int = 0, message: str = ""):
+        self.sys_exit_code = sys_exit_code
+        self.message = message
 
 
 def run(*analysis_dir, clean_up: bool, cfg: Optional[ClConfig] = None) -> RunResult:

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -30,12 +30,12 @@ class HeatmapConfig(PConfig):
     ycats_samples: bool = False
     square: bool = True
     colstops: List[List] = []
-    reverseColors: bool = Field(False, deprecated="use 'reverse_colors' instead")
+    reverseColors: bool = Field(False, deprecated="reverse_colors")
     reverse_colors: bool = False
-    decimalPlaces: int = Field(2, deprecated="use 'tt_decimals' instead")
+    decimalPlaces: int = Field(2, deprecated="tt_decimals")
     tt_decimals: int = 2
     legend: bool = True
-    datalabels: Optional[bool] = Field(None, deprecated="use 'display_values' instead")
+    datalabels: Optional[bool] = Field(None, deprecated="display_values")
     display_values: Optional[bool] = None
     angled_xticks: bool = True
 

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -21,20 +21,20 @@ class LinePlotConfig(PConfig):
     smooth_points: Optional[int] = None
     smooth_points_sumcounts: Optional[int] = None
     extra_series: Union[Dict[str, Any], List[Dict[str, Any]], List[List[Dict[str, Any]]], None] = None
-    xMinRange: Optional[Union[float, int]] = Field(None, deprecated="use 'x_minrange' instead")
-    yMinRange: Optional[Union[float, int]] = Field(None, deprecated="use 'y_minrange' instead")
+    xMinRange: Optional[Union[float, int]] = Field(None, deprecated="x_minrange")
+    yMinRange: Optional[Union[float, int]] = Field(None, deprecated="y_minrange")
     x_minrange: Optional[Union[float, int]] = None
     y_minrange: Optional[Union[float, int]] = None
-    xPlotBands: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="use 'x_bands' instead")
-    yPlotBands: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="use 'y_bands' instead")
-    xPlotLines: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="use 'x_lines' instead")
-    yPlotLines: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="use 'y_lines' instead")
+    xPlotBands: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="x_bands")
+    yPlotBands: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="y_bands")
+    xPlotLines: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="x_lines")
+    yPlotLines: Optional[List[Dict[str, Union[float, int, str]]]] = Field(None, deprecated="y_lines")
     x_bands: Optional[List[Dict[str, Union[float, int, str]]]] = None
     y_bands: Optional[List[Dict[str, Union[float, int, str]]]] = None
     x_lines: Optional[List[Dict[str, Union[float, int, str]]]] = None
     y_lines: Optional[List[Dict[str, Union[float, int, str]]]] = None
     style: Literal["lines", "lines+markers"] = "lines"
-    hide_zero_cats: Optional[bool] = Field(False, deprecated="use 'hide_empty' instead")
+    hide_zero_cats: Optional[bool] = Field(False, deprecated="hide_empty")
     hide_empty: bool = False
     colors: Dict[str, str] = {}
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -576,7 +576,8 @@ def search_files(run_module_names):
     for key in sorted(file_search_stats, key=file_search_stats.get, reverse=True):
         if "skipped_" in key and file_search_stats[key] > 0:
             summaries.append(f"{key}: {file_search_stats[key]}")
-    logger.debug(f"Summary of files that were skipped by the search: |{'|, |'.join(summaries)}|")
+    if summaries:
+        logger.debug(f"Summary of files that were skipped by the search: |{'|, |'.join(summaries)}|")
 
 
 def search_file(pattern, f: SearchFile, module_key):


### PR DESCRIPTION
- Remove dead code
- Remove `report` and `config` from `RunResult` and move `RunResult` to multiqc.py
- Print summary of skipped files only if there are any
- Always use `coloredlogs` (Rich strips square brackets that we need want to print in type hints in Pydantic error messages)
- Avoid `sys.exit()` and raise `PConfigValidationError` handled in `run()`
- Handle `KeyboardInterrupt` in `run()` as well
- Better Pydantic plot config deprecation messages
