### PR TITLE
Fix ValueError in `ngsderive` module, `encoding` submodule.

### DIFF
--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -275,7 +275,7 @@ class MultiqcModule(BaseMultiqcModule):
         for sample, readlen in self.readlen.items():
             data[sample] = {
                 "evidence": readlen.get("Evidence"),
-                "majoritypctdetected": round(float(readlen.get("MajorityPctDetected")) * 100.0, 2),
+                "majoritypctdetected": round(float(readlen.get("MajorityPctDetected").strip("%")) * 100.0, 2),
                 "consensusreadlength": int(readlen.get("ConsensusReadLength")),
             }
 


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)

# Issue:

```

         ngsderive | Found 86 reports
╭─────────────── Oops! The 'ngsderive' MultiQC module broke... ────────────────╮
│ Please copy this log and report it at                                        │
│ https://github.com/MultiQC/MultiQC/issues                                    │
│ Please attach a file that triggers the error. The last file found was:       │
│ tmp/fair_bowtie2_mapping_ngsderive_encoding/homo_sapiens.GRCh38/109.dna/Hort │
│ on_1_001-0170.encoding.tsv                                                   │
│                                                                              │
│ Traceback (most recent call last):                                           │
│   File "/mnt/beegfs/pipelines/unofficial-snakemake-wrappers/shared_install/3 │
│     these_modules: Union[BaseMultiqcModule, List[BaseMultiqcModule]] = modul │
│                                                                        ^^^^^ │
│   File "/mnt/beegfs/pipelines/unofficial-snakemake-wrappers/shared_install/3 │
│     self.add_readlen_data()                                                  │
│   File "/mnt/beegfs/pipelines/unofficial-snakemake-wrappers/shared_install/3 │
│     "majoritypctdetected": round(float(readlen.get("MajorityPctDetected")) * │
│                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   │
│ ValueError: could not convert string to float: '55.22%'                      │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

# Solution:

Remove the `%` symbol after the numbers. Don't stop if no `%` exists on this string.