### PR TITLE
Resolve inconsistent non-optical pair duplicate variable name in samtools markdup module

### DIFF
--- a/multiqc/modules/samtools/markdup.py
+++ b/multiqc/modules/samtools/markdup.py
@@ -86,7 +86,7 @@ class MarkdupReportMixin:
             d["duplicate_optical_total"] = d["duplicate_pair_optical"] + d["duplicate_single_optical"]
             d["duplicate_optical_fraction"] = d["duplicate_optical_total"] / n_reads if n_reads > 0 else 0.0
             d["duplicate_fraction"] = d["duplicate_total"] / n_reads if n_reads > 0 else 0.0
-            d["duplicate_paired_non_optical"] = d["duplicate_pair"] - d["duplicate_pair_optical"]
+            d["duplicate_pair_non_optical"] = d["duplicate_pair"] - d["duplicate_pair_optical"]
             d["duplicate_single_non_optical"] = d["duplicate_single"] - d["duplicate_single_optical"]
             d["duplicate_non_primary_non_optical"] = d["duplicate_non_primary"] - d["duplicate_non_primary_optical"]
             d["non_duplicate"] = d["paired"] + d["single"] - d["duplicate_total"]


### PR DESCRIPTION
This commit fixes an inconsistency in the variable name relating to non-optical duplicate pairs as described in #2625. This PR fixes #2625

See below the results from the modified code with the non-optical pair duplicates category now included:

<img width="688" alt="image" src="https://github.com/MultiQC/MultiQC/assets/13511784/3a3b440d-25b7-439d-851b-8fb7a981d438">


<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)


