### PR TITLE
Fix `--pdf` option to generate `multiqc_report.pdf`

### DIFF
--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -154,6 +154,7 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None, log_to_file=Fal
     if cfg.development is not None:
         config.development = cfg.development
     if cfg.make_pdf:
+        config.make_pdf = cfg.make_pdf
         config.template = "simple"
     if config.template == "simple":
         config.plots_force_flat = True

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -450,7 +450,10 @@ class Plot(BaseModel, Generic[T]):
         layout = go.Layout(self.layout.to_plotly_json())  # make a copy
         layout.update(**dataset.layout)
         if flat:
-            layout.width = FLAT_PLOT_WIDTH
+            if config.simple_output:
+                layout.width = 600
+            else:
+                layout.width = 1100
         for axis in self.axis_controlled_by_switches:
             layout[axis].type = "linear"
             minval = layout[axis].autorangeoptions["minallowed"]
@@ -744,10 +747,6 @@ def add_logo(
         output_buffer = img_buffer
 
     return output_buffer
-
-
-# Default width for flat plots
-FLAT_PLOT_WIDTH = 1100
 
 
 def _set_axis_log_scale(axis):

--- a/multiqc/templates/default/footer.html
+++ b/multiqc/templates/default/footer.html
@@ -20,7 +20,6 @@ Content for the report footer.
     This report uses <a href="https://www.plotly.com/" target="_blank">Plotly</a>,
     <a href="https://jquery.com/" target="_blank">jQuery</a>,
     <a href="https://jqueryui.com/" target="_blank">jQuery UI</a>,
-    <a href="http://getbootstrap.com/" target="_blank">Bootstrap</a>,
-    <a href="https://github.com/eligrey/FileSaver.js" target="_blank">FileSaver.js</a> and
-    <a href="https://clipboardjs.com/" target="_blank">clipboard.js</a>.
+    <a href="http://getbootstrap.com/" target="_blank">Bootstrap</a> and
+    <a href="https://github.com/eligrey/FileSaver.js" target="_blank">FileSaver.js</a>.
 </p>

--- a/multiqc/templates/simple/footer.html
+++ b/multiqc/templates/simple/footer.html
@@ -1,0 +1,7 @@
+{# #######################
+  footer.html
+##########################
+
+Leaving this file blank to omit from the report.
+
+#}


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2728

`--pdf` option was broken for some time. 

Additionally, the LaTeX requirement wasn't specified, and pandoc presence wasn't properly checked either.

Few minor things:

* the html report with the `simple` template doesn't look nice, so if `--pdf` if requested, the HTML should be removed.
* `xelatex` doesn't  render plots, so replaced it with `pdflatex`

TODO:

- [x]  The PDF doesn't look very nice unfortunately, the plots are too wide and getting cropped. Need to adjust the actual plots layouts to fix this. At least make them narrow.
- [x] PDF footer is broken. Hide it?