### PR TITLE
Fix Incorrect Calculation of % Q30 Bases

### DIFF
--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -76,8 +76,8 @@ class MultiqcModule(BaseMultiqcModule):
         # Special case - qchist metric in General Stats
         if "qchist" in self.mod_data:
             data = {}
-            fraction_gt_q30 = []
             for s_name in self.mod_data["qchist"]:
+                fraction_gt_q30 = []
                 for qual, d in self.mod_data["qchist"][s_name]["data"].items():
                     if int(qual) >= 30:
                         fraction_gt_q30.append(d[1])


### PR DESCRIPTION
Fix Incorrect Calculation of % Q30 Bases in MultiQC (bbmap Module) as described in https://github.com/MultiQC/MultiQC/issues/2627


- [x] Moved the initialization of `fraction_gt_q30` inside the loop to prevent the accumulation of values across different samples