### PR TITLE
Better handling of calling `write_report` twice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,22 @@
 # Git things
 .git/
 .gitignore
-.github
+.github/
 
 # Python build things
 build/
 dist/
 *.egg-info
-
+.pytest_cache/
 venv
 venv38
 venv311
+
+# MultiQC results
+multiqc_config.yaml
+multiqc_report.html
+multiqc_data/
+multiqc_plots/
 result
+
+test-data

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -25,12 +25,6 @@ This checklist is for my own reference, as I forget the steps every time.
      mv ~/.multiqc_config.yml ~/.multiqc_config.yml.bkup
      ```
 
-   - Install `NationalGenomicsInfrastructure/MultiQC_NGI` - **NEEDS Python 3.11**:
-
-     ```bash
-     pip install git+https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI@0.7.1
-     ```
-
    - Generate reports in the multiqc/website repo.
 
      ```bash

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -175,10 +175,6 @@ def exec_modules(mod_dicts_in_order: List[Dict[str, Dict]]) -> None:
     # Update report with software versions provided in configs
     software_versions.update_versions_from_config()
 
-    # Add section for software versions if any are found
-    if not config.skip_versions_section and report.software_versions:
-        report.modules.append(SoftwareVersionModule())
-
     # Did we find anything?
     if len(report.modules) == 0:
         raise NoAnalysisFound("No analysis results found", sys_exit_code=sys_exit_code)

--- a/multiqc/core/order_modules_and_sections.py
+++ b/multiqc/core/order_modules_and_sections.py
@@ -1,0 +1,89 @@
+import logging
+
+from multiqc import config, report
+from multiqc.core.file_search import include_or_exclude_modules
+
+logger = logging.getLogger(__name__)
+
+
+def order_modules_and_sections():
+    """
+    Finalise modules and sections: place in the write order, add special-case modules.
+    """
+    # Importing here to avoid circular imports
+    from multiqc.modules.software_versions import MultiqcModule as SoftwareVersionsModule
+    from multiqc.modules.profile_runtime import MultiqcModule as ProfileRuntimeModule
+
+    # First, remove the special-case modules that we want to re-add at the end, in case if they were
+    # already added by a previous call of multiqc.write_report in an interactive session.
+    report.modules = [
+        m
+        for m in report.modules
+        if (not isinstance(m, SoftwareVersionsModule) and not isinstance(m, ProfileRuntimeModule))
+    ]
+
+    # In case if user passed exclude_modules or include_modules again:
+    mod_ids = include_or_exclude_modules([mod.id for mod in report.modules])
+    for mod in report.modules:
+        if mod.id not in mod_ids:
+            mod.hidden = True
+
+    # Add section for software versions if any are found
+    if not config.skip_versions_section and report.software_versions:
+        report.modules.append(SoftwareVersionsModule())
+
+    # Special-case module if we want to profile the MultiQC running time
+    if config.profile_runtime:
+        report.modules.append(ProfileRuntimeModule())
+
+    # Sort the report module output if we have a config
+    if len(config.report_section_order) > 0:
+        section_id_order = {}
+        idx = 10
+        for mod in reversed(report.modules):
+            section_id_order[mod.anchor] = idx
+            idx += 10
+        for anchor, ss in config.report_section_order.items():
+            if anchor not in section_id_order.keys():
+                logger.debug(f"Reordering sections: anchor '{anchor}' not found.")
+                continue
+            if ss.get("order") is not None:
+                section_id_order[anchor] = ss["order"]
+            if ss.get("after") in section_id_order.keys():
+                section_id_order[anchor] = section_id_order[ss["after"]] + 1
+            if ss.get("before") in section_id_order.keys():
+                section_id_order[anchor] = section_id_order[ss["before"]] - 1
+        sorted_ids = sorted(section_id_order.keys(), key=lambda k: section_id_order[k])
+        report.modules = [mod for i in reversed(sorted_ids) for mod in report.modules if mod.anchor == i]
+
+    # Sort the report sections if we have a config
+    # Basically the same as above, but sections within a module
+    if len(config.report_section_order) > 0:
+        # Go through each module
+        for midx, mod in enumerate(report.modules):
+            section_id_order = dict()
+            # Get a list of the section anchors
+            idx = 10
+            for s in mod.sections:
+                section_id_order[s.anchor] = idx
+                idx += 10
+            # Go through each section to be reordered
+            for anchor, ss in config.report_section_order.items():
+                # Section to be moved is not in this module
+                if anchor not in section_id_order.keys():
+                    logger.debug(f"Reordering sections: anchor '{anchor}' not found for module '{mod.name}'.")
+                    continue
+                if ss == "remove":
+                    section_id_order[anchor] = False
+                    continue
+                if ss.get("order") is not None:
+                    section_id_order[anchor] = ss["order"]
+                if ss.get("after") in section_id_order.keys():
+                    section_id_order[anchor] = section_id_order[ss["after"]] + 1
+                if ss.get("before") in section_id_order.keys():
+                    section_id_order[anchor] = section_id_order[ss["before"]] - 1
+            # Remove module sections
+            section_id_order = {s: o for s, o in section_id_order.items() if o is not False}
+            # Sort the module sections
+            sorted_ids = sorted(section_id_order.keys(), key=lambda k: section_id_order[k])
+            report.modules[midx].sections = [s for i in sorted_ids for s in mod.sections if s.anchor == i]

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Set
 
 from multiqc.base_module import Section
