### PR TITLE
When user provides a search pattern dict in config, recursively update instead of replacing

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -383,7 +383,7 @@ def _add_config(conf: Dict, conf_path=None):
     for c, v in conf.items():
         if c == "sp":
             # Merge filename patterns instead of replacing
-            sp.update(v)
+            update_dict(sp, v)
             log_filename_patterns.append(v)
         elif c == "extra_fn_clean_exts":
             # Prepend to filename cleaning patterns instead of replacing


### PR DESCRIPTION
E.g.

```yaml
sp:
  samtools/coverage:
    max_filesize: 2000000000
```

in user config shouldn't completely remove the pattern for `samtools/coverage`, but update the `max_filesize` value, resulting in

```yaml
sp:
  samtools/coverage:
    max_filesize: 2000000000
    contents: "#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq"
    num_lines: 10
```

Came up in https://github.com/MultiQC/MultiQC/issues/2561