### PR TITLE
Correctly use module ids `run_modules`

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -75,7 +75,7 @@ class BaseMultiqcModule:
         self.versions = defaultdict(list)
 
         # Specific module level config to overwrite (e.g. config.bcftools, config.fastqc)
-        config.update({anchor: self.mod_cust_config.get("custom_config", {})})
+        config.update({self.id: self.mod_cust_config.get("custom_config", {})})
 
         # Sanitise anchor ID and check for duplicates
         self.anchor = report.save_htmlid(self.anchor)

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -45,6 +45,7 @@ class Section:
 class BaseMultiqcModule:
     # Custom options from user config that can overwrite base module values
     mod_cust_config: Dict = {}
+    mod_id = None
 
     def __init__(
         self,
@@ -61,7 +62,7 @@ class BaseMultiqcModule:
     ):
         # Custom options from user config that can overwrite base module values
         self.name = self.mod_cust_config.get("name", name)
-        self.id = anchor  # cannot be overwritten for repeated modules with path_filters
+        self.id = self.mod_id if self.mod_id else anchor  # cannot be overwritten for repeated modules with path_filters
         self.anchor = self.mod_cust_config.get("anchor", anchor)
         target = self.mod_cust_config.get("target", target)
         self.href = self.mod_cust_config.get("href", href)

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -64,6 +64,7 @@ def exec_modules(
             entry_point: EntryPoint = config.avail_modules[this_module]
             module_initializer: Callable[[], Union[BaseMultiqcModule, List[BaseMultiqcModule]]] = entry_point.load()
             module_initializer.mod_cust_config = mod_cust_config
+            module_initializer.mod_id = this_module
 
             # *********************************************
             # RUN MODULE. Heavy part. Run module logic to parse logs and prepare plot data.

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -172,7 +172,7 @@ def exec_modules(
 
     # Again, if config.require_logs is set, check if for all explicitly requested
     # modules samples were found.
-    if not required_logs_found([m.anchor for m in report.modules]):
+    if not required_logs_found([m.id for m in report.modules]):
         raise RunError()
 
     # Update report with software versions provided in configs

--- a/multiqc/modules/dragen/dragen.py
+++ b/multiqc/modules/dragen/dragen.py
@@ -57,7 +57,6 @@ class MultiqcModule(
         super(MultiqcModule, self).__init__(
             name="DRAGEN",
             anchor="DRAGEN",
-            target="DRAGEN",
             href="https://www.illumina.com/products/by-type/informatics-products/dragen-bio-it-platform.html",
             info=""" is a Bio-IT Platform that provides ultra-rapid secondary analysis of sequencing data
                      using field-programmable gate array technology (FPGA).""",

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -727,7 +727,7 @@ def dois_tofile(modules: List["BaseMultiqcModule"]):
     dois = {"MultiQC": ["10.1093/bioinformatics/btw354"]}
     for mod in modules:
         if mod.doi is not None and mod.doi != "" and mod.doi != []:
-            dois[mod.anchor] = mod.doi
+            dois[mod.id] = mod.doi
     # Write to a file
     fn = f"multiqc_citations.{config.data_format_extensions[config.data_format]}"
     with open(os.path.join(config.data_dir, fn), "w") as f:


### PR DESCRIPTION
Fixes the `run_modules` behavior when module ids (= entry_points) don't match module anchors.

E.g. https://github.com/MultiQC/MultiQC/blob/034e1c05867475d5643dd439555229410aae5f02/multiqc/modules/dragen/dragen.py#L59,
https://github.com/MultiQC/MultiQC/blob/034e1c05867475d5643dd439555229410aae5f02/multiqc/modules/dragen_fastqc/dragen_fastqc.py#L34