### PR TITLE
Profile per-module memory and run time, visualize in the profile module

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -71,6 +71,7 @@ custom_css_files: List[str]
 simple_output: bool
 template: str
 profile_runtime: bool
+profile_memory: bool
 pandoc_template: str
 read_count_multiplier: float
 read_count_prefix: str

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -24,6 +24,7 @@ custom_css_files: []
 simple_output: false
 template: "default"
 profile_runtime: false
+profile_memory: false
 pandoc_template: null
 read_count_multiplier: 0.000001
 read_count_prefix: "M"

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -48,7 +48,7 @@ def exec_modules(
 
     for mod_idx, mod_dict in enumerate(mod_dicts_in_order):
         mod_starttime = time.time()
-        if config.profile_runtime:
+        if config.profile_memory:
             tracemalloc.start()
 
         this_module: str = list(mod_dict.keys())[0]
@@ -144,7 +144,7 @@ def exec_modules(
             sys_exit_code = 1
 
         report.runtimes["mods"][mod_names[mod_idx]] = time.time() - mod_starttime
-        if config.profile_runtime:
+        if config.profile_memory:
             mem_current, mem_peak = tracemalloc.get_traced_memory()
             tracemalloc.stop()
             report.peak_memory_bytes_per_module[mod_names[mod_idx]] = mem_peak
@@ -152,6 +152,7 @@ def exec_modules(
             logger.warning(
                 f"{this_module}: memory change: {humanize.naturalsize(mem_current)}, peak during module execution: {humanize.naturalsize(mem_peak)}"
             )
+        if config.profile_runtime:
             logger.warning(
                 f"{this_module}: module run time: {humanize.precisedelta(report.runtimes['mods'][mod_names[mod_idx]])}"
             )

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -49,6 +49,7 @@ class ClConfig(BaseModel):
     verbose: Optional[bool] = None
     no_ansi: Optional[bool] = None
     profile_runtime: Optional[bool] = None
+    profile_memory: Optional[bool] = None
     no_version_check: Optional[bool] = None
     ignore: List[str] = ()
     ignore_samples: List[str] = ()
@@ -171,6 +172,8 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None):
         config.require_logs = cfg.require_logs
     if cfg.profile_runtime is not None:
         config.profile_runtime = cfg.profile_runtime
+    if cfg.profile_memory is not None:
+        config.profile_runtime = config.profile_memory = cfg.profile_memory
     if cfg.no_version_check is not None:
         config.no_version_check = cfg.no_version_check
     if cfg.custom_css_files:

--- a/multiqc/modules/profile_runtime.py
+++ b/multiqc/modules/profile_runtime.py
@@ -2,9 +2,11 @@
 
 import logging
 
+
 from multiqc.base_module import BaseMultiqcModule
-from multiqc.plots import bargraph
+from multiqc.plots import bargraph, table
 from multiqc import report
+from multiqc.plots.table_object import TableConfig
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -14,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
-            name="Run Time",
+            name="Run time and memory profiling",
             anchor="multiqc_runtime",
             info="""
                 This analysis is about the MultiQC run itself, profiling the time spent
@@ -25,15 +27,64 @@ class MultiqcModule(BaseMultiqcModule):
             """,
         )
 
-        log.info("Running run time profiling module")
-
-        self.file_search_stats_section()
-
+        log.info("Running profiling module")
+        self.module_table()
+        self.module_memory_section()
+        self.module_times_section()
         self.search_pattern_times_section()
+        self.file_search_counts_section()
 
-        self.module_run_times_section()
+    def module_table(self):
+        """
+        Table with time and memory usage per module
+        """
+        headers = {
+            "run_time": {
+                "title": "Run time",
+                "description": "Time spent running the module",
+                "suffix": "s",
+                "format": "{:.2f}",
+                "scale": "Oranges",
+            },
+            "peak_mem": {
+                "title": "Peak memory",
+                "description": "Peak memory usage during module execution",
+                "suffix": " MB",
+                "format": "{:.2f}",
+                "scale": "Greys",
+            },
+            "mem_change": {
+                "title": "Memory change",
+                "description": "Change in memory usage during module execution",
+                "suffix": " MB",
+                "format": "{:.2f}",
+                "scale": "Blues",
+            },
+        }
 
-    def file_search_stats_section(self):
+        table_data = dict()
+        for key in report.runtimes["mods"]:
+            table_data[key] = {
+                "run_time": report.runtimes["mods"][key],
+                "peak_mem": report.peak_memory_bytes_per_module[key] / 1024 / 1024,
+                "mem_change": report.diff_memory_bytes_per_module[key] / 1024 / 1024,
+            }
+
+        self.add_section(
+            name="Per module",
+            anchor="per_module_benchmark",
+            plot=table.plot(
+                table_data,
+                headers,
+                pconfig=TableConfig(
+                    id="per_module_benchmark_table",
+                    title="Module run times and memory usage",
+                    col1_header="Module",
+                ),
+            ),
+        )
+
+    def file_search_counts_section(self):
         """Count of all files iterated through by MultiQC, by category"""
 
         pdata = dict()
@@ -56,7 +107,7 @@ class MultiqcModule(BaseMultiqcModule):
         }
 
         self.add_section(
-            name="Files searched",
+            name="Files searched counts",
             anchor="multiqc_runtime_files_searched",
             description="""
                 Number of files searched by MultiQC, categorised by what happened to them.
@@ -82,18 +133,19 @@ class MultiqcModule(BaseMultiqcModule):
 
         pdata = dict()
         for key in sorted(report.runtimes["sp"], key=report.runtimes["sp"].get, reverse=True):
-            pdata[key] = {"time": report.runtimes["sp"][key]}
+            pdata[key] = {"Run time": report.runtimes["sp"][key]}
 
         pconfig = {
             "id": "multiqc_runtime_search_patterns_plot",
             "title": "MultiQC: Time per search pattern key",
-            "ylab": "Time (seconds)",
+            "ylab": "Run time",
             "use_legend": False,
             "cpswitch": False,
+            "suffix": "s",
         }
 
         self.add_section(
-            name="Search patterns",
+            name="Search patterns run times",
             anchor="multiqc_runtime_search_patterns",
             description="""
                 Time spent running each search pattern to find files for MultiQC modules.
@@ -105,7 +157,7 @@ class MultiqcModule(BaseMultiqcModule):
                 will have limited practical benefit.**
 
                 MultiQC works by recursively looking through all files found in the analysis directories.
-                After skipping any that are too big / binary file types etc, it uses the search patterns
+                After skipping any that are too big / binary file types etc., it uses the search patterns
                 defined in `multiqc/search_patterns.yaml`.
                 These work by matching either file names or file contents. Generally speaking, matching
                 filenames is super fast and matching file contents is slower.
@@ -118,43 +170,63 @@ class MultiqcModule(BaseMultiqcModule):
             plot=bargraph.plot(pdata, None, pconfig),
         )
 
