### PR TITLE
Fix disabling `sort_rows` in custom content: subclass `TableConfig` from `ValidatedConfig` and use deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ For more information, please see the MultiQC release blog article on the Seqera 
 - Lint check for use of `f["content_lines"]` ([#2485](https://github.com/MultiQC/MultiQC/pull/2485))
 - Allow to set style of line graph (`lines` or `lines+markers`) per plot ([#2413](https://github.com/MultiQC/MultiQC/pull/2413))
 - Add `CMD` to `Dockerfile` so a default run without any parameters displays the `--help` ([#2279](https://github.com/MultiQC/MultiQC/pull/2279))
+- Custom content tables are sorted by key by default (unless `sort_rows: false` is set in config), to harmonize with tables in modules.
 
 ### New modules
 

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -14,7 +14,7 @@ from multiqc import config, report
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 from multiqc.core.exceptions import RunError
 from multiqc.core import plugin_hooks, software_versions
-from multiqc.plots.plotly.plot import PConfigValidationError
+from multiqc.validation import ConfigValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def exec_modules(
             logger.debug(f"No samples found: {this_module}")
         except KeyboardInterrupt:
             raise
-        except PConfigValidationError:
+        except ConfigValidationError:
             raise
         except:  # noqa: E722
             if config.strict:

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -334,8 +334,10 @@ def _render_general_stats_table() -> None:
     # Add general-stats IDs to table row headers
     for idx, h in enumerate(report.general_stats_headers):
         for k in h.keys():
-            if "rid" not in h[k]:
-                h[k]["rid"] = re.sub(r"\W+", "_", k).strip().strip("_")
+            unclean_rid = h[k].get("rid", k)
+            rid = re.sub(r"\W+", "_", unclean_rid).strip().strip("_")
+            h[k]["rid"] = report.save_htmlid(report.clean_htmlid(rid), skiplint=True)
+
             ns_html = re.sub(r"\W+", "_", h[k]["namespace"]).strip().strip("_").lower()
             report.general_stats_headers[idx][k]["rid"] = report.save_htmlid(
                 f"mqc-generalstats-{ns_html}-{h[k]['rid']}"

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -355,6 +355,15 @@ class MultiqcModule(BaseMultiqcModule):
         # Table
         if plot_type == "table":
             headers = mod["config"].get("headers")
+
+            # handle some legacy fields for backwards compat
+            sort_rows = pconfig.pop("sortRows", None)
+            if sort_rows is not None:
+                pconfig["sort_rows"] = sort_rows
+            no_violin = pconfig.pop("no_beeswarm", None)
+            if no_violin is not None:
+                pconfig["no_violin"] = no_violin
+
             plot = table.plot(mod["data"], headers=headers, pconfig=pconfig)
 
         # Bar plot

--- a/multiqc/modules/damageprofiler/damageprofiler.py
+++ b/multiqc/modules/damageprofiler/damageprofiler.py
@@ -132,7 +132,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         headers = {
             f"{readend}1": {
-                "id": f"misinc-stats-1st-{readend}-{substitution}",
+                "rid": f"misinc-stats-1st-{readend}-{substitution}",
                 "title": f"{readend} {substitution} 1st base",
                 "description": f"{readend} 1st base substitution frequency for {substitution}",
                 "max": 100,
@@ -142,7 +142,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "modify": lambda x: x * 100.0,
             },
             f"{readend}2": {
-                "id": f"misinc-stats-2nd-{readend}-{substitution}",
+                "rid": f"misinc-stats-2nd-{readend}-{substitution}",
                 "title": f"{readend} {substitution} 2nd base",
                 "description": f"{readend} 2nd base substitution frequency for {substitution}",
                 "max": 100,

--- a/multiqc/modules/mapdamage/mapdamage.py
+++ b/multiqc/modules/mapdamage/mapdamage.py
@@ -172,7 +172,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         headers = {
             f"mapdamage-{readend}1": {
-                "id": f"misinc-stats-1st-{readend}-{substitution}",
+                "rid": f"misinc-stats-1st-{readend}-{substitution}",
                 "title": f"{readend} {substitution} 1st base",
                 "description": f"{readend} 1st base substitution frequency for {substitution}",
                 "max": 100,
@@ -182,7 +182,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "modify": lambda x: x * 100.0,
             },
             f"mapdamage-{readend}2": {
-                "id": f"misinc-stats-2nd-{readend}-{substitution}",
+                "rid": f"misinc-stats-2nd-{readend}-{substitution}",
                 "title": f"{readend} {substitution} 2nd base",
                 "description": f"{readend} 2nd base substitution frequency for {substitution}",
                 "max": 100,

--- a/multiqc/modules/pbmarkdup/pbmarkdup.py
+++ b/multiqc/modules/pbmarkdup/pbmarkdup.py
@@ -110,7 +110,6 @@ class MultiqcModule(BaseMultiqcModule):
 
         general_stats_headers = {
             "unique_molecules": {
-                "id": "unique_molecules",
                 "title": "% Unique Molecules",
                 "description": "Percentage of unique molecules",
                 "suffix": "%",
@@ -120,7 +119,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "scale": "RdYlGn",
             },
             "duplicate_reads": {
-                "id": "duplicate_erads",
                 "title": "% Duplicate Reads",
                 "description": "Percentage of duplicate reads",
                 "suffix": "%",

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -203,7 +203,7 @@ class MultiqcModule(BaseMultiqcModule):
         color_list = ["Oranges", "Reds", "Blues", "Greens"]
         for order, header in enumerate(cat_names):
             table_cats[header] = {
-                "name": header,
+                "title": header,
                 "format": "{:,.0f}",
                 "scale": color_list[order % 4],
             }
@@ -217,7 +217,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.add_section(
             name="General Statistics",
             anchor="vep-general-statistics",
-            helptext="Table showing general statistics of VEP annotaion run",
+            helptext="Table showing general statistics of VEP annotation run",
             plot=table.plot(table_data, table_cats, table_config),
         )
 

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -203,7 +203,7 @@ class MultiqcModule(BaseMultiqcModule):
         # https://whatshap.readthedocs.io/en/latest/guide.html#the-tsv-statistics-format
         general_stats_headers = {
             "frac_het_phased": {
-                "id": "perc_het_phased",
+                "rid": "perc_het_phased",
                 "title": "% Phased Variants",
                 "description": """Fraction of heterozygous variants
                                           that could be phased.
@@ -217,7 +217,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "bp_per_block_avg": {
-                "id": "bp_per_block_avg",
+                "rid": "bp_per_block_avg",
                 "title": "Avg bp per Block",
                 "description": """Description of the distribution of non-singleton
                                         block lengths, where the length of a block is the
@@ -229,7 +229,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "block_n50": {
-                "id": "block_n50",
+                "rid": "block_n50",
                 "title": "NG50",
                 "description": """The NG50 value of the distribution of the block
                                         lengths. Interleaved blocks are cut in order to
@@ -301,7 +301,7 @@ class MultiqcModule(BaseMultiqcModule):
         # https://whatshap.readthedocs.io/en/latest/guide.html#the-tsv-statistics-format
         stats_headers = {
             "variants": {
-                "id": "variants",
+                "rid": "variants",
                 "title": "Input Variants",
                 "description": """Number of biallelic variants in the input VCF, but
                                         excluding any non-SNV variants if --only-snvs was
@@ -310,7 +310,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "heterozygous_variants": {
-                "id": "heterozygous_variants",
+                "rid": "heterozygous_variants",
                 "title": "Heterozygous Variants",
                 "description": """The number of biallelic, heterozygous variants in
                                         the input VCF. This is a subset of Input Variants.""",
@@ -318,7 +318,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "heterozygous_snvs": {
-                "id": "heterozygous_snvs",
+                "rid": "heterozygous_snvs",
                 "title": "Heterozygous SNVs",
                 "description": """The number of biallelic, heterozygous SNVs in the
                                         input VCF. This is a subset of Heterozygous
@@ -327,7 +327,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "unphased": {
-                "id": "unphased",
+                "rid": "unphased",
                 "title": "Unphased Variants",
                 "description": """The number of biallelic, heterozygous variants that
                                         are not marked as phased in the input VCF. This
@@ -336,7 +336,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "phased": {
-                "id": "phased",
+                "rid": "phased",
                 "title": "Phased Variants",
                 "description": """The number of biallelic, heterozygous variants that
                                         are marked as phased in the input VCF. This is
@@ -346,7 +346,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "phased_snvs": {
-                "id": "phased_snvs",
+                "rid": "phased_snvs",
                 "title": "Phased SNVs",
                 "description": """The number of biallelic, heterozygous SNVs that are
                                         marked as phased in the input VCF. This is a subset
@@ -355,21 +355,21 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "blocks": {
-                "id": "blocks",
+                "rid": "blocks",
                 "title": "Blocks",
                 "description": "The total number of phase sets/blocks.",
                 "format": "{:,.0f}",
                 "hidden": False,
             },
             "singletons": {
-                "id": "singletons",
+                "rid": "singletons",
                 "title": "Singletons",
                 "description": "The number of blocks that contain exactly one variant.",
                 "format": "{:,.0f}",
                 "hidden": False,
             },
             "bp_per_block_sum": {
-                "id": "bp_per_block_sum",
+                "rid": "bp_per_block_sum",
                 "title": "Total Phased bp",
                 "description": """The sum of the lengths of all non-singleton
                                         blocks, where the length of a block is the
@@ -380,7 +380,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "variant_per_block_avg": {
-                "id": "variant_per_block_avg",
+                "rid": "variant_per_block_avg",
                 "title": "Avg Variants per Block",
                 "description": """Description of the distribution of non-singleton
                                         block sizes, where the size of a block is the number
@@ -390,7 +390,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "frac_het_phased": {
-                "id": "perc_het_phased",
+                "rid": "perc_het_phased",
                 "title": "% Phased Variants",
                 "description": """Fraction of heterozygous variants
                                           that could be phased.
@@ -403,7 +403,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": True,
             },
             "bp_per_block_avg": {
-                "id": "bp_per_block_avg",
+                "rid": "bp_per_block_avg",
                 "title": "Avg bp per Block",
                 "description": """Description of the distribution of non-singleton
                                         block lengths, where the length of a block is the
@@ -414,7 +414,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": True,
             },
             "block_n50": {
-                "id": "block_n50",
+                "rid": "block_n50",
                 "title": "NG50",
                 "description": """The NG50 value of the distribution of the block
                                         lengths. Interleaved blocks are cut in order to

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -203,7 +203,6 @@ class MultiqcModule(BaseMultiqcModule):
         # https://whatshap.readthedocs.io/en/latest/guide.html#the-tsv-statistics-format
         general_stats_headers = {
             "frac_het_phased": {
-                "rid": "perc_het_phased",
                 "title": "% Phased Variants",
                 "description": """Fraction of heterozygous variants
                                           that could be phased.
@@ -217,7 +216,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "bp_per_block_avg": {
-                "rid": "bp_per_block_avg",
                 "title": "Avg bp per Block",
                 "description": """Description of the distribution of non-singleton
                                         block lengths, where the length of a block is the
@@ -229,7 +227,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "block_n50": {
-                "rid": "block_n50",
                 "title": "NG50",
                 "description": """The NG50 value of the distribution of the block
                                         lengths. Interleaved blocks are cut in order to
@@ -301,7 +298,6 @@ class MultiqcModule(BaseMultiqcModule):
         # https://whatshap.readthedocs.io/en/latest/guide.html#the-tsv-statistics-format
         stats_headers = {
             "variants": {
-                "rid": "variants",
                 "title": "Input Variants",
                 "description": """Number of biallelic variants in the input VCF, but
                                         excluding any non-SNV variants if --only-snvs was
@@ -310,7 +306,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "heterozygous_variants": {
-                "rid": "heterozygous_variants",
                 "title": "Heterozygous Variants",
                 "description": """The number of biallelic, heterozygous variants in
                                         the input VCF. This is a subset of Input Variants.""",
@@ -318,7 +313,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "heterozygous_snvs": {
-                "rid": "heterozygous_snvs",
                 "title": "Heterozygous SNVs",
                 "description": """The number of biallelic, heterozygous SNVs in the
                                         input VCF. This is a subset of Heterozygous
@@ -327,7 +321,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "unphased": {
-                "rid": "unphased",
                 "title": "Unphased Variants",
                 "description": """The number of biallelic, heterozygous variants that
                                         are not marked as phased in the input VCF. This
@@ -336,7 +329,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "phased": {
-                "rid": "phased",
                 "title": "Phased Variants",
                 "description": """The number of biallelic, heterozygous variants that
                                         are marked as phased in the input VCF. This is
@@ -346,7 +338,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "phased_snvs": {
-                "rid": "phased_snvs",
                 "title": "Phased SNVs",
                 "description": """The number of biallelic, heterozygous SNVs that are
                                         marked as phased in the input VCF. This is a subset
@@ -355,21 +346,18 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "blocks": {
-                "rid": "blocks",
                 "title": "Blocks",
                 "description": "The total number of phase sets/blocks.",
                 "format": "{:,.0f}",
                 "hidden": False,
             },
             "singletons": {
-                "rid": "singletons",
                 "title": "Singletons",
                 "description": "The number of blocks that contain exactly one variant.",
                 "format": "{:,.0f}",
                 "hidden": False,
             },
             "bp_per_block_sum": {
-                "rid": "bp_per_block_sum",
                 "title": "Total Phased bp",
                 "description": """The sum of the lengths of all non-singleton
                                         blocks, where the length of a block is the
@@ -380,7 +368,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "variant_per_block_avg": {
-                "rid": "variant_per_block_avg",
                 "title": "Avg Variants per Block",
                 "description": """Description of the distribution of non-singleton
                                         block sizes, where the size of a block is the number
@@ -390,7 +377,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": False,
             },
             "frac_het_phased": {
-                "rid": "perc_het_phased",
                 "title": "% Phased Variants",
                 "description": """Fraction of heterozygous variants
                                           that could be phased.
@@ -414,7 +400,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "hidden": True,
             },
             "block_n50": {
-                "rid": "block_n50",
                 "title": "NG50",
                 "description": """The NG50 value of the distribution of the block
                                         lengths. Interleaved blocks are cut in order to

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -22,8 +22,8 @@ from multiqc.core.update_config import update_config, ClConfig
 from multiqc.core.version_check import check_version
 from multiqc.core.write_results import write_results
 from multiqc.core.exceptions import RunError
-from multiqc.plots.plotly.plot import PConfigValidationError
 from multiqc.utils import util_functions
+from multiqc.validation import ConfigValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -456,7 +456,7 @@ def run_cli(analysis_dir: Tuple[str], clean_up: bool, **kwargs):
         )
         result = RunResult(sys_exit_code=1)
 
-    except PConfigValidationError:
+    except ConfigValidationError:
         result = RunResult(sys_exit_code=1)
 
     # End execution using the exit code returned from MultiQC

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -38,6 +38,7 @@ class TableColumn(ValidatedConfig):
     Column model class. Holds configuration for a single column in a table.
     """
 
+    id: str = Field(None, deprecated="rid")
     rid: str
     title: str
     description: str

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -22,10 +22,10 @@ class TableConfig(PConfig):
     save_file: bool = False
     raw_data_fn: Optional[str] = None
     defaultsort: Optional[List[Dict[str, str]]] = None
-    sort_rows: bool = Field(True, alias="sortRows")
+    sort_rows: bool = True
     only_defined_headers: bool = True
     col1_header: str = "Sample Name"
-    no_violin: bool = Field(False, alias="no_beeswarm")
+    no_violin: bool = False
     scale: Union[str, bool] = "GnBu"
     min: Optional[Union[int, float]] = None
 

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -23,7 +23,7 @@ class TableConfig(PConfig):
     save_file: bool = False
     raw_data_fn: Optional[str] = None
     defaultsort: Optional[List[Dict[str, str]]] = None
-    sortRows: bool = Field(True, deprecated="sortRows")
+    sortRows: bool = Field(True, deprecated="sort_rows")
     sort_rows: bool = True
     only_defined_headers: bool = True
     col1_header: str = "Sample Name"

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -186,7 +186,7 @@ class DataTable(BaseModel):
                 # Unique id to avoid overwriting by other datasets
                 unclean_rid = headers[d_idx][k].get("rid", k)
                 rid = re.sub(r"\W+", "_", unclean_rid).strip().strip("_")
-                headers[d_idx][k]["rid"] = report.save_htmlid(rid)
+                headers[d_idx][k]["rid"] = report.save_htmlid(rid, skiplint=True)
 
                 # Applying defaults presets for data keys if shared_key is set to base_count or read_count
                 shared_key = headers[d_idx][k].get("shared_key", None)

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from multiqc import config, report
 from multiqc.plots.plotly.plot import PConfig
+from multiqc.validation import ValidatedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +23,15 @@ class TableConfig(PConfig):
     save_file: bool = False
     raw_data_fn: Optional[str] = None
     defaultsort: Optional[List[Dict[str, str]]] = None
-    sort_rows: bool = True
+    sort_rows: bool = Field(True, deprecated="sortRows")
     only_defined_headers: bool = True
     col1_header: str = "Sample Name"
-    no_violin: bool = False
+    no_violin: bool = Field(False, deprecated="no_beeswarm")
     scale: Union[str, bool] = "GnBu"
     min: Optional[Union[int, float]] = None
 
 
-class TableColumn(BaseModel):
+class TableColumn(ValidatedConfig):
     """
     Column model class. Holds configuration for a single column in a table.
     """
@@ -41,7 +42,8 @@ class TableColumn(BaseModel):
     namespace: str
     scale: Union[str, bool]
     hidden: bool
-    color: str = Field(validation_alias="colour")
+    colour: Optional[str] = Field(None, deprecated="color")
+    color: str
     placement: float = None
     max: Optional[float] = None
     dmax: Optional[float] = None

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -23,10 +23,12 @@ class TableConfig(PConfig):
     save_file: bool = False
     raw_data_fn: Optional[str] = None
     defaultsort: Optional[List[Dict[str, str]]] = None
-    sort_rows: bool = Field(True, deprecated="sortRows")
+    sortRows: bool = Field(True, deprecated="sortRows")
+    sort_rows: bool = True
     only_defined_headers: bool = True
     col1_header: str = "Sample Name"
-    no_violin: bool = Field(False, deprecated="no_beeswarm")
+    no_beeswarm: bool = Field(False, deprecated="no_violin")
+    no_violin: bool = False
     scale: Union[str, bool] = "GnBu"
     min: Optional[Union[int, float]] = None
 

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -184,8 +184,9 @@ class DataTable(BaseModel):
             formatted_dataset: Dict[str, Dict[str, str]] = defaultdict(dict)
             for k in keys:
                 # Unique id to avoid overwriting by other datasets
-                if "rid" not in headers[d_idx][k]:
-                    headers[d_idx][k]["rid"] = report.save_htmlid(re.sub(r"\W+", "_", k).strip().strip("_"))
+                unclean_rid = headers[d_idx][k].get("rid", k)
+                rid = re.sub(r"\W+", "_", unclean_rid).strip().strip("_")
+                headers[d_idx][k]["rid"] = report.save_htmlid(rid)
 
                 # Applying defaults presets for data keys if shared_key is set to base_count or read_count
                 shared_key = headers[d_idx][k].get("shared_key", None)

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -186,7 +186,7 @@ class DataTable(BaseModel):
                 # Unique id to avoid overwriting by other datasets
                 unclean_rid = headers[d_idx][k].get("rid", k)
                 rid = re.sub(r"\W+", "_", unclean_rid).strip().strip("_")
-                headers[d_idx][k]["rid"] = report.save_htmlid(rid, skiplint=True)
+                headers[d_idx][k]["rid"] = report.save_htmlid(report.clean_htmlid(rid), skiplint=True)
 
                 # Applying defaults presets for data keys if shared_key is set to base_count or read_count
                 shared_key = headers[d_idx][k].get("shared_key", None)

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -741,12 +741,10 @@ def dois_tofile(modules: List["BaseMultiqcModule"]):
             print(body.encode("utf-8", "ignore").decode("utf-8"), file=f)
 
 
-def save_htmlid(html_id, skiplint=False):
-    """Take a HTML ID, sanitise for HTML, check for duplicates and save.
-    Returns sanitised, unique ID"""
-    global html_ids
-    global lint_errors
-
+def clean_htmlid(html_id):
+    """
+    Clean up an HTML ID to remove illegal characters.
+    """
     # Trailing whitespace
     html_id_clean = html_id.strip()
 
@@ -759,6 +757,18 @@ def save_htmlid(html_id, skiplint=False):
 
     # Replace illegal characters
     html_id_clean = re.sub("[^a-zA-Z0-9_-]+", "_", html_id_clean)
+
+    return html_id_clean
+
+
+def save_htmlid(html_id, skiplint=False):
+    """Take a HTML ID, sanitise for HTML, check for duplicates and save.
+    Returns sanitised, unique ID"""
+    global html_ids
+    global lint_errors
+
+    # Clean up the HTML ID
+    html_id_clean = clean_htmlid(html_id)
 
     # Validate if linting
     modname = ""

--- a/multiqc/validation.py
+++ b/multiqc/validation.py
@@ -1,0 +1,96 @@
+import inspect
+import logging
+
+from pydantic import BaseModel, ValidationError, model_validator
+from typeguard import check_type, TypeCheckError
+
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigValidationError(Exception):
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        super().__init__()
+
+
+_validation_errors = []
+
+
+class ValidatedConfig(BaseModel):
+    def __init__(self, **data):
+        try:
+            super().__init__(**data)
+        except ValidationError as e:
+            if not _validation_errors:
+                raise
+            else:
+                # errors are already added into plot.pconfig_validation_errors by a custom validator
+                logger.debug(e)
+
+        if _validation_errors:
+            # Get module name
+            modname = ""
+            callstack = inspect.stack()
+            for n in callstack:
+                if "multiqc/modules/" in n[1] and "base_module.py" not in n[1]:
+                    callpath = n[1].split("multiqc/modules/", 1)[-1]
+                    modname = f"{callpath}: "
+                    break
+
+            plot_type = self.__class__.__name__.replace("Config", "")
+            logger.error(f"{modname}Invalid {plot_type} plot configuration {data}:")
+            for error in _validation_errors:
+                logger.error(f"• {error}")
+            _validation_errors.clear()  # Reset for interactive usage
+            raise ConfigValidationError(module_name=modname)
+
+    # noinspection PyNestedDecorators
+    @model_validator(mode="before")
+    @classmethod
+    def validate_fields(cls, values):
+        # Check unrecognized fields
+        filtered_values = {}
+        for name, val in values.items():
+            if name not in cls.model_fields:
+                _validation_errors.append(
+                    f"unrecognized field '{name}'. Available fields: {', '.join(cls.model_fields.keys())}"
+                )
+            else:
+                filtered_values[name] = val
+        values = filtered_values
+
+        # Convert deprecated fields
+        values_without_deprecateds = {}
+        for name, val in values.items():
+            if cls.model_fields[name].deprecated:
+                new_name = cls.model_fields[name].deprecated
+                logger.debug(f"Deprecated field '{name}'. Use '{new_name}' instead")
+                if new_name not in values:
+                    values_without_deprecateds[new_name] = val
+            else:
+                values_without_deprecateds[name] = val
+        values = values_without_deprecateds
+
+        # Check missing fields
+        for name, field in cls.model_fields.items():
+            if field.is_required():
+                if name not in values:
+                    _validation_errors.append(f"missing required field '{name}'")
+
+        # Check types
+        for name, val in values.items():
+            field = cls.model_fields[name]
+            expected_type = field.annotation
+            try:
+                check_type(val, expected_type)
+            except TypeCheckError as e:
+                v_str = repr(val)
+                if len(v_str) > 20:
+                    v_str = v_str[:20] + "..."
+                expected_type_str = str(expected_type).replace("typing.", "")
+                msg = f"'{name}': expected type '{expected_type_str}', got '{type(val).__name__}' {v_str}"
+                _validation_errors.append(msg)
+                logger.debug(f"{msg}: {e}")
+
+        return values


### PR DESCRIPTION

- [x] This comment contains a description of changes (with reason)

I found that it is no longer possible to disable row sorting in custom content. Here's an example `mycc_mqc.json`:

```
{
  "data": {
    "cc_b": {
      "Col1": "Hi"
    },
    "cc_a": {
      "Col1": "Hello"
    }
  },
  "file_format": "json",
  "headers": {
    "Col1": {}
  },
  "id": "mycc",
  "parent_name": "My CC",
  "pconfig": {
    "sortRows": false
  },
  "plot_type": "table",
  "section_name": "CC Section"
}
```

We get this error:

```
              plot | • unrecognized field 'sortRows'. Available fields: id, table_title, title, height, width, square, logswitch, logswitch_active, logswitch_label, cpswitch, cpswitch_c_active, cpswitch_counts_label, cpswitch_percent_label, xLog, yLog, xlog, ylog, data_labels, xTitle, yTitle, xlab, ylab, xsuffix, ysuffix, tt_suffix, xLabFormat, yLabFormat, yLabelFormat, xlab_format, ylab_format, tt_label, xDecimals, yDecimals, decimalPlaces, x_decimals, y_decimals, tt_decimals, xmin, xmax, ymin, ymax, xFloor, xCeiling, yFloor, yCeiling, x_clipmin, x_clipmax, y_clipmin, y_clipmax, save_data_file, namespace, save_file, raw_data_fn, defaultsort, sort_rows, only_defined_headers, col1_header, no_violin, scale, min
```

Changing from `sortRows` to `sort_rows`, it does actually run:
![Screenshot 2024-06-02 at 01-59-52 MultiQC Report](https://github.com/MultiQC/MultiQC/assets/6404517/54bf7cf1-e770-489d-8a44-b39b246c9907)

Note that the rows _are_ sorted!

So in this case it succeeded but didn't do what it was supposed to.

I chased down the issue to this parsing: https://github.com/MultiQC/MultiQC/blob/788e78beb890467c383c712295c4e86c16fc25e8/multiqc/plots/table.py#L37

Adding in logging before/after:

```
Before constructor pconfig['sort_rows']=False
After constructor pconfig.sort_rows=True
```

After more digging, I found the issue stems from this alias: https://github.com/MultiQC/MultiQC/blob/788e78beb890467c383c712295c4e86c16fc25e8/multiqc/plots/table_object.py#L25

I minimally reproduced this with just pydantic:

```
$ docker run -it --rm -v $(pwd):/work -w /work python:3.12 bash
root@8bead663aa61:/work# pip install pydantic
root@8bead663aa61:/work# python3
>>> from pydantic import BaseModel, Field
>>> class TableConfig(BaseModel):
...     sort_rows: bool = Field(True, alias="sortRows")
... 
>>> TableConfig(sort_rows=False)
TableConfig(sort_rows=True)
>>> TableConfig(sortRows=False)
TableConfig(sort_rows=False)
```

This is exactly what's going on. The field is aliased, we pass in `sort_rows`, and it just ignores it.

One confounding issue is that there is already complex pre-validation logic on the pydantic models: https://github.com/MultiQC/MultiQC/blob/788e78beb890467c383c712295c4e86c16fc25e8/multiqc/plots/plotly/plot.py#L126

Specifically, `cls.model_fields` uses the non-aliased fields but `values` is raw and has aliases. From the [pydantic docs](https://docs.pydantic.dev/latest/concepts/validators/#before-after-wrap-and-plain-validators)

> Before validators run before Pydantic's internal parsing and validation (e.g. coercion of a str to an int). These are more flexible than After validators since they can modify the raw input, but they also have to deal with the raw input, which in theory could be any arbitrary object.

So they pretty much recommend against before validators for this exact reason, you need to hack around some of pydantic's great features. I'm not sure if an `after` validator was considered instead - I could believe that it came with worse tradeoffs.

Okay, so where to go from here? A few options came to mind:

1. Should pydantic just fail when parsing? You can do this:

    ```
    >>> from pydantic import BaseModel, ConfigDict, Field
    >>> class TableConfig(BaseModel):
    ...     model_config = ConfigDict(extra="forbid")
    ...     sort_rows: bool = Field(True, alias="sortRows")
    ... 
    >>> TableConfig(sort_rows=False)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 176, in __init__
        self.__pydantic_validator__.validate_python(data, self_instance=self)
    pydantic_core._pydantic_core.ValidationError: 1 validation error for TableConfig
    sort_rows
      Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
        For further information visit https://errors.pydantic.dev/2.7/v/extra_forbidden
    ```

    So this would certainly be an improvement. At least it would have failed loudly. I have no idea what it'd break. But it wouldn't fix the issue, it would make both inputs (`sort_rows` and `sortRows`) break.

1. Switch to an `after` validator - seems worthwhile but quite involved!
1. In the `before` validator, it is actually possible to get fields by their alias. Looking at the `model_fields` [docs](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields), the dict values of type `FieldInfo` [do have](https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.FieldInfo) and `Alias` attribute. So in theory, the `before` validator could search the dict for every value rather than trying to index the dict by key. Quite messy and probably poorly performing, but maybe performance here doesn't matter.
1. I decided to check how many aliases were even used:

    ```
     j@spider  ~/third-party/MultiQC   main ±  rg alias= -t py
    multiqc/plots/table_object.py
    25:    sort_rows: bool = Field(True, alias="sortRows")
    28:    no_violin: bool = Field(False, alias="no_beeswarm")
    44:    color: str = Field(validation_alias="colour")
    ```

    So maybe a special-purpose fix isn't so bad. That's what I went with. i think it's elegant because multiqc mostly controls the multiqc codebase, so you really only need to patch custom-content.

    However, in the future, it seems people will be importing and using multiqc from python. In that case, the models will need backwords compat and it's probably worth making `alias` work. I'm sure these won't be the last fields to be deprecated.