### PR TITLE
FastQC: Skip per tile sequence quality section for better performance

### DIFF
--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -176,6 +176,9 @@ class MultiqcModule(BaseMultiqcModule):
                 (section, status) = line[2:].split("\t", 1)
                 section = section.lower().replace(" ", "_")
                 self.fastqc_data[s_name]["statuses"][section] = status
+            elif section == "per_tile_sequence_quality":
+                # Lots and lots of data. None of it used in MultiQC.
+                continue
             elif section is not None:
                 if line.startswith("#"):
                     s_headers = line[1:].split("\t")


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

This is not really good for me personally, as I made a FastQC replacement: [Sequali](https://github.com/rhpvorderman/sequali). People should be using that tool instead of FastQC. Sequali accepts paired-end data, it is much faster, it correctly averages Phred Scores and does deliver nicer plots. 

Okay with that of my chest: the FastQC module. It turns out that the high memory usage is because of the per tile quality data. This was exactly the same with Sequali. So in the Sequali module, those data are removed as they weren't used. After some inspection I found that the FastQC module has the exact same problem. Not saving all this data saves a whopping **2.2 GB** on the profile data run. Bringing the memory from 3 GiB to 800 MiB. This is quite a massive improvement.

Also converting all those float values from text to float data takes a very long time. As a consequence the FastQC module runs twice as fast. This brings it execution time more in line with other modules. 
