### PR TITLE
Nonpareil: Update docs about new version that generates the JSON file

### DIFF
--- a/multiqc/modules/nonpareil/nonpareil.py
+++ b/multiqc/modules/nonpareil/nonpareil.py
@@ -16,48 +16,10 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     """
-    Since Nonpareil main output has no model information, it is necessary to run its
-    auxiliary `R` plot functions and save the `curves` object as a `JSON` file. Briefly,
-    call function `export_curve()` on object `curves` (for an example, see [snakemake wrapper](https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/nonpareil/plot.html#code)):
-
-    ```r
-    base::library("jsonlite")
-    base::message("Exporting model as JSON")
-
-    export_curve <- function(object){
-      # Extract variables
-      n <- names(attributes(object))[c(1:12,21:29)]
-      x <- sapply(n, function(v) attr(object,v))
-      names(x) <- n
-      # Extract vectors
-      n <- names(attributes(object))[13:20]
-      y <- lapply(n, function(v) attr(object,v))
-      names(y) <- n
-      curve_json <- c(x, y)
-
-      # Add model
-      if (object$has.model) {
-        # https://github.com/lmrodriguezr/nonpareil/blob/162f1697ab1a21128e1857dd87fa93011e30c1ba/utils/Nonpareil/R/Nonpareil.R#L330-L332
-        x_min <- 1e3
-        x_max <- signif(tail(attr(object,"x.adj"), n=1)*10, 1)
-        x.model <- exp(seq(log(x_min), log(x_max), length.out=1e3))
-        y.model <- predict(object, lr=x.model)
-        curve_json <- append(curve_json, list(x.model=x.model))
-        curve_json <- append(curve_json, list(y.model=y.model))
-      }
-
-      base::print(curve_json)
-      curve_json
-    }
-
-    export_set <- function(object){
-      y <- lapply(object$np.curves, "export_curve")
-      names(y) <- sapply(object$np.curves, function(n) n$label)
-      jsonlite::prettify(toJSON(y, auto_unbox=TRUE))
-    }
-
-    y <- export_set(curves)
-    write(y, "output.json")
+    Since Nonpareil main output has no model information, it is necessary extract the `curves` object as a `JSON` file.
+    From version `v3.5.5` this can be done with an auxiliary `R` script, briefly:
+    ```bash
+    NonpareilCurves.R --json out.json model.npo
     ```
 
     #### Module config options


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

From `Nonpareil` version `v3.5.5` there is an auxiliary script that generated the `JSON` file, so there is no need for the extra R functions provided. 