### PR TITLE
Codecov: Disable inline PR annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,4 @@ coverage:
     patch:
       default:
         informational: true
+github_checks: false


### PR DESCRIPTION
Finding the inline PR annotations pretty noisy, this should disable them completely.

@vladsavelyev if you find them helpful then close this without merging. In the course of finding how to do this, I also found that the comments can be toggled using the keyboard shortcut `a` (or a dropdown top right of a file), so happy to do that if you prefer.