-    def module_run_times_section(self):
+    def module_times_section(self):
         """Section with a bar plot showing the time spent on each search pattern"""
 
         pdata = dict()
         for key in report.runtimes["mods"]:
-            pdata[key] = {"time": report.runtimes["mods"][key]}
+            pdata[key] = {"Time": report.runtimes["mods"][key]}
 
         pconfig = {
             "id": "multiqc_runtime_modules_plot",
             "title": "MultiQC: Time per module",
-            "ylab": "Time (seconds)",
+            "ylab": "Run time",
             "use_legend": False,
             "cpswitch": False,
+            "suffix": "s",
         }
 
         self.add_section(
-            name="Modules",
+            name="Per module run times",
             anchor="multiqc_runtime_modules",
             description="""
                 Time spent running each module.
                 **Total modules run time: {:.2f} seconds**.
             """.format(report.runtimes["total_mods"]),
-            helptext="""
-                **NOTE: Usually, MultiQC run time is fairly insignificant - in the order of seconds.
-                Unless you are running MultiQC on many thousands of analysis files, optimising this process
-                will have limited practical benefit.**
-
-                MultiQC works by recursively looking through all files found in the analysis directories.
-                After skipping any that are too big / binary file types etc, it uses the search patterns
-                defined in `multiqc/search_patterns.yaml`.
-                These work by matching either file names or file contents. Generally speaking, matching
-                filenames is super fast and matching file contents is slower.
-
-                Please see the [MultiQC Documentation](https://multiqc.info/docs/#optimising-run-time)
-                for information on how to optimise MultiQC to speed this process up.
-                The plot below shows which search keys are running and how long each has taken to run in
-                total. This should help to guide you to where optimisation is most worthwhile.
-            """,
             plot=bargraph.plot(pdata, None, pconfig),
+        )
+
+    def module_memory_section(self):
+        """
+        Section with a bar plot showing the memory usage of each module
+        """
+        pdata = {}
+        for key in report.peak_memory_bytes_per_module:
+            pdata[key] = {"Peak memory": report.peak_memory_bytes_per_module[key] / 1024 / 1024}
+        for key in report.diff_memory_bytes_per_module:
+            pdata[key]["Memory change"] = report.diff_memory_bytes_per_module[key] / 1024 / 1024
+
+        pconfig = {
+            "id": "multiqc_runtime_memory_plot",
+            "title": "MultiQC: Memory usage per module",
+            "ylab": "Memory",
+            "suffix": " MB",
+            "stacking": "overlay",
+        }
+        self.add_section(
+            name="Per module memory usage",
+            anchor="multiqc_runtime_memory",
+            description="Memory usage per each module. The <span style='color: #7cb5ec'>blue</span> "
+            "bar indicates how much more memory MultiQC occupies after finishing running the module, which roughly should"
+            "correspond to the size of the parsed data, which is loaded into memory. "
+            "The <span style='color: #888888'>grey</span> bar shows the peak memory usage during the module "
+            "execution - some memory could be cleaned after module is finished.",
+            plot=bargraph.plot(
+                pdata,
+                {
+                    "Peak memory": {"name": "Peak memory", "color": "#999999"},
+                    "Memory change": {"name": "Memory change", "color": "#7cb5ec"},
+                },
+                pconfig=pconfig,
+            ),
         )

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -108,7 +108,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--strict",
                 "--development",
                 "--require-logs",
