### PR TITLE
Sequali: allow paired-end data.

### DIFF
--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -429,7 +429,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot_data = {}
             for sample_name, sample_dict in data.items():
                 gc_dict = sample_dict.get(key)
-                if sample_dict is None:
+                if gc_dict is None:
                     continue
                 # Take the smoothened results here. Less resolution, but also less
                 # confusing at first glance.

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -114,20 +114,25 @@ class MultiqcModule(BaseMultiqcModule):
                 continue
             # Save memory by pruning the sample dict's unused keys.
             prune_sample_dict(sample_dict)
+            try:
+                meta = sample_dict["meta"]
+                filename1 = meta["filename"]
+                filename2 = meta.get("filename_read2")
+                if filename2:
+                    sample_name = self.clean_s_name([filename1, filename2])
+            except KeyError:
+                log.error("JSON file is not a proper Sequali report")
+                continue
             data[sample_name] = sample_dict
         if len(data) == 0:
             raise ModuleNoSamplesFound
         log.info(f"Found {len(data)} reports")
 
         for sample_name, sample_dict in data.items():
-            try:
-                sequali_version = sample_dict["meta"]["sequali_version"]
-                versions.add(sequali_version)
-                min_lengths.add(sample_dict["summary"]["minimum_length"])
-                max_lengths.add(sample_dict["summary"]["maximum_length"])
-            except KeyError:
-                log.error("JSON file is not a proper Sequali report")
-                continue
+            sequali_version = sample_dict["meta"]["sequali_version"]
+            versions.add(sequali_version)
+            min_lengths.add(sample_dict["summary"]["minimum_length"])
+            max_lengths.add(sample_dict["summary"]["maximum_length"])
             self.add_software_version(sequali_version, sample_name)
 
         summary_data = {sample_name: sample_dict["summary"] for sample_name, sample_dict in data.items()}

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -584,6 +584,7 @@ class MultiqcModule(BaseMultiqcModule):
             table_config = {
                 "id": "sequali_top_overrepresented_sequences_table" + id_suffix,
                 "title": "Sequali: top overrepresented sequences" + title_suffix,
+                "defaultsort": [{"column": "libraries_affected", "order": "desc"}],
             }
             self.add_section(
                 name="Top overrepresented sequences" + title_suffix,

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -55,19 +55,31 @@ def prune_sample_dict(sample_dict: Dict[str, Any]):
     Function to remove unused keys from the parsed data. This prevents loading
     them into memory long-term wich reduces memory usage.
     """
-    # This is a per sample data gathering of all the base qualities
-    # per position for a stacked bar plot to clearly see the distribution.
-    # Too hard to aggregate for MultiQC.
-    del sample_dict["per_position_quality_distribution"]
-    # Per tile quality is not analysed by multiqc and uses a lot of space
-    del sample_dict["per_tile_quality"]
-    # Nanopore metrics for pore data do not have modules yet
-    del sample_dict["nanopore_metrics"]
-    # Only the mean is used for the per position mean quality and spread data,
-    # so remove the rest of the data
-    percentiles_list = sample_dict["per_position_mean_quality_and_spread"]["percentiles"]
-    new_percentiles_list = [(percentile, values) for percentile, values in percentiles_list if percentile == "mean"]
-    sample_dict["per_position_mean_quality_and_spread"]["percentiles"] = new_percentiles_list
+    keys_to_delete = [
+        # This is a per sample data gathering of all the base qualities
+        # per position for a stacked bar plot to clearly see the distribution.
+        # Too hard to aggregate for MultiQC.
+        "per_position_quality_distribution",
+        "per_position_quality_distribution_read2",
+        "per_tile_quality",
+        # Per tile quality is not analysed by multiqc and uses a lot of space
+        "per_tile_quality_read2"
+        # Nanopore metrics for pore data do not have modules yet
+        "nanopore_metrics",
+    ]
+    for key in keys_to_delete:
+        if key in sample_dict:
+            del sample_dict[key]
+
+    for key in ("per_position_mean_quality_and_spread", "per_position_mean_quality_and_spread_read2"):
+        if key in sample_dict:
+            # Only the mean is used for the per position mean quality and spread data,
+            # so remove the rest of the data
+            percentiles_list = sample_dict[key]["percentiles"]
+            new_percentiles_list = [
+                (percentile, values) for percentile, values in percentiles_list if percentile == "mean"
+            ]
+            sample_dict[key]["percentiles"] = new_percentiles_list
 
 
 class MultiqcModule(BaseMultiqcModule):

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -680,6 +680,7 @@ class MultiqcModule(BaseMultiqcModule):
         plot_config = {
             "id": "sequali_most_common_adapters_read_1",
             "title": "Sequali: Most common adapters for read 1",
+            "defaultsort": [{"column": "Percentage of libraries with this adapter", "order": "desc"}],
         }
 
         self.add_section(
@@ -690,6 +691,7 @@ class MultiqcModule(BaseMultiqcModule):
         plot_config = {
             "id": "sequali_most_common_adapters_read_2",
             "title": "Sequali: Most common adapters for read 2",
+            "defaultsort": [{"column": "Percentage of libraries with this adapter", "order": "desc"}],
         }
 
         self.add_section(
@@ -700,6 +702,10 @@ class MultiqcModule(BaseMultiqcModule):
         plot_config = {
             "id": "sequali_adapter_content_from_overlap_table",
             "title": "Sequali: Adapter Content calculated from overlap",
+            "defaultsort": [
+                {"column": "adapter_content_read1", "order": "desc"},
+                {"column": "adapter_content_read2", "order": "desc"},
+            ],
         }
 
         headers = {

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -507,7 +507,9 @@ class MultiqcModule(BaseMultiqcModule):
         plot_data = {}
 
         for sample_name, sample_dict in data.items():
-            adapter_content = sample_dict["adapter_content"]
+            adapter_content = sample_dict.get("adapter_content")
+            if adapter_content is None:
+                continue
             x_labels = adapter_content["x_labels"]
             x_points = [avg_x_label(x_label) for x_label in x_labels]
             adapters_and_series = adapter_content["adapter_content"]
@@ -517,6 +519,9 @@ class MultiqcModule(BaseMultiqcModule):
                     continue
                 series_name = f"{sample_name}-{adapter}"
                 plot_data[series_name] = dict(zip(x_points, series))
+
+        if not plot_data:
+            return
 
         plot_config = {
             "id": "sequali_adapter_content_plot",

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -461,7 +461,7 @@ def _get_sortlist(dt: DataTable) -> str:
             idx = next(
                 idx
                 for idx, (_, k, header) in enumerate(headers)
-                if d["column"].lower() in [k.lower(), header["title"].lower()]
+                if d["column"].lower() in [k.lower(), header.title.lower()]
             )
         except StopIteration:
             logger.warning(


### PR DESCRIPTION

- [x] This comment contains a description of changes (with reason)

Hi, since Sequali 0.8.0 it supports paired-end data. So naturally the MultiQC module also has to support this. I released 0.8.0 just now, but I developed this PR alongside. 

Could this still be included in 1.22? Pretty please with cherries on top! :pray: :pray: :pray:

I added the test data in this pr: https://github.com/MultiQC/test-data/pull/325