-from multiqc.core.file_search import include_or_exclude_modules
 from multiqc.core.tmp_dir import rmtree_with_retries
 from multiqc.plots import table
 
@@ -22,7 +21,7 @@ import jinja2
 from multiqc import config, report
 from multiqc.core.exceptions import RunError, NoAnalysisFound
 from multiqc.plots.plotly.plot import Plot
-from multiqc.core import plugin_hooks, tmp_dir, log_and_rich
+from multiqc.core import plugin_hooks, tmp_dir
 from multiqc.utils import megaqc, util_functions
 from multiqc.core.log_and_rich import iterate_using_progress_bar
 
@@ -35,9 +34,6 @@ def write_results(clean_up=True) -> None:
     # Did we find anything?
     if len(report.modules) == 0:
         raise NoAnalysisFound("No analysis data for any module. Check that input files and directories exist")
-
-    if config.make_report:
-        _order_modules_and_sections()
 
     _set_output_paths()
 
@@ -222,88 +218,6 @@ def _create_or_override_dirs() -> Set[str]:
         os.makedirs(os.path.dirname(config.output_fn), exist_ok=True)
 
     return overwritten
-
-
-def _order_modules_and_sections():
-    """
-    Finalise modules and sections: place in the write order, add special-case modules
-    """
-
-    # In case if user passed exclude_modules or include_modules again:
-    mod_ids = include_or_exclude_modules([mod.id for mod in report.modules])
-    for mod in report.modules:
-        if mod.id not in mod_ids:
-            mod.hidden = True
-
-    # Add section for software versions if any are found
-    if not config.skip_versions_section and report.software_versions:
-        # Importing here to avoid circular imports
-        from multiqc.modules.software_versions import MultiqcModule as SoftwareVersionsModule
-
-        # Remove existing software_versions module that can be already added into the end.
-        # That can happen if write_report was already called in an interactive session.
-        report.modules = [m for m in report.modules if not isinstance(m, SoftwareVersionsModule)]
-        report.modules.append(SoftwareVersionsModule())
-
-    # Special-case module if we want to profile the MultiQC running time
-    if config.profile_runtime:
-        from multiqc.modules.profile_runtime import MultiqcModule as ProfileRuntimeModule
-
-        # if the software versions module is not in report.modules, add it:
-        if not any([isinstance(m, ProfileRuntimeModule) for m in report.modules]):
-            report.modules.append(ProfileRuntimeModule())
-
-    # Sort the report module output if we have a config
-    if len(config.report_section_order) > 0:
-        section_id_order = {}
-        idx = 10
-        for mod in reversed(report.modules):
-            section_id_order[mod.anchor] = idx
-            idx += 10
-        for anchor, ss in config.report_section_order.items():
-            if anchor not in section_id_order.keys():
-                logger.debug(f"Reordering sections: anchor '{anchor}' not found.")
-                continue
-            if ss.get("order") is not None:
-                section_id_order[anchor] = ss["order"]
-            if ss.get("after") in section_id_order.keys():
-                section_id_order[anchor] = section_id_order[ss["after"]] + 1
-            if ss.get("before") in section_id_order.keys():
-                section_id_order[anchor] = section_id_order[ss["before"]] - 1
-        sorted_ids = sorted(section_id_order.keys(), key=lambda k: section_id_order[k])
-        report.modules = [mod for i in reversed(sorted_ids) for mod in report.modules if mod.anchor == i]
-
-    # Sort the report sections if we have a config
-    # Basically the same as above, but sections within a module
-    if len(config.report_section_order) > 0:
-        # Go through each module
-        for midx, mod in enumerate(report.modules):
-            section_id_order = dict()
-            # Get a list of the section anchors
-            idx = 10
-            for s in mod.sections:
-                section_id_order[s.anchor] = idx
-                idx += 10
-            # Go through each section to be reordered
-            for anchor, ss in config.report_section_order.items():
-                # Section to be moved is not in this module
-                if anchor not in section_id_order.keys():
-                    logger.debug(f"Reordering sections: anchor '{anchor}' not found for module '{mod.name}'.")
-                    continue
-                if ss == "remove":
-                    section_id_order[anchor] = False
-                    continue
-                if ss.get("order") is not None:
-                    section_id_order[anchor] = ss["order"]
-                if ss.get("after") in section_id_order.keys():
-                    section_id_order[anchor] = section_id_order[ss["after"]] + 1
-                if ss.get("before") in section_id_order.keys():
-                    section_id_order[anchor] = section_id_order[ss["before"]] - 1
-            # Remove module sections
-            section_id_order = {s: o for s, o in section_id_order.items() if o is not False}
-            # Sort the module sections
-            sorted_ids = sorted(section_id_order.keys(), key=lambda k: section_id_order[k])
-            report.modules[midx].sections = [s for i in sorted_ids for s in mod.sections if s.anchor == i]
 
 
 def render_and_export_plots():

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -439,7 +439,6 @@ def _write_report():
             logger.error(f"Could not include file '{name}': {e}")
 
     # Load the report template
