### PR TITLE
Scale exported plot fonts with `config.plots_export_font_scale`

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -106,6 +106,7 @@ export_plots: bool
 make_report: bool
 make_pdf: bool
 plots_force_flat: bool
+plots_export_font_scale: float
 plots_force_interactive: bool
 plots_flat_numseries: int
 num_datasets_plot_limit: int

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -60,6 +60,7 @@ export_plots: false
 make_report: true
 make_pdf: false
 plots_force_flat: false
+plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
 plots_flat_numseries: 1000
 num_datasets_plot_limit: 50

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -657,11 +657,13 @@ def fig_to_static_html(
     export_plots = export_plots if export_plots is not None else config.export_plots
 
     assert fig.layout.width
+    scale = 2.0  # higher detail (to look sharp on the retina display)
+    scale *= config.plots_export_font_scale  # bigger font if configured in the settings
     write_kwargs = dict(
-        width=fig.layout.width,  # While interactive plots take full width of screen,
+        width=fig.layout.width / config.plots_export_font_scale,  # While interactive plots take full width of screen,
         # for the flat plots we explicitly set width
-        height=fig.layout.height,
-        scale=2,  # higher detail (retina display)
+        height=fig.layout.height / config.plots_export_font_scale,
+        scale=scale,  # higher detail (retina display)
     )
 
     formats = set(config.export_plot_formats) if export_plots else set()

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -367,23 +367,23 @@ $(function () {
         let format = mime.replace("image/", "").split("+")[0];
         let f_width = parseInt($("#mqc_exp_width").val());
         let f_height = parseInt($("#mqc_exp_height").val());
-        const f_scale = parseFloat($("#mqc_export_scaling").val());
+        const font_scale = parseFloat($("#mqc_export_scaling").val());
         checked_plots.each(function () {
           const target = $(this).val();
 
           promises.push(
             Plotly.toImage(target, {
               format: format,
-              width: f_width / f_scale,
-              height: f_height / f_scale,
-              scale: f_scale,
+              width: f_width / font_scale,
+              height: f_height / font_scale,
+              scale: font_scale,
             }).then(function (img) {
               if (format === "svg") {
                 Plotly.Snapshot.downloadImage(target, {
                   format: format,
-                  width: f_width / f_scale,
-                  height: f_height / f_scale,
-                  scale: f_scale,
+                  width: f_width / font_scale,
+                  height: f_height / font_scale,
+                  scale: font_scale,
                   filename: target,
                 });
                 // if (checked_plots.length <= zip_threshold) {


### PR DESCRIPTION
Similar to the JS toolbox feature "scale", add a config option `config.plots_export_font_scale` to scale exported plots from the command line as well. Affects both `--export` and `--flat` (e.g. embedded flat plots).

```
multiqc -fv test-data/data/modules/kallisto --flat
```

<img width="1147" alt="Screenshot 2024-08-12 at 12 53 14" src="https://github.com/user-attachments/assets/e0c83fb7-467d-4234-9d4c-85cc164c4f33">

```
multiqc -fv test-data/data/modules/kallisto --flat --cl-config 'plots_export_font_scale: 1.5'
```
<img width="1134" alt="Screenshot 2024-08-12 at 12 58 10" src="https://github.com/user-attachments/assets/b5c34ee3-7fd6-4100-a049-320c3cf7f2ef">

Fixes https://github.com/MultiQC/MultiQC/issues/876