### PR TITLE
Fix error when using default sort

### DIFF
--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -461,7 +461,7 @@ def _get_sortlist(dt: DataTable) -> str:
             idx = next(
                 idx
                 for idx, (_, k, header) in enumerate(headers)
-                if d["column"].lower() in [k.lower(), header["title"].lower()]
+                if d["column"].lower() in [k.lower(), header.title.lower()]
             )
         except StopIteration:
             logger.warning(


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

I am currently working on the sequali module and wanted to use sort. And then MultiQC crashed. Apparently sequali is the first user of defaultsort. (Cannot find other modules using it).

This is probably due to a refactor. header is not a dict, but it is an object (much better!) but this was forgotten in the refactor because no tool used it (yet). 