-    assert len(report.analysis_files) > 0, report.analysis_files
     try:
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(tmp_dir.get_tmp_dir()))
         env.globals["include_file"] = include_file

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -439,6 +439,7 @@ def _write_report():
             logger.error(f"Could not include file '{name}': {e}")
 
     # Load the report template
+    assert len(report.analysis_files) > 0, report.analysis_files
     try:
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(tmp_dir.get_tmp_dir()))
         env.globals["include_file"] = include_file

--- a/multiqc/interactive.py
+++ b/multiqc/interactive.py
@@ -11,6 +11,7 @@ from typing import Dict, Union, List, Optional, Sequence
 
 from multiqc import report, config
 from multiqc.base_module import BaseMultiqcModule
+from multiqc.core.order_modules_and_sections import order_modules_and_sections
 from multiqc.core.update_config import update_config, ClConfig
 from multiqc.core.file_search import file_search
 from multiqc.core.exec_modules import exec_modules
@@ -449,11 +450,9 @@ def write_report(
 
     check_version(write_report.__name__)
 
-    if len(report.modules) == 0:
-        logger.error("No analysis results found to make a report")
-        return
-
     try:
+        order_modules_and_sections()
+
         write_results(clean_up=clean_up)
 
     except NoAnalysisFound:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -14,10 +14,11 @@ from typing import Tuple, Optional
 import rich_click as click
 
 from multiqc import config, report
-from multiqc.core import plugin_hooks, log_and_rich, tmp_dir
+from multiqc.core import plugin_hooks, log_and_rich
 from multiqc.core.exceptions import RunError, NoAnalysisFound
 from multiqc.core.exec_modules import exec_modules
 from multiqc.core.file_search import file_search
+from multiqc.core.order_modules_and_sections import order_modules_and_sections
 from multiqc.core.update_config import update_config, ClConfig
 from multiqc.core.version_check import check_version
 from multiqc.core.write_results import write_results
@@ -502,6 +503,8 @@ def run(*analysis_dir, clean_up: bool = True, cfg: Optional[ClConfig] = None) ->
         mod_dicts_in_order = file_search()
 
         exec_modules(mod_dicts_in_order)
+
+        order_modules_and_sections()
 
         write_results()
 

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -20,9 +20,19 @@ the output from each module and print it in sections.
               <div class="text-muted">
                 {% for tool, versions in m.versions.items() %}
                   {% if tool == m.name %}
-                    <em>Version{% if versions|length > 1 %}s{% endif %}:</em> <code>{{versions|join("</code>, <code>")}}</code>
+                    <em>Version{% if versions|length > 1 %}s{% endif %}: </em>
+                    <code>
+                      {% for version in versions %}
+                        {{ version[1] }}{% if not loop.last %}, {% endif %}
+                      {% endfor %}
+                    </code>
                   {% else %}
-                    <em>{{ tool }}:</em> <code>{{ versions|join("</code>, <code>") }}</code>
+                    <em>{{ tool }}:</em>
+                    <code>
+                      {% for version in versions %}
+                        {{ version[1] }}{% if not loop.last %}, {% endif %}
+                      {% endfor %}
+                    </code>
                   {% endif %}
                 {% endfor %}
               </div>

--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -68,7 +68,8 @@ was generated and the button that launches the welcome tour.
   {% if config.show_analysis_paths %}
     based on data in:
     {% if report.analysis_files | length == 1 %}
-      <code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code></p>
+      <code class="mqc_analysis_path">{{ report.analysis_files[0] }}</code>
+      </p>
     {% else %}
       </p>
       <ul>

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -2,7 +2,6 @@ import os
 
 import multiqc
 from multiqc import report
-from multiqc.core.write_results import _order_modules_and_sections
 
 
 def test_parse_logs_fn_clean_exts(data_dir):
@@ -36,6 +35,15 @@ def test_write_report(tmp_path):
     multiqc.write_report(force=True, output_dir=str(tmp_path))
     assert (tmp_path / "multiqc_report.html").is_file()
     assert (tmp_path / "multiqc_data").is_dir()
+
+
+def test_software_versions_section(data_dir, tmp_path, capsys):
+    multiqc.reset()
+
+    multiqc.parse_logs(data_dir / "modules/fastp")
+    multiqc.parse_logs(data_dir / "modules/bcftools")
+    multiqc.write_report(filename="stdout")  # triggers adding software_versions module
+    assert multiqc.list_modules() == ["fastp", "Bcftools", "Software Versions"]
 
 
 def test_write_report_multiple_times(data_dir, tmp_path):
@@ -76,12 +84,3 @@ def test_run_twice(data_dir, tmp_path):
     )
     assert (tmp_path / "multiqc_report.html").is_file()
     assert (tmp_path / "multiqc_data").is_dir()
-
-
-def test_software_versions_section(data_dir, tmp_path):
-    multiqc.reset()
-
-    multiqc.parse_logs(data_dir / "modules/fastp")
-    multiqc.parse_logs(data_dir / "modules/bcftools")
-    multiqc.write_report(filename="stdout")  # triggers adding software_versions module
-    assert multiqc.list_modules() == ["fastp", "bcftools", "Software Versions"]


### PR DESCRIPTION
Better handling of calling `multiqc.write_report()` twice: replace the software_versions and general stats sections.

Fixes https://github.com/MultiQC/MultiQC/issues/2685