### PR TITLE
Flat plot legend tweaks

### DIFF
--- a/docs/core/getting_started/config.md
+++ b/docs/core/getting_started/config.md
@@ -386,7 +386,7 @@ to scale to these sample numbers, most plot types have two plotting methods in t
 interactive and flat. Flat plots take up the same disk space irrespective of sample number
 and do not consume excessive resources to display.
 
-By default, MultiQC generates flat plots when there are 100 or more samples. This cutoff
+By default, MultiQC generates flat plots when there are 1000 or more samples. This cutoff
 can be changed by changing the `plots_flat_numseries` config option. This behaviour can also
 be changed by running MultiQC with the `--flat` / `--interactive` command line options or by
 setting the `plots_force_flat` / `plots_force_interactive` config options to `True`.

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -111,7 +111,6 @@ plots_force_interactive: bool
 plots_flat_numseries: int
 num_datasets_plot_limit: int
 lineplot_style: str
-lineplot_max_samples: int
 barplot_legend_on_bottom: bool
 violin_downsample_after: int
 violin_min_threshold_outliers: int

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -61,11 +61,10 @@ make_report: true
 make_pdf: false
 plots_force_flat: false
 plots_force_interactive: false
-plots_flat_numseries: 100
+plots_flat_numseries: 1000
 num_datasets_plot_limit: 50
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
-lineplot_max_samples: 100 # turn into a violin plot if more than this number
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples
 violin_min_threshold_outliers: 100 # for more than this number of samples, show only outliers
 violin_min_threshold_no_points: 1000 # for more than this number of samples, show no points

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -430,6 +430,7 @@ class MultiqcModule(BaseMultiqcModule):
             "xmin": 0,
             "xDecimals": False,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}",
+            "showlegend": False if status_checks else True,
         }
         if status_checks:
             pconfig.update(
@@ -486,6 +487,7 @@ class MultiqcModule(BaseMultiqcModule):
             "xmin": 0,
             "xDecimals": False,
             "tt_label": "<b>Phred {point.x}</b>: {point.y} reads",
+            "showlegend": False if status_checks else True,
         }
         if status_checks:
             pconfig.update(
@@ -648,6 +650,7 @@ class MultiqcModule(BaseMultiqcModule):
                 {"name": "Percentages", "ylab": "Percentage", "tt_suffix": "%"},
                 {"name": "Counts", "ylab": "Count", "tt_suffix": ""},
             ],
+            "showlegend": False if status_checks else True,
         }
         if status_checks:
             pconfig.update(
@@ -701,7 +704,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "dash": "dash",
                 "line": {"width": 2},
                 "color": "black",
-                "showlegend": False,
+                "showlegend": False if status_checks else True,
             }
             pconfig["extra_series"] = [[dict(extra_series_config)], [dict(extra_series_config)]]
             pconfig["extra_series"][0][0]["data"] = theoretical_gc
@@ -760,6 +763,7 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "xmin": 0,
             "tt_label": "<b>Base {point.x}</b>: {point.y:.2f}%",
+            "showlegend": False if status_checks else True,
         }
         if status_checks:
             pconfig.update(
@@ -831,6 +835,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "xlab": "Sequence Length (bp)",
                 "ymin": 0,
                 "tt_label": "<b>{point.x} bp</b>: {point.y}",
+                "showlegend": False if status_checks else True,
             }
             if status_checks:
                 pconfig.update(
@@ -878,6 +883,7 @@ class MultiqcModule(BaseMultiqcModule):
             "ymin": 0,
             "tt_decimals": 2,
             "tt_suffix": "%",
+            "showlegend": False if status_checks else True,
         }
         if status_checks:
             pconfig.update(

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -129,7 +129,9 @@ class Dataset(BaseDataset):
         """
         Create a Plotly figure for a dataset
         """
-        layout.height += len(self.lines) * 5  # extra space for legend
+        if layout.showlegend is True:
+            # Extra space for legend
+            layout.height += len(self.lines) * 5
 
         fig = go.Figure(layout=layout)
         for line in self.lines:
@@ -202,14 +204,20 @@ class LinePlot(Plot):
         pconfig: LinePlotConfig,
         lists_of_lines: List[List[LineT]],
     ) -> "LinePlot":
+        max_n_samples = max(len(x) for x in lists_of_lines) if len(lists_of_lines) > 0 else 0
+
         model = Plot.initialize(
             plot_type=PlotType.LINE,
             pconfig=pconfig,
             n_datasets=len(lists_of_lines),
-            n_samples=max(len(x) for x in lists_of_lines) if len(lists_of_lines) > 0 else 0,
+            n_samples=max_n_samples,
             axis_controlled_by_switches=["yaxis"],
             default_tt_label="<br>%{x}: %{y}",
         )
+
+        # Very large legend for automatically enabled flat plot mode is not very helpful
+        if pconfig.showlegend is None and max_n_samples > 250:
+            model.layout.showlegend = False
 
         model.datasets = [Dataset.create(d, lines, pconfig) for d, lines in zip(model.datasets, lists_of_lines)]
 

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -73,6 +73,7 @@ class PConfig(ValidatedConfig):
     y_clipmin: Optional[Union[float, int]] = None
     y_clipmax: Optional[Union[float, int]] = None
     save_data_file: bool = True
+    showlegend: Optional[bool] = None
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -215,6 +216,10 @@ class Plot(BaseModel):
         elif flat_threshold is not None and not config.plots_force_interactive and n_samples > flat_threshold:
             flat = True
 
+        showlegend = pconfig.showlegend
+        if showlegend is None:
+            showlegend = True if flat else False
+
         layout = go.Layout(
             title=go.layout.Title(
                 text=pconfig.title,
@@ -258,7 +263,7 @@ class Plot(BaseModel):
                 color="rgba(0, 0, 0, 0.5)",
                 activecolor="rgba(0, 0, 0, 1)",
             ),
-            showlegend=flat,
+            showlegend=showlegend,
             legend=go.layout.Legend(
                 orientation="h",
                 yanchor="top",


### PR DESCRIPTION
* Increase the flat threshold from 100 to 1000 - the performance is reasonable, so no reason to remove the interactivity.
* Allow to override `showlegend` for line config plots. Default to not-show for large datasets to avoid bloated legends.
* For FastQC line plots, default to not-show the legend, as we don't distinguish sample colors. Unless `--cl-config '{"fastqc_config": {"status_checks": False}}'` is set.

Address https://github.com/MultiQC/MultiQC/issues/2613