### PR TITLE
Fix Bracken bug when direct reads not classified

### DIFF
--- a/multiqc/modules/bracken/bracken.py
+++ b/multiqc/modules/bracken/bracken.py
@@ -34,3 +34,15 @@ class MultiqcModule(KrakenModule):
             doi="10.7717/peerj-cs.104",
             sp_key="bracken",
         )
+
+    def sample_total_readcounts(self):
+        # Get the total read counts for each sample, using the fact that all reads are assigned to root
+        total_all_samples = 0
+        for s_name, data in self.kraken_raw_data.items():
+            self.kraken_sample_total_readcounts[s_name] = data[0]['counts_rooted']
+            total_all_samples += self.kraken_sample_total_readcounts[s_name]
+        
+        # Check that we had some counts for some samples, exit if not
+        if total_all_samples == 0:
+            log.warning("No samples had any reads")
+            raise super.ModuleNoSamplesFound


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

Update Bracken module to fix the bug described in #2731 Rather than looping over direct reads to get total reads, simply takes the reported reads for root (the first line of each file)

- [ ] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
