### PR TITLE
copy headers with table

### DIFF
--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -27,7 +27,7 @@ $(function () {
 
       return text;
     };
-    $(".mqc_table").tablesorter({ sortInitialOrder: "desc", textExtraction: get_sort_val });
+    $(".mqc_table").tablesorter({ sortInitialOrder: "desc", textExtraction: get_sort_val, cancelSelection: false });
 
     // Update tablesorter if samples renamed
     $(document).on("mqc_renamesamples", function (e, f_texts, t_texts, regex_mode) {


### PR DESCRIPTION
When using the "Copy table" button:
![Screenshot 2024-05-30 at 20-19-04 MultiQC Report](https://github.com/MultiQC/MultiQC/assets/6404517/901052a2-2d68-4a88-9090-6bbbfc201254)

This change will also cause the table headers to be copied as well.

Previously, the `user-select: none` style caused the headers to be omitted while copying.

This has the side-effect of enabling text selection in the headers. I'm not sure if this is good or bad - I could see a user wanting to copy a long header.

Thanks as always!

- [x] This comment contains a description of changes (with reason)