-                "--profile-runtime",
+                "--profile",
                 "--no-megaqc-upload",
                 "--no-ansi",
                 "--version",
@@ -382,10 +382,12 @@ click.rich_click.OPTION_GROUPS = {
     help="Only show log warnings",
 )
 @click.option(
+    "--profile",
     "--profile-runtime",
+    "profile_runtime",
     is_flag=True,
     default=None,
-    help="Add analysis of how long MultiQC takes to run to the report",
+    help="Add analysis of how long MultiQC takes to run to the report along with memory usage",
 )
 @click.option(
     "--no-ansi",

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -108,7 +108,8 @@ click.rich_click.OPTION_GROUPS = {
                 "--strict",
                 "--development",
                 "--require-logs",
-                "--profile",
+                "--profile-runtime",
+                "--profile-memory",
                 "--no-megaqc-upload",
                 "--no-ansi",
                 "--version",
@@ -382,12 +383,18 @@ click.rich_click.OPTION_GROUPS = {
     help="Only show log warnings",
 )
 @click.option(
-    "--profile",
     "--profile-runtime",
     "profile_runtime",
     is_flag=True,
     default=None,
-    help="Add analysis of how long MultiQC takes to run to the report along with memory usage",
+    help="Add analysis of how long MultiQC takes to run to the report",
+)
+@click.option(
+    "--profile-memory",
+    "profile_memory",
+    is_flag=True,
+    default=None,
+    help="Add analysis of how much memory each module uses. Note that tracking memory will increase the runtime, so the runtime metrics could scale up a few times",
 )
 @click.option(
     "--no-ansi",

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -35,7 +35,6 @@ class BarPlotConfig(PConfig):
     @model_validator(mode="before")
     @classmethod
     def validate_fields(cls, values):
-        print(values)
         if "suffix" in values:
             values["ysuffix"] = values["suffix"]
             del values["suffix"]

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class BarPlotConfig(PConfig):
-    stacking: Union[Literal["group", "overlay", "relative"], None] = "relative"
+    stacking: Union[Literal["group", "overlay", "relative", "normal"], None] = "relative"
     hide_zero_cats: bool = False
     sort_samples: bool = True
     use_legend: bool = True
@@ -174,6 +174,8 @@ class BarPlot(Plot):
         barmode = pconfig.stacking  # stacking, but drawing negative values below zero
         if barmode is None:  # For legacy reasons, interpreting non-default None as "group"
             barmode = "group"  # side by side
+        if barmode == "normal":  # Legacy
+            barmode = "relative"
 
         max_n_cats = max([len(dataset.cats) for dataset in model.datasets])
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -50,6 +50,8 @@ num_flat_plots: int
 saved_raw_data: Dict[str, Dict[str, Any]]  # Indexed by unique key, then sample name
 last_found_file: Optional[str]
 runtimes: Dict[str, Union[float, Dict]]
+peak_memory_bytes_per_module: Dict[str, int]
+diff_memory_bytes_per_module: Dict[str, int]
 file_search_stats: Dict[str, int]
 searchfiles: List
 files: Dict
@@ -79,6 +81,8 @@ def __initialise():
     global saved_raw_data
     global last_found_file
     global runtimes
+    global peak_memory_bytes_per_module
+    global diff_memory_bytes_per_module
     global data_sources
     global html_ids
     global plot_data
@@ -107,6 +111,8 @@ def __initialise():
         "sp": defaultdict(),
         "mods": defaultdict(),
     }
+    peak_memory_bytes_per_module = dict()
+    diff_memory_bytes_per_module = dict()
     data_sources = defaultdict(lambda: defaultdict(lambda: defaultdict()))
     html_ids = []
     plot_data = dict()


### PR DESCRIPTION
Add option `--profile-memory`.

* Profile per-module memory usage, visualize in the profile module

![CleanShot 2024-05-09 at 11 50 21@2x](https://github.com/MultiQC/MultiQC/assets/1575412/f3e0c1b6-58c7-46ec-9a7b-b9f1a21a6c2f)

* Visualize per-module run time in the profile module

* Support `stacking="overlay"` in the bar plot and `suffix` settings.