### PR TITLE
Fix `re_contents` search patterns when pattern is in the middle of the file

### DIFF
--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -19,7 +19,7 @@ class LinePlotConfig(PConfig):
     ylab: Optional[str] = None
     categories: bool = False
     smooth_points: Optional[int] = None
-    smooth_points_sumcounts: Optional[int] = None
+    smooth_points_sumcounts: Union[bool, List[bool], None] = None
     extra_series: Union[Dict[str, Any], List[Dict[str, Any]], List[List[Dict[str, Any]]], None] = None
     xMinRange: Optional[Union[float, int]] = Field(None, deprecated="x_minrange")
     yMinRange: Optional[Union[float, int]] = Field(None, deprecated="y_minrange")

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -644,7 +644,7 @@ def search_file(pattern, f: SearchFile, module_key):
                 if expected_contents and expected_contents in line_block:
                     contents_matched = True
                     break
-                if repattern and repattern.match(line_block):
+                if repattern and repattern.search(line_block):
                     contents_matched = True
                     break
                 total_newlines += line_count

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -382,7 +382,7 @@ happy:
   fn: "*.summary.csv"
   contents: "Type,Filter,TRUTH"
 htseq:
-  contents_re: '^(feature\tcount|\w+.*\t\d+)$'
+  contents_re: '^(feature\tcount|\w+.*\t\d+)\n'
   num_lines: 1
 hicexplorer:
   contents: "Min rest. site distance"


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2607 and https://github.com/MultiQC/MultiQC/issues/2608

Checking the file patterns against 4kb multi-line blocks made some pattern miss hits, when the pattern occurs in the middle of the file, e.g. picard WgsMetrics (https://github.com/MultiQC/MultiQC/blob/main/multiqc/search_patterns.yaml#L678), as well as the patterns that math the exact end of the line, e.g. `'^(feature\tcount|\w+.*\t\d+)$'` (https://github.com/MultiQC/MultiQC/blob/main/multiqc/search_patterns.yaml#L385).

Changing the test function from `pattern.match` to `pattern.search` to match within multi-line blocks, and changing `$` to `\n` in patterns like `htseq` where the top line is matched entirely. 