### PR TITLE
Fix flat scatter plot with categorical axis

### DIFF
--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -83,36 +83,41 @@ class Dataset(BaseDataset):
         MAX_ANNOTATIONS = 10  # Maximum number of dots to be annotated directly on the plot
         n_annotated = len([el for el in self.points if "annotation" in el])
         if n_annotated < MAX_ANNOTATIONS:
-            # Finding and marking outliers to only label them
-            # 1. Calculate Z-scores
             points = [(i, x) for i, x in enumerate(self.points) if x.get("annotate", True) is not False]
             x_values = np.array([x["x"] for (i, x) in points])
             y_values = np.array([x["y"] for (i, x) in points])
-            x_std = np.std(x_values)
-            y_std = np.std(y_values)
-            if x_std == 0 and y_std == 0:
-                logger.warning(f"Scatter plot {self.plot_id}: all {len(points)} points have the same coordinates")
-                if len(points) == 1:  # Only single point - annotate it!
-                    for i, point in points:
-                        point["annotation"] = point["name"]
-            else:
-                x_z_scores = np.abs((x_values - np.mean(x_values)) / x_std) if x_std else np.zeros_like(x_values)
-                y_z_scores = np.abs((y_values - np.mean(y_values)) / y_std) if y_std else np.zeros_like(y_values)
-                # 2. Find a reasonable threshold so there are not too many outliers
-                threshold = 1.0
-                while threshold <= 6.0:
-                    n_outliers = np.count_nonzero((x_z_scores > threshold) | (y_z_scores > threshold))
-                    # logger.debug(f"Scatter plot outlier threshold: {threshold:.2f}, outliers: {n_outliers}")
-                    if n_annotated + n_outliers <= MAX_ANNOTATIONS:
-                        break
-                    # If there are too many outliers, we increase the threshold until we have less than 10
-                    threshold += 0.2
-                # 3. Annotate outliers that pass the threshold
-                for (i, point), x_z_score, y_z_score in zip(points, x_z_scores, y_z_scores):
-                    # Check if point is an outlier or if total points are less than 10
-                    if x_z_score > threshold or y_z_score > threshold:
-                        point["annotation"] = point["name"]
-            n_annotated = len([point for point in self.points if "annotation" in point])
+
+            x_are_numeric = np.issubdtype(x_values.dtype, np.number)
+            y_are_numeric = np.issubdtype(y_values.dtype, np.number)
+
+            if x_are_numeric and y_are_numeric:
+                # Finding and marking outliers to only label them
+                # 1. Calculate Z-scores
+                x_std = np.std(x_values)
+                y_std = np.std(y_values)
+                if x_std == 0 and y_std == 0:
+                    logger.warning(f"Scatter plot {self.plot_id}: all {len(points)} points have the same coordinates")
+                    if len(points) == 1:  # Only single point - annotate it!
+                        for i, point in points:
+                            point["annotation"] = point["name"]
+                else:
+                    x_z_scores = np.abs((x_values - np.mean(x_values)) / x_std) if x_std else np.zeros_like(x_values)
+                    y_z_scores = np.abs((y_values - np.mean(y_values)) / y_std) if y_std else np.zeros_like(y_values)
+                    # 2. Find a reasonable threshold so there are not too many outliers
+                    threshold = 1.0
+                    while threshold <= 6.0:
+                        n_outliers = np.count_nonzero((x_z_scores > threshold) | (y_z_scores > threshold))
+                        # logger.debug(f"Scatter plot outlier threshold: {threshold:.2f}, outliers: {n_outliers}")
+                        if n_annotated + n_outliers <= MAX_ANNOTATIONS:
+                            break
+                        # If there are too many outliers, we increase the threshold until we have less than 10
+                        threshold += 0.2
+                    # 3. Annotate outliers that pass the threshold
+                    for (i, point), x_z_score, y_z_score in zip(points, x_z_scores, y_z_scores):
+                        # Check if point is an outlier or if total points are less than 10
+                        if x_z_score > threshold or y_z_score > threshold:
+                            point["annotation"] = point["name"]
+                n_annotated = len([point for point in self.points if "annotation" in point])
 
         # If there are few unique colors, we can additionally put a unique list into a legend
         # (even though some color might belong to many distinct names - we will just crop the list)


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2555

For flat scatter plots, we attempt to add labels on some data points by determining outliers. That breaks when there are non-numeric axes. Adding a check to get around this.