### PR TITLE
Use gzip level 6 for faster json compression

### DIFF
--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -795,7 +795,7 @@ def compress_json(data):
     # Stream to an in-memory buffer rather than compressing the big string
     # at once. This saves memory.
     buffer = io.BytesIO()
-    with gzip.open(buffer, "wt", encoding="utf-8", compresslevel=9) as gzip_buffer:
+    with gzip.open(buffer, "wt", encoding="utf-8", compresslevel=6) as gzip_buffer:
         dump_json(data, gzip_buffer)
     base64_bytes = base64.b64encode(buffer.getvalue())
     return base64_bytes.decode("ascii")

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -796,7 +796,7 @@ def compress_json(data):
     # at once. This saves memory.
     buffer = io.BytesIO()
     with gzip.open(buffer, "wt", encoding="utf-8", compresslevel=6) as gzip_buffer:
-        # The compression level 6 gives 10% speed gain vs. 2% extra size, in contrast to default compresslevel=9 
+        # The compression level 6 gives 10% speed gain vs. 2% extra size, in contrast to default compresslevel=9
         dump_json(data, gzip_buffer)
     base64_bytes = base64.b64encode(buffer.getvalue())
     return base64_bytes.decode("ascii")

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -796,6 +796,7 @@ def compress_json(data):
     # at once. This saves memory.
     buffer = io.BytesIO()
     with gzip.open(buffer, "wt", encoding="utf-8", compresslevel=6) as gzip_buffer:
+        # The compression level 6 gives 10% speed gain vs. 2% extra size, in contrast to default compresslevel=9 
         dump_json(data, gzip_buffer)
     base64_bytes = base64.b64encode(buffer.getvalue())
     return base64_bytes.decode("ascii")


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

This is a tradeoff:

Before:
```
           multiqc | Run took 36.22 seconds
           multiqc |  - 6.54s: Searching files
           multiqc |  - 12.93s: Running modules
           multiqc |  - 12.07s: Compressing report data

$ wc -c multiqc_report.html 
34024212 multiqc_report.html
```

After:
```
           multiqc | Run took 32.38 seconds
           multiqc |  - 6.37s: Searching files
           multiqc |  - 13.60s: Running modules
           multiqc |  - 7.64s: Compressing report data

$ wc -c multiqc_report.html 
34522536 multiqc_report.html
```

For comparison, v1.21, using lz compression: 
```
35952091 multiqc_report.html
```

So a report that is less than 2% bigger, for a significant gain in speed. 

The reason I chose 9 initially is because it is the python default and that back then the compression time was not a too big part of the total runtime when the switch to gzip was made. Well things have changed I guess :sweat_smile: .
