### PR TITLE
Mosdepth: optimize memory and runtime

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -173,7 +173,8 @@ class BaseMultiqcModule:
         """
         Return matches log files of interest.
         :param sp_key: Search pattern key specified in config
-        :param filehandles: Set to true to return a file handle instead of slurped file contents
+        :param filecontents: f["f"] will contain raw file contents
+        :param filehandles: f["f"] will be the file handle
         :return: Yields a dict with filename (fn), root directory (root), cleaned sample name
                  generated from the filename (s_name) and either the file contents or file handle
                  for the current matched file (f).

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -3,8 +3,6 @@ import logging
 from collections import defaultdict
 from typing import Dict, Union, Optional, Tuple, List, Mapping
 
-import line_profiler
-
 from multiqc import config, Plot
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 
@@ -430,7 +428,6 @@ class MultiqcModule(BaseMultiqcModule):
         )
         self.general_stats_addcols(genstats_by_sample, genstats_headers)
 
-    @line_profiler.profile
     def parse_cov_dist(
         self, scope: str
     ) -> Tuple[


### PR DESCRIPTION
Partially address https://github.com/MultiQC/MultiQC/issues/1961

Optimize the mosdpeth module:

- Don't load the entire file contents in memory, but read by line
- Smooth the data early. Avoid extra parsing and processing of thousands of data points so that it gets downampled down to 500 pints with `smooth_line_data` in line plot.
- Drop the non-cumulative coverage plot as it's not as useful as the cumulative one.
- Read configuration and add general stats headers only once.
- Process data by sample and drop stuff when sample is finished.
- For good measure, add type hints and refactor slightly.

Performance before/after:

<img width="913" alt="Screenshot 2024-08-08 at 21 51 53" src="https://github.com/user-attachments/assets/9140fe49-0448-4034-b860-f367c60002c6">

A lot of memory is a constant overhead. I can imaging the performance on thousand of samples with be significantly better now.