### PR TITLE
Add changelog entries without labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,15 +38,28 @@ tests that take the specific module logic into account, and place them in
 
 #### Fixes
 
-- Multiple fixes of the custom content parsing logic ([#2674](https://github.com/MultiQC/MultiQC/pull/2674))
+- Custom content"
+  - Multiple fixes of the custom content parsing logic ([#2674](https://github.com/MultiQC/MultiQC/pull/2674))
+  - Fix parsing custom content submodules with a custom config ([#2654](https://github.com/MultiQC/MultiQC/pull/2654))
+  - Line plot: fix spreading `extra_series` between multiple datasets ([#2684](https://github.com/MultiQC/MultiQC/pull/2684))
+  - Line plot series: allow pass lists instead of x/y tuples to work properly with YAML ([#2683](https://github.com/MultiQC/MultiQC/pull/2683))
 - Re-enabling the `software_version` module section ([#2670](https://github.com/MultiQC/MultiQC/pull/2670))
-- Fix parsing custom content submodules with a custom config ([#2654](https://github.com/MultiQC/MultiQC/pull/2654))
+- When `--no-ansi` is set, disable colors in `rich_click` too ([#2678](https://github.com/MultiQC/MultiQC/pull/2678))
+- Support CWD path filters ( `./path/...`) in config ([#2676](https://github.com/MultiQC/MultiQC/pull/2676))
+- Fix writing report to stdout with `--filename stdout`, log to stderr ([#2672](https://github.com/MultiQC/MultiQC/pull/2672))
+- Interactive use:
+  - Reset all config values in `config.reset()`, even those that are not in `config_default.yaml` ([#2660](https://github.com/MultiQC/MultiQC/pull/2660))
+  - Reset config between `multiqc.run()` calls ([#2655](https://github.com/MultiQC/MultiQC/pull/2655))
+  - Better handling of calling `write_report` twice ([#2688](https://github.com/MultiQC/MultiQC/pull/2688))
 
 #### Updates
 
-- Custom content: allow hash-fenced table columns ([#2649](https://github.com/MultiQC/MultiQC/pull/2649))
-- Line plot series: allow pass lists instead of x/y tuples to work properly with YAML ([#2683](https://github.com/MultiQC/MultiQC/pull/2683))
 - Run mypy on core library ([#2665](https://github.com/MultiQC/MultiQC/pull/2665))
+- Add tests for plot export ([#2682](https://github.com/MultiQC/MultiQC/pull/2682))
+- Add tests for command line use, including for passing `TMPDIR` ([#2677](https://github.com/MultiQC/MultiQC/pull/2677))
+- Custom content: allow hash-fenced table columns ([#2649](https://github.com/MultiQC/MultiQC/pull/2649))
+- Software versions: parse for sorting, but preserve the original strings ([#2671](https://github.com/MultiQC/MultiQC/pull/2671))
+- Allow both table-level and column-level custom plot config for table ([#2662](https://github.com/MultiQC/MultiQC/pull/2662))
 
 #### New modules
 
@@ -60,6 +73,11 @@ tests that take the specific module logic into account, and place them in
 #### Module updates
 
 - Picard HsMetrics: support any custom X coverage metrics ([#2663](https://github.com/MultiQC/MultiQC/pull/2663))
+- Samtools coverage: avoid hard crash for invalid file contents ([#2664](https://github.com/MultiQC/MultiQC/pull/2664))
+
+#### Refactoring
+
+- Abstract code related to temporary directory creation into a separate module ([#2675](https://github.com/MultiQC/MultiQC/pull/2675))
 
 #### Infrastructure
 

--- a/scripts/print_changelog.py
+++ b/scripts/print_changelog.py
@@ -79,35 +79,41 @@ def main():
     assert_milestone_exists(milestones, previous_tag)
     prs: List[PullRequest] = get_milestone_prs(repo, current_tag, previous_tag)
 
-    sections: Dict[str, List[PullRequest]] = {
-        "MultiQC fixes": [],
-        "MultiQC updates": [],
+    label_to_section: Dict[str, str] = {
+        "module: new": "New modules",
+        "bug: module": "Module fixes",
+        "module: enhancement": "Module updates",
+        "module: change": "Updates",
+        "bug: core": "Fixes",
+        "core: infrastructure": "Infrastructure",
+        "core: refactoring": "Refactoring",
+        "documentation": "Chores",
+    }
+    sections_to_prs: Dict[str, List[PullRequest]] = {
+        "Fixes": [],
+        "Updates": [],
         "New modules": [],
         "Module fixes": [],
         "Module updates": [],
+        "Refactoring": [],
         "Infrastructure": [],
         "Chores": [],
     }
     for pr in prs:
         if skip_pr(pr.title):
             continue
-        for label in pr.labels:
-            section_name = {
-                "module: new": "New modules",
-                "bug: module": "Module fixes",
-                "module: enhancement": "Module updates",
-                "module: change": "Module updates",
-                "bug: core": "MultiQC fixes",
-                "core: infrastructure": "Infrastructure",
-                "documentation": "Chores",
-            }.get(label.name, "MultiQC updates")
-            sections[section_name].append(pr)
+        if pr.labels:
+            for label in pr.labels:
+                section_name = label_to_section.get(label.name, "Updates")
+                sections_to_prs[section_name].append(pr)
+        else:
+            sections_to_prs["Updates"].append(pr)
 
     print("")
     print(f"## [MultiQC {current_tag}]({REPO_URL}/releases/tag/{current_tag}) - {datetime.date.today().isoformat()}")
     print("")
 
-    for section, prs in sections.items():
+    for section, prs in sections_to_prs.items():
         if section == "Chores":
             continue
         print(f"### {section}")


### PR DESCRIPTION
Fix changelog generation: also add the entries without labels into generic `Updates`.