### PR TITLE
Use a set for fast membership checking of headers

### DIFF
--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -857,6 +857,7 @@ def write_data_file(
         # noinspection PyBroadException
         try:
             # Get all headers from the data, except if data is a dictionary (i.e. has >1 dimensions)
+            header_set = set()
             headers = []
             rows = []
 
@@ -865,7 +866,8 @@ def write_data_file(
                     continue
                 if isinstance(d, dict):
                     for h in d.keys():
-                        if h not in headers:
+                        if h not in header_set:  # Use a set for fast membership checking.
+                            header_set.add(h)
                             headers.append(h)
             if headers:
                 if sort_cols:


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

Hi, I am doing a presentation on MultiQCs recent improvements in our institute, so I figured I'd run the profiler again to check if I missed anything. I found this, but I can't recall this was in 1.22, it must be a later addition. 

List membership checking is expensive, all the items are checked for equality. If a dict or set is used, only the items with colliding hashes are checked for equality. In practice that means one equality check per membership check. If there are lots of items in the list, as is the case with the test data, membership checking takes increasingly long. According to py-spy, this was taking 10% of the entire test-data runtime!
