### PR TITLE
Fix running multiqc as library

### DIFF
--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -153,6 +153,9 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None):
                 config.export_plot_formats.append("png")
     if cfg.make_pdf:
         config.template = "simple"
+    if config.template == "simple":
+        config.plots_force_flat = True
+        config.simple_output = True
     if cfg.filename:
         config.filename = cfg.filename
     if cfg.no_megaqc_upload is not None:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -503,6 +503,7 @@ def run(*analysis_dir, clean_up: bool, cfg: Optional[ClConfig] = None) -> RunRes
             "Strict mode specified. Will exit early if a module or a template crashed, and will "
             "give warnings if anything is not optimally configured in a module or a template."
         )
+    report.reset()
     report.multiqc_command = " ".join(sys.argv)
     logger.debug(f"Command used: {report.multiqc_command}")
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -503,7 +503,10 @@ def run(*analysis_dir, clean_up: bool, cfg: Optional[ClConfig] = None) -> RunRes
             "Strict mode specified. Will exit early if a module or a template crashed, and will "
             "give warnings if anything is not optimally configured in a module or a template."
         )
+
+    # In case if run() is called multiple times in the same session:
     report.reset()
+
     report.multiqc_command = " ".join(sys.argv)
     logger.debug(f"Command used: {report.multiqc_command}")
 


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

I noticed a recent regression where running multiqc twice now fails in weird ways.

First, for how to reproduce. The easiest way I found is to just modify https://github.com/MultiQC/MultiQC/blob/9ac15689e50f208a342d4b28d7dccb9cb15d5c3f/multiqc/multiqc.py#L448 with:
```
        result = run(*analysis_dir, clean_up=clean_up, cfg=ClConfig(
            strict=True,
            force=True,
        ))
        result = run(*analysis_dir, clean_up=clean_up, cfg=ClConfig(
            strict=True,
            force=True,
            template="simple",
        ))
```

3 main breakages:
1. `report` module has a ton of globals. In particular, the `html_ids` global gets carried over between runs. This needs to be reset. See: https://github.com/MultiQC/MultiQC/blob/9ac15689e50f208a342d4b28d7dccb9cb15d5c3f/multiqc/report.py#L117
2. It seems the `simple` template configures some `config` at load time: https://github.com/MultiQC/MultiQC/blob/9ac15689e50f208a342d4b28d7dccb9cb15d5c3f/multiqc/templates/simple/__init__.py#L19-L20 - however I found that the second run had `config.simple_output` set to `False` even though the `simple` template is passed in. I assume this has to do with how the global is configured at template load time.
3. I noticed multiqc also messes up loggers. My best guess is it comes from here: https://github.com/MultiQC/MultiQC/blob/9ac15689e50f208a342d4b28d7dccb9cb15d5c3f/multiqc/core/init_log.py#L43 - anyway calling `multiqc.run(...)` and then using your own logger (e.g. `logger.info(...)`) bombs because my own logger was trying to write to the tmp log file multiqc was using, which is now cleaned up. I'm not sure what the solution is here, maybe for multiqc to clean up whatever loggers it configures, but more likely for it to not mess with global root loggers. Anyway, I just ended up calling `logger.handlers.clear()` and `logging.basicConfig(...)` again in my own code after executing multiqc. Tastes bad but it works.

Now onto the fixes, I only tackled 1 and 2. I noticed there is already a `reset` function here: https://github.com/MultiQC/MultiQC/blob/9ac15689e50f208a342d4b28d7dccb9cb15d5c3f/multiqc/interactive.py#L326 but it cannot be imported into `multiqc/multiqc.py`. So I just called `report.reset()` directly.

For the config re: simple, I just mimicked what loading the simple template does, except at config initialization time.

These seem to fix the immediate issues. The abuse of globals certainly makes it tough to understand where they're set/used and how to fully wipe state clean.