### PR TITLE
Fix parsing kraken vs. bracken: respect `num_lines` in search patterns

### DIFF
--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -210,17 +210,17 @@ ccs/v5:
 cellranger/count_html:
   - fn: "*.html"
     contents: '"command":"Cell Ranger","subcommand":"count"'
-    num_lines: 13
+    num_lines: 14
   - fn: "*.html"
     contents: '"command": "Cell Ranger", "subcommand": "count"'
-    num_lines: 13
+    num_lines: 14
 cellranger/vdj_html:
   - fn: "*.html"
     contents: '"command":"Cell Ranger","subcommand":"vdj"'
-    num_lines: 13
+    num_lines: 14
   - fn: "*.html"
     contents: '"command": "Cell Ranger", "subcommand": "vdj"'
-    num_lines: 13
+    num_lines: 14
 checkqc:
   contents: "instrument_and_reagent_type"
   fn: "*.json"

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -874,10 +874,10 @@ sortmerna:
 spaceranger/count_html:
   - fn: "*.html"
     contents: '"command":"Space Ranger","subcommand":"count"'
-    num_lines: 13
+    num_lines: 20
   - fn: "*.html"
     contents: '"command": "Space Ranger", "subcommand": "count"'
-    num_lines: 13
+    num_lines: 20
 stacks/gstacks:
   fn: "gstacks.log.distribs"
   contents: "BEGIN effective_coverages_per_sample"

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -210,17 +210,17 @@ ccs/v5:
 cellranger/count_html:
   - fn: "*.html"
     contents: '"command":"Cell Ranger","subcommand":"count"'
-    num_lines: 14
+    num_lines: 20
   - fn: "*.html"
     contents: '"command": "Cell Ranger", "subcommand": "count"'
-    num_lines: 14
+    num_lines: 20
 cellranger/vdj_html:
   - fn: "*.html"
     contents: '"command":"Cell Ranger","subcommand":"vdj"'
-    num_lines: 14
+    num_lines: 20
   - fn: "*.html"
     contents: '"command": "Cell Ranger", "subcommand": "vdj"'
-    num_lines: 14
+    num_lines: 20
 checkqc:
   contents: "instrument_and_reagent_type"
   fn: "*.json"


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

There have been some changes to how line-matching works recently and it broke kraken vs bracken kreport matching.

Closes https://github.com/MultiQC/MultiQC/issues/2656

Most details are in the issue.

I opted to create a `line_iterator` because I found the `line_block_iterator` quite challenging to use in practice.

Note that there are changes in behaviour here:
1. `num_lines` will actually be respected - this is probably desirable?
2. `expected_contents` now only checks one line at a time. If any modules/cc depend on checking a block, that will no longer work. I don't know if we want to support checking whole blocks.

I'm open to other implementations. This regressed so just figured I'd offer up a fix.