### PR TITLE
Fix custom content submodules with config

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -248,6 +248,7 @@ kwargs: Dict = {}
 
 # Other variables that set only through the CLI
 run_modules: List[str] = []
+custom_content_modules: List[str] = []
 exclude_modules: List[str] = []
 data_dir: Optional[str] = None
 plots_dir: Optional[str] = None

--- a/multiqc/core/file_search.py
+++ b/multiqc/core/file_search.py
@@ -65,9 +65,10 @@ def include_or_exclude_modules(module_names: List[str]) -> List[str]:
             )
         if len(unknown_modules) == len(config.run_modules):
             raise RunError("No available modules to run!")
-        config.run_modules = [m for m in config.run_modules if m in config.avail_modules.keys()]
-        module_names = [m for m in module_names if m in config.run_modules]
-        logger.info(f"Only using modules: {', '.join(config.run_modules)}")
+        module_names = [m for m in module_names if m in config.run_modules and m in config.avail_modules.keys()]
+        if "custom_content" in config.run_modules:
+            module_names.extend(config.custom_content_modules)
+        logger.info(f"Only using modules: {', '.join(module_names)}")
 
     if len(config.exclude_modules) > 0:
         logger.info("Excluding modules '{}'".format("', '".join(config.exclude_modules)))

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -292,10 +292,12 @@ class MultiqcModule(BaseMultiqcModule):
         if modname == "" or modname is None:
             modname = "Custom Content"
 
+        anchor = mod["config"].get("section_anchor", c_id)
+
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
             name=modname,
-            anchor=mod["config"].get("section_anchor", c_id),
+            anchor=anchor,
             href=mod["config"].get("section_href"),
             info=mod_info,
             extra=mod["config"].get("extra"),
@@ -305,6 +307,10 @@ class MultiqcModule(BaseMultiqcModule):
         # Don't repeat the Custom Content name in the subtext
         if self.info or self.extra or self.doi_link:
             self.intro = f"<p>{self.info}{self.doi_link}</p>{self.extra}"
+
+        if "custom_content" in config.run_modules:
+            # To allow file_search.include_or_exclude_modules() correctly filter these modules
+            config.custom_content_modules.append(anchor)
 
     def update_init(self, c_id, mod):
         """


### PR DESCRIPTION
Fix applying `config.run_modules` to custom content submodules, e. g. when the `custom_content` special case module adds new custom "modules" from config, like in this example: https://github.com/MultiQC/test-data/tree/main/data/custom_content/with_config/issue_1205