### PR TITLE
UMI-tools extract module: Improve plots

### DIFF
--- a/multiqc/modules/umitools/umitools.py
+++ b/multiqc/modules/umitools/umitools.py
@@ -73,7 +73,13 @@ class MultiqcModule(BaseMultiqcModule):
         if extract_data_by_sample:
             self.extract_general_stats_table(extract_data_by_sample)
             self.umitools_extract_barplot(extract_data_by_sample)
-            self.umitools_extract_barplot_regex(extract_data_by_sample)
+
+            # Only plot regex match rate if we have regex extraction logs:
+            if any(
+                any(key in v for key in ["read1_match", "read2_match", "read1_mismatch", "read2_mismatch"])
+                for v in extract_data_by_sample.values()
+            ):
+                self.umitools_extract_barplot_regex(extract_data_by_sample)
 
     def _parse_s_name(self, f) -> Optional[str]:
         # Get the s_name from the input file if possible

--- a/multiqc/modules/umitools/umitools.py
+++ b/multiqc/modules/umitools/umitools.py
@@ -142,7 +142,7 @@ class MultiqcModule(BaseMultiqcModule):
                     data[key] = re_matches.group(1)
                 else:
                     data[key] = type_(re_matches.group(1))
-            
+
             # Calculate a few simple supplementary stats
             try:
                 data["extract_percent_passing"] = round(
@@ -226,7 +226,7 @@ class MultiqcModule(BaseMultiqcModule):
                 },
             ),
         )
