### PR TITLE
Search patterns: allow multiple values for `contents`

### DIFF
--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -2,7 +2,11 @@
 Tests for discovering and excluding files
 """
 
+from pathlib import Path
+from typing import Dict, Set, Union
+
 import pytest
+import yaml
 
 from multiqc import config
 from multiqc import report
@@ -11,25 +15,28 @@ from multiqc.core.file_search import file_search
 from multiqc.core.update_config import update_config
 
 
-def _test_search_files(search_patterns, analysis_dir, extra_config, expected_files):
+def _test_search_files(
+    search_patterns: Dict,
+    analysis_dir: Path,
+    extra_config: Dict,
+    expected_paths_by_module: Dict[str, Set[Union[Path, str]]],
+):
     update_config()
 
     config.sp = search_patterns
     config.run_modules = list(config.sp.keys())
     config.avail_modules = dict.fromkeys(config.run_modules)
 
-    config.analysis_dir = [analysis_dir]
+    config.analysis_dir = [str(analysis_dir)]
     if extra_config:
         config.update(extra_config)
 
     report.reset_file_search()
     file_search()
 
-    filenames = set()
-    for m, files in report.files.items():
-        for f in files:
-            filenames.add(f["fn"])
-    assert filenames == expected_files
+    expected = {m: set(str(p) for p in paths) for m, paths in expected_paths_by_module.items()}
+    found = {m: set(f["fn"] for f in files) for m, files in report.files.items()}
+    assert found == expected
 
 
 def test_excluded_dirs(data_dir):
@@ -45,7 +52,7 @@ def test_excluded_dirs(data_dir):
         },
         analysis_dir=data_dir / "file_search/ignore_dirs",
         extra_config={"fn_ignore_dirs": ["ignored", "*_ignored"]},
-        expected_files={"included.txt"},
+        expected_paths_by_module={"module": {"included.txt"}},
     )
 
 
@@ -62,7 +69,7 @@ def test_excluded_paths(data_dir):
         },
         analysis_dir=data_dir / "file_search/ignore_paths",
         extra_config={"fn_ignore_paths": ["*/*_ignored"]},
-        expected_files={"included.txt"},
+        expected_paths_by_module={"module": {"included.txt"}},
     )
 
 
@@ -88,10 +95,12 @@ def test_fn_ignore_files(data_dir):
         },
         analysis_dir=data_dir / "file_search/ignore_files",
         extra_config={"ignored_paths": ["*.txt.gz"]},
-        expected_files={
-            "included.txt",
-            "included.txt.gz",
-            "matching_content.txt",
+        expected_paths_by_module={
+            "module": {
+                "included.txt",
+                "included.txt.gz",
+                "matching_content.txt",
+            }
         },
     )
 
@@ -106,7 +115,7 @@ def test_symlinked_files_found(data_dir, ignore_links, expected_files):
     """
     _test_search_files(
         search_patterns={
-            "module_filelink": [
+            "module": [
                 {"fn": "filelink"},
                 {"fn": "nested"},
                 {"fn": "file"},
@@ -114,7 +123,7 @@ def test_symlinked_files_found(data_dir, ignore_links, expected_files):
         },
         analysis_dir=data_dir / "special_cases/symlinks/linked",
         extra_config={"ignore_symlinks": ignore_links},
-        expected_files=expected_files,
+        expected_paths_by_module={"module": expected_files},
     )
 
 
@@ -139,7 +148,7 @@ def test_filelist(data_dir, tmp_path):
         },
         analysis_dir=filelist,
         extra_config={"file_list": True},
-        expected_files={"included.txt"},
+        expected_paths_by_module={"module": {"included.txt"}},
     )
 
 
@@ -157,5 +166,52 @@ def test_filelist_all_missing(data_dir, tmp_path):
             },
             analysis_dir=filelist,
             extra_config={"file_list": True},
-            expected_files=set(),
+            expected_paths_by_module={},
         )
+
+
+def test_contents_multi_line(tmp_path):
+    """
+    Test that multi-line contents are correctly matched
+    """
+    tool1_1 = tmp_path / "tool1-1.txt"
+    tool1_1.write_text("""\
+metric1: 321
+both_tool1_and_tool2_look_for_this_metric: 123
+metric3: 321
+tool1_also_requires_this_metric: 132
+metric5: 321
+""")
+
+    tool1_2 = tmp_path / "tool1-2.txt"
+    tool1_2.write_text("""\
+metric1: 321
+tool1_can_alternatively_take_this_metric: 222
+""")
+
+    tool2 = tmp_path / "tool2.txt"
+    tool2.write_text("""\
+metric1: 321
+both_tool1_and_tool2_look_for_this_metric: 444
+metric3: 321
+""")
+
+    sp_patterns: Dict = yaml.safe_load("""
+tool1:
+  - contents:
+    - "both_tool1_and_tool2_look_for_this_metric"
+    - "tool1_also_requires_this_metric"
+  - contents: "tool1_can_alternatively_take_this_metric"
+tool2:
+   contents: "both_tool1_and_tool2_look_for_this_metric"
+""")
+
+    _test_search_files(
+        search_patterns=sp_patterns,
+        analysis_dir=tmp_path,
+        extra_config={},
+        expected_paths_by_module={
+            "tool1": {tool1_1.name, tool1_2.name},
+            "tool2": {tool2.name},
+        },
+    )


### PR DESCRIPTION
1. Make search patterns a Pydantic class.
2. Allow multiple values for the `contents` field in search patterns. This will make it easier to make complex patterns for stdout without requiring users to rename to a specific file name.

E.g., for VG tools, matching any one of the line would be not specific enough:

```
Total alignments: 474360680
Total primary: 474360680
Total secondary: 0
Total aligned: 471750172
Total perfect: 367671783
Total gapless (softclips allowed): 466504598
Total paired: 474360680
Total properly paired: 470328074
Alignment score: mean 154.829, median 161, stdev 20.9245, max 161 (367671783 reads)
Mapping quality: mean 53.9949, median 60, stdev 17.1112, max 60 (413376174 reads)
Insertions: 14742595 bp in 3492881 read events
Deletions: 13369245 bp in 4751230 read events
Substitutions: 301480922 bp in 301480922 read events
Softclips: 1223329875 bp in 24252186 read events
Total time: 293601 seconds
Speed: 1615.67 reads/second
```

But requiring several of those would be unique enough to match this output:

```yaml
vg/stats:
  contents: 
    - "Total perfect:"
    - "Total gapless (softclips allowed):"
    - "Total time:"
    - "Speed:"
  num_lines: 30
```