### PR TITLE
Fix repeated modules with `path_filters`

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -61,6 +61,7 @@ class BaseMultiqcModule:
     ):
         # Custom options from user config that can overwrite base module values
         self.name = self.mod_cust_config.get("name", name)
+        self.id = anchor  # cannot be overwritten for repeated modules with path_filters
         self.anchor = self.mod_cust_config.get("anchor", anchor)
         target = self.mod_cust_config.get("target", target)
         self.href = self.mod_cust_config.get("href", href)

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -224,9 +224,9 @@ def _order_modules_and_sections():
     """
 
     # In case if user passed exclude_modules or include_modules again:
-    mod_anchors = include_or_exclude_modules([mod.anchor for mod in report.modules])
+    mod_ids = include_or_exclude_modules([mod.id for mod in report.modules])
     for mod in report.modules:
-        if mod.anchor not in mod_anchors:
+        if mod.id not in mod_ids:
             mod.hidden = True
 
     # Add section for software versions if any are found
@@ -310,7 +310,7 @@ def render_and_export_plots():
             if s.plot_id:
                 plot = report.plot_by_id[s.plot_id]
                 if isinstance(plot, Plot):
-                    s.plot = plot.add_to_report(report)
+                    s.plot = plot.add_to_report()
                 elif isinstance(plot, str):
                     s.plot = plot
                 else:
@@ -357,7 +357,7 @@ def _render_general_stats_table() -> None:
             "raw_data_fn": "multiqc_general_stats",
         }
         p = table.plot(report.general_stats_data, report.general_stats_headers, pconfig)
-        report.general_stats_html = p.add_to_report(clean_html_id=False)
+        report.general_stats_html = p.add_to_report()
     else:
         config.skip_generalstats = True
 

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -532,7 +532,6 @@ class Plot(BaseModel):
         """
         Build and add the plot data to the report, return an HTML wrapper.
         """
-        # Setting IDs again now that we have "report" object to guarantee uniqueness
         for ds in self.datasets:
             ds.uid = self.id
             if len(self.datasets) > 1:  # for flat plots, each dataset will have its own unique ID

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -280,6 +280,7 @@ class Plot(BaseModel):
         if id is None:  # id of the plot group
             uniq_suffix = "".join(random.sample(string.ascii_lowercase, 10))
             id = f"mqc_plot_{uniq_suffix}"
+        id = report.save_htmlid(id)
 
         # Counts / Percentages / Log10 switch
         add_log_tab = pconfig.logswitch and plot_type in [PlotType.BAR, PlotType.LINE]
@@ -527,13 +528,11 @@ class Plot(BaseModel):
         d = {k: v for k, v in self.__dict__.items() if k not in ("datasets", "layout")}
         return f"<{self.__class__.__name__} {self.id} {d}>"
 
-    def add_to_report(self, clean_html_id=True) -> str:
+    def add_to_report(self) -> str:
         """
         Build and add the plot data to the report, return an HTML wrapper.
         """
         # Setting IDs again now that we have "report" object to guarantee uniqueness
-        if clean_html_id:
-            self.id = report.save_htmlid(self.id)
         for ds in self.datasets:
             ds.uid = self.id
             if len(self.datasets) > 1:  # for flat plots, each dataset will have its own unique ID

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -587,7 +587,7 @@ class ViolinPlot(Plot):
             assert self.main_table_dt is not None
             # Render both, add a switch between table and violin
             table_html, configuration_modal = make_table(self.main_table_dt, violin_id=self.id)
-            violin_html = super().add_to_report(clean_html_id=clean_html_id)
+            violin_html = super().add_to_report()
 
             violin_visibility = "style='display: none;'" if self.show_table_by_default else ""
             html = f"<div id='mqc_violintable_wrapper_{self.id}' {violin_visibility}>{warning}{violin_html}</div>"

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -577,7 +577,7 @@ class ViolinPlot(Plot):
             # Show violin alone.
             # Note that "no_violin" will be ignored here as we need to render _something_. The only case it can
             # happen if violin.plot() is called directly, and "no_violin" is passed, which doesn't make sense.
-            html = warning + super().add_to_report(clean_html_id=clean_html_id)
+            html = warning + super().add_to_report()
         elif self.no_violin:
             assert self.main_table_dt is not None
             # Show table alone


### PR DESCRIPTION
- Make sure module IDs are unique before they added into `report.plot_by_id`
- Add `module.id` separate from `module.anchor`

Fixes https://github.com/MultiQC/MultiQC/issues/2584