### PR TITLE
Fix `re_contents` search patterns when pattern is in the middle of the file - naive

### DIFF
--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -643,13 +643,17 @@ def search_file(pattern, f: SearchFile, module_key):
             for line_count, line_block in f.line_block_iterator():
                 if expected_contents and expected_contents in line_block:
                     contents_matched = True
+                elif repattern:
+                    for line in line_block.split("\n"):
+                        if repattern.match(line):
+                            contents_matched = True
+                            break
+                if contents_matched:
                     break
-                if repattern and repattern.match(line_block):
-                    contents_matched = True
-                    break
-                total_newlines += line_count
-                if total_newlines >= num_lines:
-                    break
+                else:
+                    total_newlines += line_count
+                    if total_newlines >= num_lines:
+                        break
         except Exception:
             file_search_stats["skipped_file_contents_search_errors"] += 1
             return False

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -658,17 +658,17 @@ picard/oxogmetrics:
 picard/pcr_metrics:
   contents: "TargetedPcrMetrics"
 picard/quality_by_cycle:
-  - contents_re: "[Qq]uality[Bb]y[Cc]ycle"
+  - contents_re: ".*[Qq]uality[Bb]y[Cc]ycle"
     contents: "MEAN_QUALITY"
   - contents: "--algo MeanQualityByCycle"
 picard/quality_score_distribution:
-  - contents_re: "[Qq]uality[Ss]core[Dd]istribution"
+  - contents_re: ".*[Qq]uality[Ss]core[Dd]istribution"
     contents: "COUNT_OF_Q"
   - contents: "--algo QualDistribution"
 picard/quality_yield_metrics:
   contents: "QualityYieldMetrics"
 picard/rnaseqmetrics:
-  contents_re: "[Rr]na[Ss]eq[Mm]etrics"
+  contents_re: ".*[Rr]na[Ss]eq[Mm]etrics"
 picard/rrbs_metrics:
   contents: "RrbsSummaryMetrics"
 picard/sam_file_validation:

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -654,27 +654,33 @@ picard/markdups:
   - contents: "markduplicates.GATKDuplicationMetrics"
   - contents: "--algo Dedup"
 picard/oxogmetrics:
-  contents: "OxoGMetrics"
+  - contents: "# picard.analysis.CollectOxoGMetrics"
+  - contents_re: "# CollectMultipleMetrics .*OxoGMetrics"
 picard/pcr_metrics:
-  contents: "TargetedPcrMetrics"
+  - contents: "# picard.analysis.directed.CollectTargetedPcrMetrics"
+  - contents_re: "# CollectMultipleMetrics .*TargetedPcrMetrics"
 picard/quality_by_cycle:
-  - contents_re: ".*[Qq]uality[Bb]y[Cc]ycle"
-    contents: "MEAN_QUALITY"
+  - contents: "# MeanQualityByCycle"
   - contents: "--algo MeanQualityByCycle"
+  - contents_re: ".*CollectMultipleMetrics.*MeanQualityByCycle"
 picard/quality_score_distribution:
-  - contents_re: ".*[Qq]uality[Ss]core[Dd]istribution"
-    contents: "COUNT_OF_Q"
+  - contents: "# QualityScoreDistribution"
+  - contents_re: ".*CollectMultipleMetrics.*QualityScoreDistribution"
   - contents: "--algo QualDistribution"
 picard/quality_yield_metrics:
-  contents: "QualityYieldMetrics"
+  - contents: "# CollectQualityYieldMetrics"
+  - contents_re: ".*CollectMultipleMetrics.*QualityYieldMetrics"
 picard/rnaseqmetrics:
-  contents_re: ".*[Rr]na[Ss]eq[Mm]etrics"
+  - contents: "# picard.analysis.Collectrnaseqmetrics"
+  - contents: "# picard.analysis.CollectRnaSeqMetrics"
+  - contents_re: "# CollectMultipleMetrics .*RnaSeqMetrics"
 picard/rrbs_metrics:
-  contents: "RrbsSummaryMetrics"
+  - contents: "# picard.analysis.CollectRrbsMetrics"
+  - contents_re: "# CollectMultipleMetrics .*RrbsMetrics"
 picard/sam_file_validation:
   fn: "*[Vv]alidate[Ss]am[Ff]ile*"
 picard/variant_calling_metrics:
-  contents: "VariantCallingDetailMetrics"
+  contents_re: "## METRICS CLASS.*VariantCallingDetailMetrics"
 picard/wgs_metrics:
   contents_re: "## METRICS CLASS.*WgsMetrics"
 picard/collectilluminabasecallingmetrics:

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -384,6 +384,7 @@ happy:
 htseq:
   contents_re: '^(feature\tcount|\w+.*\t\d+)$'
   num_lines: 1
+  shared: true
 hicexplorer:
   contents: "Min rest. site distance"
   max_filesize: 4096


### PR DESCRIPTION
Another attempt to address https://github.com/MultiQC/MultiQC/pull/2609. Fixes https://github.com/MultiQC/MultiQC/issues/2607 and https://github.com/MultiQC/MultiQC/issues/2608

* In each 4-kb block, match each line separately against the contents_re patterns to allow matches in the middle of the file. Defeats the purpose of 4-kb block iteration, unfortunately.
* Prepend some `picard`'s `re_contents` patterns with `.*` to allow matching in the middle of the string (otherwise requires to match from the start).
* Mark the `htseq`'s `".*\t.*"` way-too-generic pattern as "shared" to avoid accidental matching to picard and other files that have two columns.