### PR TITLE
fix handling of module href str

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -96,6 +96,10 @@ class BaseMultiqcModule:
         if self.extra is None:
             self.extra = ""
 
+        if isinstance(self.href, str):
+            self.href = [self.href]
+        self.href = [i for i in self.href if i != ""]
+
         if isinstance(self.doi, str):
             self.doi = [self.doi]
         self.doi = [i for i in self.doi if i != ""]


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Passing an href string as part of `module_order` resulted in weird output.

I used https://github.com/MultiQC/test-data/blob/066e040dbd5b3360b9b01002559d5cbc73b05928/data/modules/kraken/v2.1.1/metagenome.kreport to reproduce.

`multiqc_config.yaml`:
```
module_order:
  - "kraken": {"doi": "foo.bar", "href": "https://foo.bar"}
```

Before fix:
![Screenshot 2024-08-04 at 19-58-02 MultiQC Report](https://github.com/user-attachments/assets/3938d272-08de-41cf-a293-aee64b8fad58)

After fix:
![Screenshot 2024-08-04 at 19-58-52 MultiQC Report](https://github.com/user-attachments/assets/c760db55-8a9c-4a06-b610-fa17b3aabb61)
