### PR TITLE
Salmon: fix ignored parsed `library_types` when its type is list

### DIFF
--- a/multiqc/modules/salmon/salmon.py
+++ b/multiqc/modules/salmon/salmon.py
@@ -31,7 +31,9 @@ class MultiqcModule(BaseMultiqcModule):
                 s_name = os.path.basename(os.path.dirname(f["root"]))
                 s_name = self.clean_s_name(s_name, f)
                 self.salmon_meta[s_name] = {
-                    metric: val for metric, val in json.loads(f["f"]).items() if isinstance(val, (int, float, str, list))
+                    metric: val
+                    for metric, val in json.loads(f["f"]).items()
+                    if isinstance(val, (int, float, str, list))
                 }
                 self.add_software_version(self.salmon_meta[s_name]["salmon_version"], s_name)
 

--- a/multiqc/modules/salmon/salmon.py
+++ b/multiqc/modules/salmon/salmon.py
@@ -31,7 +31,7 @@ class MultiqcModule(BaseMultiqcModule):
                 s_name = os.path.basename(os.path.dirname(f["root"]))
                 s_name = self.clean_s_name(s_name, f)
                 self.salmon_meta[s_name] = {
-                    metric: val for metric, val in json.loads(f["f"]).items() if isinstance(val, (int, float, str))
+                    metric: val for metric, val in json.loads(f["f"]).items() if isinstance(val, (int, float, str, list))
                 }
                 self.add_software_version(self.salmon_meta[s_name]["salmon_version"], s_name)
 


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

Currently, the code parsing Salmon's `meta_info.json` ignores anything that isn't an `int`, `float` or `string`. There's reference further in the module to the `library_types` key, but it's pointless, since the field was excluded in the 'instanceOf' filter, since it's a list:

```
{
    "salmon_version": "1.10.1",
    "samp_type": "none",
    "opt_type": "vb",
    "quant_errors": [],
    "num_libraries": 1,
    "library_types": [
        "ISR"
    ],
    "frag_dist_length": 1001,
    "frag_length_mean": 161.5665059992703,
```

This PR just adds in the list type, so that the data becomes available. I've tested, and it works- the column shows up the report.


