### PR TITLE
Kraken: refactor, fix top % calculation, more efficient total read count calculation

### DIFF
--- a/multiqc/modules/bracken/bracken.py
+++ b/multiqc/modules/bracken/bracken.py
@@ -1,6 +1,7 @@
 import logging
 
 from multiqc.modules.kraken import MultiqcModule as KrakenModule
+from multiqc.base_module import ModuleNoSamplesFound
 
 log = logging.getLogger(__name__)
 
@@ -34,3 +35,17 @@ class MultiqcModule(KrakenModule):
             doi="10.7717/peerj-cs.104",
             sp_key="bracken",
         )
+
+    def sample_total_readcounts(self):
+        """
+        Get the total read counts for each sample, using the fact that all reads are assigned to root
+        """
+        total_all_samples = 0
+        for s_name, data in self.kraken_raw_data.items():
+            self.kraken_sample_total_readcounts[s_name] = data[0]["counts_rooted"]
+            total_all_samples += self.kraken_sample_total_readcounts[s_name]
+
+        # Check that we had some counts for some samples, exit if not
+        if total_all_samples == 0:
+            log.warning("No samples had any reads")
+            raise ModuleNoSamplesFound

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -242,7 +242,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Take the unassigned counts (line 1) and counts assigned to root (line 2) for each sample
         for s_name, data in self.kraken_raw_data.items():
             unassigned_counts = data[0]["counts_rooted"]
-            assigned_counts = data[1]["counts_rooted"]
+            assigned_counts = data[1]["counts_rooted"] if len(data) > 0 else 0 
             self.kraken_sample_total_readcounts[s_name] = unassigned_counts + assigned_counts
             total_all_samples += self.kraken_sample_total_readcounts[s_name]
 
@@ -250,7 +250,6 @@ class MultiqcModule(BaseMultiqcModule):
         if total_all_samples == 0:
             log.warning("No samples had any reads")
             raise ModuleNoSamplesFound
-
 
     def sum_sample_counts(self):
         """Sum counts across all samples for kraken data"""

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -84,7 +84,7 @@ class MultiqcModule(BaseMultiqcModule):
         if len(self.kraken_raw_data) == 0:
             raise ModuleNoSamplesFound
 
-        log.info(f"Found {len(self.kraken_raw_data)} reports")
+        log.info(f"{name + ': ' if name != 'Kraken' else ''}Found {len(self.kraken_raw_data)} reports")
 
         # Superfluous function call to confirm that it is used in this module
         # Replace None with actual version if it is available

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -242,7 +242,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Take the unassigned counts (line 1) and counts assigned to root (line 2) for each sample
         for s_name, data in self.kraken_raw_data.items():
             unassigned_counts = data[0]["counts_rooted"]
-            assigned_counts = data[1]["counts_rooted"] if len(data) > 1 else 0 
+            assigned_counts = data[1]["counts_rooted"] if len(data) > 1 else 0
             self.kraken_sample_total_readcounts[s_name] = unassigned_counts + assigned_counts
             total_all_samples += self.kraken_sample_total_readcounts[s_name]
 

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -242,7 +242,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Take the unassigned counts (line 1) and counts assigned to root (line 2) for each sample
         for s_name, data in self.kraken_raw_data.items():
             unassigned_counts = data[0]["counts_rooted"]
-            assigned_counts = data[1]["counts_rooted"] if len(data) > 0 else 0 
+            assigned_counts = data[1]["counts_rooted"] if len(data) > 1 else 0 
             self.kraken_sample_total_readcounts[s_name] = unassigned_counts + assigned_counts
             total_all_samples += self.kraken_sample_total_readcounts[s_name]
 

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -238,16 +238,19 @@ class MultiqcModule(BaseMultiqcModule):
         """Compute the total read counts for each sample"""
 
         total_all_samples = 0
+
+        # Take the unassigned counts (line 1) and counts assigned to root (line 2) for each sample
         for s_name, data in self.kraken_raw_data.items():
-            self.kraken_sample_total_readcounts[s_name] = 0
-            for row in data:
-                self.kraken_sample_total_readcounts[s_name] += row["counts_direct"]
+            unassigned_counts = data[0]["counts_rooted"]
+            assigned_counts = data[1]["counts_rooted"]
+            self.kraken_sample_total_readcounts[s_name] = unassigned_counts + assigned_counts
             total_all_samples += self.kraken_sample_total_readcounts[s_name]
 
         # Check that we had some counts for some samples, exit if not
         if total_all_samples == 0:
             log.warning("No samples had any reads")
             raise ModuleNoSamplesFound
+
 
     def sum_sample_counts(self):
         """Sum counts across all samples for kraken data"""


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->
Changes the method of calculating the total reads for each sample from adding direct reads from each row to instead just looking at the first two lines of each kraken file (unassigned and root).

- [x] This comment contains a description of changes (with reason)

