### PR TITLE
Re-enable falling back to flat plots for large datasets

### DIFF
--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -61,7 +61,7 @@ make_report: true
 make_pdf: false
 plots_force_flat: false
 plots_force_interactive: false
-plots_flat_numseries: 50
+plots_flat_numseries: 100
 num_datasets_plot_limit: 50
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -61,7 +61,7 @@ make_report: true
 make_pdf: false
 plots_force_flat: false
 plots_force_interactive: false
-plots_flat_numseries: 100
+plots_flat_numseries: 50
 num_datasets_plot_limit: 50
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -64,7 +64,6 @@ def plot(
         pconfig=pconfig,
         cats_lists=cats_lists,
         samples_lists=samples_lists,
-        max_n_samples=max([len(samples) for samples in samples_lists]),
     )
 
 
@@ -153,15 +152,17 @@ class BarPlot(Plot):
         pconfig: BarPlotConfig,
         cats_lists: List,
         samples_lists: List,
-        max_n_samples: int,
     ) -> "BarPlot":
         if len(cats_lists) != len(samples_lists):
             raise ValueError("Number of datasets and samples lists do not match")
+
+        max_n_samples = max(len(x) for x in samples_lists) if len(samples_lists) > 0 else 0
 
         model = Plot.initialize(
             plot_type=PlotType.BAR,
             pconfig=pconfig,
             n_datasets=len(cats_lists),
+            n_samples=max_n_samples,
             axis_controlled_by_switches=["xaxis"],
             default_tt_label="%{meta}: <b>%{x}</b>",
         )

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -34,7 +34,6 @@ def plot(
     return BoxPlot.create(
         pconfig=pconfig,
         list_of_data_by_sample=list_of_data_by_sample,
-        max_n_samples=max(len(d) for d in list_of_data_by_sample),
     )
 
 
@@ -106,12 +105,14 @@ class BoxPlot(Plot):
     def create(
         pconfig: BoxPlotConfig,
         list_of_data_by_sample: List[Dict[str, BoxT]],
-        max_n_samples: int,
     ) -> "BoxPlot":
+        max_n_samples = max(len(x) for x in list_of_data_by_sample) if list_of_data_by_sample else 0
+
         model = Plot.initialize(
             plot_type=PlotType.BOX,
             pconfig=pconfig,
             n_datasets=len(list_of_data_by_sample),
+            n_samples=max_n_samples,
         )
 
         model.datasets = [

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -133,7 +133,20 @@ class HeatmapPlot(Plot):
         xcats: Optional[List[str]],
         ycats: Optional[List[str]],
     ) -> "HeatmapPlot":
-        model = Plot.initialize(plot_type=PlotType.HEATMAP, pconfig=pconfig, n_datasets=1)
+        max_n_samples = 0
+        if rows:
+            max_n_samples = len(rows)
+            if isinstance(rows, list):
+                max_n_samples = max(max_n_samples, len(rows[0]))
+            else:
+                max_n_samples = max(max_n_samples, len(rows[next(iter(rows))]))
+
+        model = Plot.initialize(
+            plot_type=PlotType.HEATMAP,
+            pconfig=pconfig,
+            n_datasets=1,
+            n_samples=max_n_samples,
+        )
 
         if isinstance(rows, list):
             if ycats and not isinstance(ycats, list):

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -206,6 +206,7 @@ class LinePlot(Plot):
             plot_type=PlotType.LINE,
             pconfig=pconfig,
             n_datasets=len(lists_of_lines),
+            n_samples=max(len(x) for x in lists_of_lines) if len(lists_of_lines) > 0 else 0,
             axis_controlled_by_switches=["yaxis"],
             default_tt_label="<br>%{x}: %{y}",
         )

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -255,19 +255,23 @@ class Plot(BaseModel):
         plot_type: PlotType,
         pconfig: PConfig,
         n_datasets: int,
+        n_samples: int,
         id: Optional[str] = None,
         axis_controlled_by_switches: Optional[List[str]] = None,
         default_tt_label: Optional[str] = None,
+        flat_threshold: Optional[int] = config.plots_flat_numseries,
     ):
         """
         Initialize a plot model with the given configuration.
         :param plot_type: plot type
         :param pconfig: plot configuration model
         :param n_datasets: number of datasets to pre-initialize dataset models
+        :param n_samples: maximum number of samples in a dataset
         :param id: plot ID
         :param axis_controlled_by_switches: list of axis names that are controlled by the
             log10 scale and percentage switch buttons, e.g. ["yaxis"]
         :param default_tt_label: default tooltip label
+        :param flat_threshold: threshold for the number of samples to switch to flat plots
         """
         if n_datasets == 0:
             raise ValueError("No datasets to plot")
