### PR TITLE
Clean up module raw data after running each module

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -139,7 +139,7 @@ class BaseMultiqcModule:
         """
         for key in list(self.__dict__.keys()):
             if key not in self._base_attributes and not key.startswith("_"):
-                logger.debug(f"{self.name}: deleting attribute {key} from {self.name}")
+                logger.debug(f"{self.anchor}: deleting attribute self.{key}")
                 delattr(self, key)
 
     @property
@@ -668,11 +668,12 @@ class BaseMultiqcModule:
             fn = f"{base_fn}_{i}"
             i += 1
 
-        # Save the file
-        report.saved_raw_data[fn] = data
-        # Keep also in the module instance, so it's possible to map back data to specific module
-        self.__saved_raw_data[fn] = data
+        if config.preserve_module_raw_data:
+            report.saved_raw_data[fn] = data
+            # Keep also in the module instance, so it's possible to map back data to specific module
+            self.__saved_raw_data[fn] = data
 
+        # Save the file
         report.write_data_file(data, fn, sort_cols, data_format)
 
     ##################################################

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -129,6 +129,19 @@ class BaseMultiqcModule:
         self.css: Dict[str, str] = dict()
         self.js: Dict[str, str] = dict()
 
+        # Get list of all base attributes, so we clean up any added by child modules
+        self._base_attributes = [k for k in dir(self)]
+
+    def clean_child_attributes(self):
+        """
+        Clean up non-base attribute to save memory. If the attribute is added in subclass,
+        but absent in the base class BaseMultiqcModule, delete it.
+        """
+        for key in list(self.__dict__.keys()):
+            if key not in self._base_attributes and not key.startswith("_"):
+                logger.debug(f"{self.name}: deleting attribute {key} from {self.name}")
+                delattr(self, key)
+
     @property
     def saved_raw_data(self):
         """

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -168,6 +168,7 @@ fn_clean_trim: List
 fn_ignore_files: List
 top_modules: List[Dict[str, Dict]]
 module_order: List[Union[str, Dict]]
+preserve_module_raw_data: Optional[bool]
 
 
 def load_defaults():

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -519,3 +519,7 @@ module_order:
   - xengsort
   - metaphlan
   - seqwho
+
+# default is "false" for standard command line use - to save memory -
+# but "true" for interactive use - so module.saved_raw_data is available
+preserve_module_raw_data: false

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -52,6 +52,7 @@ def exec_modules(
             tracemalloc.start()
 
         this_module: str = list(mod_dict.keys())[0]
+        logger.info(f"Running module: {this_module}")
         mod_cust_config: Dict = list(mod_dict.values())[0] or {}
         # noinspection PyBroadException
         try:

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -69,6 +69,10 @@ def exec_modules(
             if not isinstance(these_modules, list):
                 these_modules = [these_modules]
 
+            # Clean up non-base attribute to save memory.
+            for m in these_modules:
+                m.clean_child_attributes()
+
             # Override duplicated outputs
             for prev_mod in report.modules:
                 if prev_mod.name in set(m.name for m in these_modules):

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -7,7 +7,6 @@ import tracemalloc
 from importlib.metadata import EntryPoint
 from typing import Dict, Union, Callable, List
 
-import humanize
 import rich
 from rich.syntax import Syntax
 
@@ -71,8 +70,12 @@ def exec_modules(
                 these_modules = [these_modules]
 
             # Clean up non-base attribute to save memory.
+            mem_current, mem_peak = tracemalloc.get_traced_memory()
+            logger.warning(f"{this_module}: memory before clean up: {mem_current:,d}b")
             for m in these_modules:
                 m.clean_child_attributes()
+            mem_current, mem_peak = tracemalloc.get_traced_memory()
+            logger.warning(f"{this_module}: memory after cleaning up attributes: {mem_current:,d}b")
 
             # Override duplicated outputs
             for prev_mod in report.modules:
@@ -155,12 +158,10 @@ def exec_modules(
             report.peak_memory_bytes_per_module[mod_names[mod_idx]] = mem_peak
             report.diff_memory_bytes_per_module[mod_names[mod_idx]] = mem_current
             logger.warning(
-                f"{this_module}: memory change: {humanize.naturalsize(mem_current)}, peak during module execution: {humanize.naturalsize(mem_peak)}"
+                f"{this_module}: memory change: {mem_current:,d}b, peak during module execution: {mem_peak:,d}b"
             )
         if config.profile_runtime:
-            logger.warning(
-                f"{this_module}: module run time: {humanize.precisedelta(report.runtimes['mods'][mod_names[mod_idx]])}"
-            )
+            logger.warning(f"{this_module}: module run time: {report.runtimes['mods'][mod_names[mod_idx]]:.2f}s")
 
     report.runtimes["total_mods"] = time.time() - total_mods_starttime
 

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -59,6 +59,7 @@ class ClConfig(BaseModel):
     cl_config: List[str] = ()
     custom_css_files: List[str] = ()
     module_order: List[Union[str, Dict]] = ()
+    preserve_module_raw_data: Optional[bool] = None
     extra_fn_clean_exts: List = ()
     extra_fn_clean_trim: List = ()
     kwargs: Optional[Dict] = None
@@ -184,6 +185,8 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None):
         config.fn_clean_exts = list(cfg.extra_fn_clean_exts) + config.fn_clean_exts
     if cfg.extra_fn_clean_trim:
         config.fn_clean_trim = list(cfg.extra_fn_clean_trim) + config.fn_clean_trim
+    if cfg.preserve_module_raw_data is not None:
+        config.preserve_module_raw_data = cfg.preserve_module_raw_data
 
     # Clean up analysis_dir if a string (interactive environment only)
     if analysis_dir:

--- a/multiqc/interactive.py
+++ b/multiqc/interactive.py
@@ -47,6 +47,7 @@ def parse_logs(
     module_order: List[Union[str, Dict]] = (),
     extra_fn_clean_exts: List = (),
     extra_fn_clean_trim: List = (),
+    preserve_module_raw_data: bool = True,
 ):
     """
     Parse files without generating a report. Useful to work with MultiQC interactively. Data can be accessed

--- a/multiqc/modules/samtools/samtools.py
+++ b/multiqc/modules/samtools/samtools.py
@@ -33,8 +33,8 @@ class MultiqcModule(
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
             name="Samtools",
-            anchor="Samtools",
-            target="Samtools",
+            anchor="samtools",
+            target="samtools",
             href="http://www.htslib.org",
             info=" is a suite of programs for interacting with high-throughput sequencing data.",
             doi="10.1093/bioinformatics/btp352",


### PR DESCRIPTION
Memory usage optimization:

* Do no keep the module saved raw data after module is finished, unless running intractively. Add `config.preserve_module_raw_data` option to control that.
* Remove module attributes that are not from `BaseMultIqcModule`.

Before (additional memory taken by module in blue)

<img width="1120" alt="Screenshot 2024-05-09 at 23 43 10" src="https://github.com/MultiQC/MultiQC/assets/1575412/7066e61e-da40-4583-8817-3fa62d1e9afc">

After

<img width="1118" alt="Screenshot 2024-05-09 at 23 43 00" src="https://github.com/MultiQC/MultiQC/assets/1575412/2be6187a-4515-4b85-9eb4-fcfb440d97f6">

FastQC peak usage is clipped (it's a bit over the top - need to figure out what is all that unzipping and HTML parsing does and if it can be optimized)

x-ref https://github.com/MultiQC/MultiQC/issues/2517
