### PR TITLE
support DOI for custom content

### DIFF
--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -299,12 +299,12 @@ class MultiqcModule(BaseMultiqcModule):
             href=mod["config"].get("section_href"),
             info=mod_info,
             extra=mod["config"].get("extra"),
-            # No DOI here.. // doi=
+            doi=mod["config"].get("doi"),
         )
 
         # Don't repeat the Custom Content name in the subtext
-        if self.info or self.extra:
-            self.intro = f"<p>{self.info}</p>{self.extra}"
+        if self.info or self.extra or self.doi_link:
+            self.intro = f"<p>{self.info}{self.doi_link}</p>{self.extra}"
 
     def update_init(self, c_id, mod):
         """
@@ -322,7 +322,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.extra = mod["config"].get("extra", None)
         # This needs overwriting again as it has already run on init
         if self.info or self.extra:
-            self.intro = f"<p>{self.info}</p>{self.extra}"
+            self.intro = f"<p>{self.info}{self.doi_link}</p>{self.extra}"
 
     def add_cc_section(self, c_id, mod):
         section_name = mod["config"].get("section_name", c_id.replace("_", " ").title())

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -321,7 +321,7 @@ class MultiqcModule(BaseMultiqcModule):
         if self.extra is None or self.info == "":
             self.extra = mod["config"].get("extra", None)
         # This needs overwriting again as it has already run on init
-        if self.info or self.extra:
+        if self.info or self.extra or self.doi_link:
             self.intro = f"<p>{self.info}{self.doi_link}</p>{self.extra}"
 
     def add_cc_section(self, c_id, mod):


### PR DESCRIPTION
Adds support for providing a DOI alongside custom content.

Tested with the cc example from multiqc docs, but with added DOI:

```yaml
id: "my_pca_section"
section_name: "PCA Analysis"
description: "This plot shows the first two components from a principal component analysis."
plot_type: "scatter"
pconfig:
  id: "pca_scatter_plot"
  title: "PCA Plot"
  xlab: "PC1"
  ylab: "PC2"
doi: foo/bar
data:
  sample_1: { x: 12, y: 14 }
  sample_2: { x: 8, y: 6 }
  sample_3: { x: 5, y: 11 }
  sample_4: { x: 9, y: 12 }
```

![Screenshot 2024-05-20 at 14-42-05 MultiQC Report](https://github.com/MultiQC/MultiQC/assets/6404517/918a5a09-6605-4b12-bd2e-e245a2ba4c8e)

I was hoping we could actually just re-use the base-modules DOI logic. Unfortunately the base module's [intro logic](https://github.com/MultiQC/MultiQC/blob/c7f69fab0899a3c4f27363a30bf299b655104862/multiqc/base_module.py#L114) includes the module name, and cc rightfully needs an intro without repeating the module name. I didn't want to start refactoring and provide overrides/hooks to get back to using base modules intro logic, as it'd be more invasive. Possibly a better approach though.

Why would someone want to do this?

- When providing content to multiqc, whether based on internal tooling or external, there may be a citation to attach
- I had a look at multiqc's setup-tools plugin architecture. There's pros/cons. It requires packaging code with multiqc, instead of passing in arbitrary code for multiqc to handle. For common tools or widely reused modules it probably makes a lot of sense. However if you have many fragments of custom-content that are one-offs, building a full module has a higher burden than just throwing some json at multiqc.
- Doesn't seem like there's much downside!

Let me know if y'all would like me to add the case above as a new test-case in multiqc, or alternatively if we should augment an existing case. I also tested without the DOI and it didn't seem to break anything.

- [x] This comment contains a description of changes (with reason)