@@ -288,9 +292,11 @@ class Plot(BaseModel):
         if pconfig.square:
             width = height
 
-        flat = config.plots_force_flat or (
-            not config.plots_force_interactive and n_datasets > config.plots_flat_numseries
-        )
+        flat = False
+        if config.plots_force_flat:
+            flat = True
+        elif flat_threshold is not None and not config.plots_force_interactive and n_samples > flat_threshold:
+            flat = True
 
         layout = go.Layout(
             title=go.layout.Title(

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -197,6 +197,7 @@ class ScatterPlot(Plot):
             plot_type=PlotType.SCATTER,
             pconfig=pconfig,
             n_datasets=len(points_lists),
+            n_samples=len(points_lists[0]) if len(points_lists) > 0 else 0,
             default_tt_label="<br><b>X</b>: %{x}<br><b>Y</b>: %{y}",
         )
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -386,6 +386,13 @@ class ViolinPlot(Plot):
         dts: List[DataTable],
         show_table_by_default: bool = False,
     ) -> "ViolinPlot":
+        all_samples = set()
+        for dt in dts:
+            for rd in dt.raw_data:
+                all_samples.update(rd.keys())
+
+        max_n_samples = len(all_samples)
+
         assert len(dts) > 0
         main_table_dt = dts[0]  # used for the table
 
@@ -393,8 +400,10 @@ class ViolinPlot(Plot):
             plot_type=PlotType.VIOLIN,
             pconfig=main_table_dt.pconfig,
             n_datasets=len(dts),
+            n_samples=max_n_samples,
             id=main_table_dt.id,
             default_tt_label=": %{x}",
+            flat_threshold=None,  # we can make violins always interactive!
         )
 
         main_table_dt.id = "table-" + main_table_dt.id  # make it different from the violin id
@@ -440,14 +449,13 @@ class ViolinPlot(Plot):
         # If the number of samples is high:
         # - do not add a table
         # - plot a Violin in Python, and serialise the figure instead of the datasets
-        n_samples = max(len(ds.all_samples) for ds in model.datasets)
         show_table = True
-        if n_samples > config.max_table_rows and not no_violin:
+        if max_n_samples > config.max_table_rows and not no_violin:
             show_table = False
             main_table_dt = None
             if show_table_by_default:
                 logger.debug(
-                    f"Table '{model.id}': sample number {n_samples} > {config.max_table_rows}, "
+                    f"Table '{model.id}': sample number {max_n_samples} > {config.max_table_rows}, "
                     "Will render only a violin plot instead of the table"
                 )
 
@@ -456,7 +464,7 @@ class ViolinPlot(Plot):
             no_violin=no_violin,
             show_table=show_table,
             show_table_by_default=show_table_by_default,
-            n_samples=n_samples,
+            n_samples=max_n_samples,
             main_table_dt=main_table_dt,
         )
 

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -62,6 +62,9 @@ class TableColumn(BaseModel):
 ValueT = Union[int, float, str, bool]
 
 
+DatasetT = Mapping[str, Mapping[str, Optional[ValueT]]]
+
+
 class DataTable(BaseModel):
     """
     Data table class. Prepares and holds data and configuration
@@ -77,7 +80,7 @@ class DataTable(BaseModel):
 
     @staticmethod
     def create(
-        data: Union[List[Mapping[str, Mapping[str, Optional[ValueT]]]], Mapping[str, Mapping[str, Optional[ValueT]]]],
+        data: Union[DatasetT, List[DatasetT]],
         pconfig: TableConfig,
         headers: Optional[Union[List[Dict[str, Dict]], Dict[str, Dict]]] = None,
     ) -> "DataTable":

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Optional, Union
 from multiqc import config
 from multiqc.plots import table_object
 from multiqc.plots.plotly import violin
-from multiqc.plots.table_object import TableConfig
+from multiqc.plots.table_object import TableConfig, DatasetT
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def get_template_mod():
 
 
 def plot(
-    data: Union[List[Dict], Dict],
+    data: Union[List[DatasetT], DatasetT],
     headers: Optional[Union[List[Dict], Dict]] = None,
     pconfig: Union[Dict, TableConfig, None] = None,
 ) -> Union[str, violin.ViolinPlot]:


### PR DESCRIPTION
Fall back to flat plots when `n_samples > config.plots_flat_numseries`. Make it individual per plot type and make Violin always interactive.