-    
+
     def umitools_extract_barplot(self, data_by_sample):
         keys = {
             "extract_output_reads": {"color": "#7fc9c7", "name": "Read1 Match"},
@@ -251,24 +251,37 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
     def umitools_extract_barplot_regex(self, data_by_sample):
-        keys = {
-            "read1_match": {"color": "#7fc9c7", "name": "Read1 Match"},
-            "read1_mismatch": {"color": "#fd9286", "name": "Read1 Mismatch"},
-            "read2_match": {"color": "#7f89c9", "name": "Read2 Match"},
-            "read2_mismatch": {"color": "#fd86aa", "name": "Read2 Mismatch"},
-        }
+        keys = [
+            {
+                "read1_match": {"color": "#7fc9c7", "name": "Read1 Match"},
+                "read1_mismatch": {"color": "#fd9286", "name": "Read1 Mismatch"},
+            },
+            {
+                "read2_match": {"color": "#7f89c9", "name": "Read2 Match"},
+                "read2_mismatch": {"color": "#fd86aa", "name": "Read2 Mismatch"},
+            },
+        ]
 
         # Add a section with a barplot plot of UMI stats to the report
         self.add_section(
-            name="Extraction Stats",
+            name="UMI extraction regex match rate",
             anchor="umitools_extract_regex",
-            description="Read stats from `umi_tools extract`",
+            description="Regex match rate of `umi_tools extract`",
             plot=bargraph.plot(
-                data_by_sample,
+                [
+                    {
+                        sample: {key: metrics[key] for key in ("read1_match", "read1_mismatch") if key in metrics}
+                        for sample, metrics in data_by_sample.items()
+                    },
+                    {
+                        sample: {key: metrics[key] for key in ("read2_match", "read2_mismatch") if key in metrics}
+                        for sample, metrics in data_by_sample.items()
+                    },
+                ],
                 keys,
                 {
-                    "id": "umitools_extract_barplot",
-                    "title": "UMI-tools: Extract Stats",
+                    "id": "umitools_extract_regex_barplot",
+                    "title": "UMI-tools: Extract Regex match stats",
                     "ylab": "# Reads",
                     "cpswitch_counts_label": "Number of Reads",
                 },

--- a/multiqc/modules/umitools/umitools.py
+++ b/multiqc/modules/umitools/umitools.py
@@ -193,7 +193,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "scale": "PuRd",
             },
             "extract_percent_passing": {
-                "title": "% Pass Extract",
+                "title": "% UMI Extract",
                 "description": "% reads from which a UMI extraction succeeded.",
                 "max": 100,
                 "min": 0,
@@ -229,8 +229,8 @@ class MultiqcModule(BaseMultiqcModule):
 
     def umitools_extract_barplot(self, data_by_sample):
         keys = {
-            "extract_output_reads": {"color": "#7fc9c7", "name": "Read1 Match"},
-            "extract_removed_reads": {"color": "#fd9286", "name": "Read1 Mismatch"},
+            "extract_output_reads": {"color": "#7fc9c7", "name": "Extraction succeeded"},
+            "extract_removed_reads": {"color": "#fd9286", "name": "Extraction failed"},
         }
 
         # Add a section with a barplot plot of UMI stats to the report
@@ -253,37 +253,39 @@ class MultiqcModule(BaseMultiqcModule):
     def umitools_extract_barplot_regex(self, data_by_sample):
         keys = [
             {
-                "read1_match": {"color": "#7fc9c7", "name": "Read1 Match"},
-                "read1_mismatch": {"color": "#fd9286", "name": "Read1 Mismatch"},
+                "read1_match": {"color": "#7fc9c7", "name": "Match on read 1"},
+                "read1_mismatch": {"color": "#fd9286", "name": "Mismatch on read 1"},
             },
             {
-                "read2_match": {"color": "#7f89c9", "name": "Read2 Match"},
-                "read2_mismatch": {"color": "#fd86aa", "name": "Read2 Mismatch"},
+                "read2_match": {"color": "#7fc9c7", "name": "Match on read 2"},
+                "read2_mismatch": {"color": "#fd9286", "name": "Mismatch on read 2"},
             },
         ]
 
-        # Add a section with a barplot plot of UMI stats to the report
+        subset_read1 = {
+            sample: {key: metrics[key] for key in ("read1_match", "read1_mismatch") if key in metrics}
+            for sample, metrics in data_by_sample.items()
+        }
+
+        subset_read2 = {
+            sample: {key: metrics[key] for key in ("read2_match", "read2_mismatch") if key in metrics}
+            for sample, metrics in data_by_sample.items()
+        }
+
+        # Add a section with a barplot plot of the regex match rate to the report
         self.add_section(
             name="UMI extraction regex match rate",
             anchor="umitools_extract_regex",
             description="Regex match rate of `umi_tools extract`",
             plot=bargraph.plot(
-                [
-                    {
-                        sample: {key: metrics[key] for key in ("read1_match", "read1_mismatch") if key in metrics}
-                        for sample, metrics in data_by_sample.items()
-                    },
-                    {
-                        sample: {key: metrics[key] for key in ("read2_match", "read2_mismatch") if key in metrics}
-                        for sample, metrics in data_by_sample.items()
-                    },
-                ],
+                [subset_read1, subset_read2],
                 keys,
                 {
                     "id": "umitools_extract_regex_barplot",
-                    "title": "UMI-tools: Extract Regex match stats",
+                    "title": "UMI-tools: Extraction regex match rate",
                     "ylab": "# Reads",
                     "cpswitch_counts_label": "Number of Reads",
+                    "data_labels": ["Read 1", "Read 2"],
                 },
             ),
         )


### PR DESCRIPTION
`umi-tools extract` has two modes, a regex-based and a plain mode. So far, MultiQC only supported logs for the regex-based extraction, but not for the plain mode. The former are admittedly also way more informative, but it caused confusion, when the module was run, because the search pattern matched, but then no plots could be generated because of a lack of data.

This PR now adds a new overall success rate plot, that also accommodates samples extracted in plain mode. 

Furthermore, it splits the regex plot into two subplots, since there is no point in stacking Read1 and Read2 matches and mismatches in one bargraph, as they are not mutually exclusive. Most often, only one read harbours the UMI, so only one regex is applied. But if two are applied, both must match for a successful extraction. A read pair will be discarded if only one or neither of the two matches. 

For test data, please see [the corresponding PR to the TestData repo](https://github.com/MultiQC/test-data/pull/328).

- [x] This comment contains a description of changes (with reason)
- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [x] Code is tested and works locally (including with `--strict` flag)
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
