### PR TITLE
allow multiple custom content to general stats table

### DIFF
--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -296,9 +296,7 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
 
     # If we only have General Stats columns then there are no module outputs
     if len(sorted_modules) == 0:
-        item = list(cust_mod_by_id.values())[0]["config"]
-        assert isinstance(item, dict)
-        if len(cust_mod_by_id) == 1 and item.get("plot_type") == "generalstats":
+        if len(cust_mod_by_id) >= 1 and all(cv["config"].get("plot_type") == "generalstats" for cv in cust_mod_by_id.values()):
             sorted_modules = [bm]
         else:
             raise ModuleNoSamplesFound

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -296,7 +296,11 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
 
     # If we only have General Stats columns then there are no module outputs
     if len(sorted_modules) == 0:
-        if len(cust_mod_by_id) >= 1 and all(cv["config"].get("plot_type") == "generalstats" for cv in cust_mod_by_id.values()):
+        cfgs: list[dict] = []
+        for cust_mod_v in cust_mod_by_id.values():
+            assert isinstance(cust_mod_v["config"], dict)
+            cfgs.append(cust_mod_v["config"])
+        if len(cust_mod_by_id) >= 1 and all(cfg.get("plot_type") == "generalstats" for cfg in cfgs):
             sorted_modules = [bm]
         else:
             raise ModuleNoSamplesFound

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -296,7 +296,7 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
 
     # If we only have General Stats columns then there are no module outputs
     if len(sorted_modules) == 0:
-        cfgs: list[dict] = []
+        cfgs: List[Dict] = []
         for cust_mod_v in cust_mod_by_id.values():
             assert isinstance(cust_mod_v["config"], dict)
             cfgs.append(cust_mod_v["config"])


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

I found the check for "only-general-stats" was overly narrow, and excluded cases where there are multiple custom content modules for general-stats.

This fixes.

Example:

`gs1_mqc.yaml`:
```
id: "gs1"
plot_type: "generalstats"
data:
  sample_1: { x: 12, y: 14 }
  sample_2: { x: 8, y: 6 }
```

`gs2_mqc.yaml`:
```
id: "gs2"
plot_type: "generalstats"
data:
  sample_1: { z: 12 }
  sample_2: { z: 8 }
```

```
$ multiqc -f .
/// MultiQC 🔍 v1.24.dev0

       file_search | Search path: /work
            report | Error: MultiQC is running in source code directory! .
            report | Please see the docs for how to use MultiQC: https://multiqc.info/docs/#running-multiqc
         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/0  
           multiqc | No analysis results found. Cleaning up…
```

With fix:
```
$ multiqc -f .
/// MultiQC 🔍 v1.24.dev0

       file_search | Search path: /work/testmultigs
         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2/2  
    custom_content | gs2: Found 2 General Statistics columns
    custom_content | gs1: Found 2 General Statistics columns
     write_results | Data        : /work/testmultigs/multiqc_data
     write_results | Report      : /work/testmultigs/multiqc_report.html
           multiqc | MultiQC complete
```

![Screenshot 2024-07-30 at 17-49-03 MultiQC Report](https://github.com/user-attachments/assets/f6fec30a-2304-49d1-a912-f66aa0eb87df)
