### PR TITLE
Update README logos for better compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 &nbsp;
-![MultiQC](https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo.png#gh-light-mode-only)
-![MultiQC](https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo_darkbg.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo_darkbg.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo.png">
+  <img src="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo.png" alt="MultiQC">
+</picture>
 &nbsp;
 
 ### Aggregate bioinformatics results across many samples into a single report

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-&nbsp;
+<h1>
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo_darkbg.png">
   <source media="(prefers-color-scheme: light)" srcset="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo.png">
   <img src="https://github.com/MultiQC/MultiQC/raw/main/docs/images/MultiQC_logo.png" alt="MultiQC">
 </picture>
-&nbsp;
+</h1>
 
 ### Aggregate bioinformatics results across many samples into a single report
 


### PR DESCRIPTION
> [!NOTE]
> PR created without any manual intervention - entirely AI driven and created, using GitHub Copilot Workspace. The only thing I did by hand was write this note! (@ewels)

----

Related to #2567

Updates the README.md to use the `<picture>` HTML tag for displaying the MultiQC logo, ensuring compatibility with both light and dark modes on PyPI and other platforms.
- Replaces the GitHub-specific markdown for light and dark mode logos with a `<picture>` element that includes `<source>` elements for both modes. This ensures the correct logo is displayed based on the user's preference.
- Adds a default `<img>` tag within the `<picture>` element to provide a fallback logo for environments where `<picture>` is not supported.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MultiQC/MultiQC/issues/2567?shareId=a15109ee-11fa-47b9-9dfb-96e116247e37).