### PR TITLE
reset config between run() calls

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -490,6 +490,10 @@ def run(*analysis_dir, clean_up: bool, cfg: Optional[ClConfig] = None) -> RunRes
     See http://multiqc.info for more details.
     """
 
+    # In case if run() is called multiple times in the same session:
+    report.reset()
+    config.reset()
+
     update_config(*analysis_dir, cfg=cfg)
 
     check_version()
@@ -503,9 +507,6 @@ def run(*analysis_dir, clean_up: bool, cfg: Optional[ClConfig] = None) -> RunRes
             "Strict mode specified. Will exit early if a module or a template crashed, and will "
             "give warnings if anything is not optimally configured in a module or a template."
         )
-
-    # In case if run() is called multiple times in the same session:
-    report.reset()
 
     report.multiqc_command = " ".join(sys.argv)
     logger.debug(f"Command used: {report.multiqc_command}")


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

I noticed recently that `config` now has a `reset()` method. Notably, it drops the loaded config files: https://github.com/MultiQC/MultiQC/blob/f25169695ca72d00e4710aadc9555329d326b437/multiqc/config.py#L198

This is important if you call `multiqc.run()` twice with the same config file. If you don't reset, the second run will bail before loading the config even once! See: https://github.com/MultiQC/MultiQC/blob/f25169695ca72d00e4710aadc9555329d326b437/multiqc/config.py#L308-L309

This is problematic because the global config vars have been reset, but they don't get properly re-set to the right values. So the second run effectively runs with no config.

Here's an example python script that exhibits this behaviour:
```python
from pathlib import Path

from multiqc import multiqc
from multiqc.core.update_config import ClConfig


def main():
    multiqc.run(  # pylint: disable=no-member
        Path("in_mqc.json"),
        cfg=ClConfig(
            strict=True,
            force=True,
            config_files=["custom_config.yaml"],
        ),
        clean_up=True,
    )
    multiqc.run(  # pylint: disable=no-member
        Path("in_mqc.json"),
        cfg=ClConfig(
            strict=True,
            force=True,
            config_files=["custom_config.yaml"],
        ),
        clean_up=True,
    )

main()
```

Is this something we could work into multiqc testing?