### PR TITLE
fix mosdepth custom thresholds

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -580,7 +580,7 @@ def get_cov_thresholds(config_key: str) -> Tuple[List[int], List[int]]:
     """
     Reads coverage thresholds from the config, otherwise sets sensible defaults. Useful for modules like mosdepth, qualimap (BamQC), ngsbits
     """
-    covs = getattr(globals(), config_key, {}).get("general_stats_coverage", [])
+    covs = globals().get(config_key, {}).get("general_stats_coverage", [])
     if not covs:
         covs = getattr(globals(), "general_stats_coverage", [])
 
@@ -591,7 +591,7 @@ def get_cov_thresholds(config_key: str) -> Tuple[List[int], List[int]]:
         covs = [1, 5, 10, 30, 50]
         logger.debug(f"Using default coverage thresholds: {', '.join([str(t) for t in covs])}")
 
-    hidden_covs = getattr(globals(), config_key, {}).get("general_stats_coverage_hidden", [])
+    hidden_covs = globals().get(config_key, {}).get("general_stats_coverage_hidden", [])
     if not hidden_covs:
         hidden_covs = getattr(globals(), "general_stats_coverage_hidden", [])
 


### PR DESCRIPTION


- [x] This comment contains a description of changes (with reason)

I noticed a regression with the mosdepth module re: setting custom thresholds. It seems we're calling `getattr` on `globals()`. But `globals()` is a dict so `getattr` isn't really useful. Accessing it as a dict by key works better. I'm not sure if this will break other usages though.

Test case:

`Citrobacter+braakii_reference.mosdepth.global.dist.txt`:
```
NZ_CP045771.1   0       1.00
total   0       1.00
```

`multiqc_config.yaml`:
```
mosdepth_config:
  general_stats_coverage: [20, 40, 100, 300, 400]
  general_stats_coverage_hidden: [100, 300, 400]
```

Before:
![Screenshot 2024-08-10 at 05-02-58 MultiQC Report](https://github.com/user-attachments/assets/a74235ea-cf3a-4973-85bd-a97e73dc289e)


After:
![Screenshot 2024-08-10 at 05-03-25 MultiQC Report](https://github.com/user-attachments/assets/73a3c849-8858-464a-b3c4-2b7368c1be6c)
