### PR TITLE
Defer render of plots if number of samples > `config.plots_num_samples_do_not_automatically_load`

### DIFF
--- a/docs/core/getting_started/config.md
+++ b/docs/core/getting_started/config.md
@@ -376,7 +376,7 @@ large reports may show plots as grey boxes with a _"Show Plot"_ button. Clicking
 render the plot as normal and prevents the browser from trying to do everything at once.
 
 By default this behaviour kicks in when a plot has 50 samples or more. This can be customised
-by changing the `num_datasets_plot_limit` config option.
+by changing the `plots_num_samples_do_not_automatically_load` config option.
 
 ### Flat / interactive plots
 

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -109,8 +109,8 @@ plots_force_flat: bool
 plots_export_font_scale: float
 plots_force_interactive: bool
 plots_flat_numseries: int
-num_datasets_plot_limit: int
-lineplot_style: str
+plots_num_samples_do_not_automatically_load: int
+lineplot_number_of_samples_to_hide_markers: int
 barplot_legend_on_bottom: bool
 violin_downsample_after: int
 violin_min_threshold_outliers: int

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -110,7 +110,7 @@ plots_export_font_scale: float
 plots_force_interactive: bool
 plots_flat_numseries: int
 plots_num_samples_do_not_automatically_load: int
-lineplot_number_of_samples_to_hide_markers: int
+lineplot_style: str
 barplot_legend_on_bottom: bool
 violin_downsample_after: int
 violin_min_threshold_outliers: int

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -62,8 +62,8 @@ make_pdf: false
 plots_force_flat: false
 plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
-plots_flat_numseries: 10000
-plots_num_samples_do_not_automatically_load: 1000
+plots_flat_numseries: 2000
+plots_num_samples_do_not_automatically_load: 500
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -63,7 +63,7 @@ plots_force_flat: false
 plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
 plots_flat_numseries: 2000
-plots_num_samples_do_not_automatically_load: 500
+plots_num_samples_do_not_automatically_load: 200
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -62,8 +62,8 @@ make_pdf: false
 plots_force_flat: false
 plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
-plots_flat_numseries: 1000
-num_datasets_plot_limit: 50
+plots_flat_numseries: 10000
+plots_num_samples_do_not_automatically_load: 1000
 lineplot_style: lines # "lines+markers"
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -268,6 +268,12 @@ def render_and_export_plots(plots_dir_name: str):
         disable_progress=not show_progress,
     )
 
+    report.some_plots_are_deferred = any(
+        isinstance(report.plot_by_id[s.plot_id], Plot) and report.plot_by_id[s.plot_id].defer_render
+        for s in sections
+        if s.plot_id
+    )
+
 
 def _render_general_stats_table(plots_dir_name: str) -> None:
     """

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -156,13 +156,10 @@ class BarPlot(Plot[Dataset]):
         if len(cats_lists) != len(samples_lists):
             raise ValueError("Number of datasets and samples lists do not match")
 
-        max_n_samples = max(len(x) for x in samples_lists) if len(samples_lists) > 0 else 0
-
         model = Plot.initialize(
             plot_type=PlotType.BAR,
             pconfig=pconfig,
-            n_datasets=len(cats_lists),
-            n_samples=max_n_samples,
+            n_samples_per_dataset=[len(x) for x in samples_lists],
             axis_controlled_by_switches=["xaxis"],
             default_tt_label="%{meta}: <b>%{x}</b>",
         )
@@ -185,6 +182,7 @@ class BarPlot(Plot[Dataset]):
         HEIGHT_PER_LEGEND_ITEM = 19
         legend_height = HEIGHT_PER_LEGEND_ITEM * max_n_cats
 
+        max_n_samples = max(len(x) for x in samples_lists) if len(samples_lists) > 0 else 0
         height = determine_barplot_height(
             max_n_samples=max_n_samples,
             # Group mode puts each category in a separate bar, so need to multiply by the number of categories

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -106,19 +106,17 @@ class BoxPlot(Plot[Dataset]):
         pconfig: BoxPlotConfig,
         list_of_data_by_sample: List[Dict[str, BoxT]],
     ) -> "BoxPlot":
-        max_n_samples = max(len(x) for x in list_of_data_by_sample) if list_of_data_by_sample else 0
-
         model = Plot.initialize(
             plot_type=PlotType.BOX,
             pconfig=pconfig,
-            n_datasets=len(list_of_data_by_sample),
-            n_samples=max_n_samples,
+            n_samples_per_dataset=[len(x) for x in list_of_data_by_sample],
         )
 
         model.datasets = [
             Dataset.create(ds, data_by_sample) for ds, data_by_sample in zip(model.datasets, list_of_data_by_sample)
         ]
 
+        max_n_samples = max(len(x) for x in list_of_data_by_sample) if list_of_data_by_sample else 0
         height = determine_barplot_height(max_n_samples)
 
         model.layout.update(

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -147,8 +147,7 @@ class HeatmapPlot(Plot):
         model = Plot.initialize(
             plot_type=PlotType.HEATMAP,
             pconfig=pconfig,
-            n_datasets=1,
-            n_samples=max_n_samples,
+            n_samples_per_dataset=[max_n_samples],
         )
 
         if isinstance(rows, list):

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -304,18 +304,16 @@ def create(
     pconfig: LinePlotConfig,
     lists_of_lines: List[List[Series]],
 ) -> "LinePlot":
-    max_n_samples = max(len(x) for x in lists_of_lines) if len(lists_of_lines) > 0 else 0
-
     model = Plot.initialize(
         plot_type=PlotType.LINE,
         pconfig=pconfig,
-        n_datasets=len(lists_of_lines),
-        n_samples=max_n_samples,
+        n_samples_per_dataset=[len(x) for x in lists_of_lines],
         axis_controlled_by_switches=["yaxis"],
         default_tt_label="<br>%{x}: %{y}",
     )
 
     # Very large legend for automatically enabled flat plot mode is not very helpful
+    max_n_samples = max(len(x) for x in lists_of_lines) if len(lists_of_lines) > 0 else 0
     if pconfig.showlegend is None and max_n_samples > 250:
         model.layout.showlegend = False
 

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -172,7 +172,7 @@ class Plot(BaseModel, Generic[T]):
     axis_controlled_by_switches: List[str] = []
     square: bool = False
     flat: bool = False
-    do_not_automatically_load: bool = False
+    defer_render: bool = False
 
     model_config = dict(
         arbitrary_types_allowed=True,
@@ -243,9 +243,9 @@ class Plot(BaseModel, Generic[T]):
         ):
             flat = True
 
-        do_not_automatically_load = False
+        defer_render = False
         if n_samples_per_dataset[0] > config.plots_num_samples_do_not_automatically_load:
-            do_not_automatically_load = True
+            defer_render = True
 
         showlegend = pconfig.showlegend
         if showlegend is None:
@@ -375,7 +375,7 @@ class Plot(BaseModel, Generic[T]):
             axis_controlled_by_switches=axis_controlled_by_switches,
             square=pconfig.square,
             flat=flat,
-            do_not_automatically_load=do_not_automatically_load,
+            defer_render=defer_render,
         )
 
     def show(self, dataset_id: Union[int, str] = 0, flat=False, **kwargs):
@@ -523,7 +523,9 @@ class Plot(BaseModel, Generic[T]):
         # re-calculate the wrapper size after rendering.
         height = self.layout.height
         height_style = f'style="height:{height + 7}px"' if height else ""
-        cls = f"hc-plot hc-{self.plot_type}-plot not_rendered"
+        cls = f"hc-plot hc-{self.plot_type}-plot not_loaded not_rendered"
+        if self.defer_render:
+            cls += " defer_render"
         html += f"""
         <div class="hc-plot-wrapper hc-{self.plot_type}-wrapper" id="{self.id}-wrapper" {height_style}>
             <div id="{self.id}" class="{cls}"></div>

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -203,8 +203,7 @@ class ScatterPlot(Plot):
         model = Plot.initialize(
             plot_type=PlotType.SCATTER,
             pconfig=pconfig,
-            n_datasets=len(points_lists),
-            n_samples=len(points_lists[0]) if len(points_lists) > 0 else 0,
+            n_samples_per_dataset=[len(x) for x in points_lists],
             default_tt_label="<br><b>X</b>: %{x}<br><b>Y</b>: %{y}",
         )
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -382,21 +382,21 @@ class ViolinPlot(Plot):
         dts: List[DataTable],
         show_table_by_default: bool = False,
     ) -> "ViolinPlot":
-        all_samples: Set[str] = set()
-        for dt in dts:
+        assert len(dts) > 0, "No datasets to plot"
+
+        samples_per_dataset: List[Set[str]] = []
+        for dt_idx, dt in enumerate(dts):
+            ds_samples: Set[str] = set()
             for rd in dt.raw_data:
-                all_samples.update(rd.keys())
+                ds_samples.update(rd.keys())
+            samples_per_dataset.append(ds_samples)
 
-        max_n_samples = len(all_samples)
-
-        assert len(dts) > 0
         main_table_dt: DataTable = dts[0]  # used for the table
 
         model = Plot.initialize(
             plot_type=PlotType.VIOLIN,
             pconfig=main_table_dt.pconfig,
-            n_datasets=len(dts),
-            n_samples=max_n_samples,
+            n_samples_per_dataset=[len(x) for x in samples_per_dataset],
             id=main_table_dt.id,
             default_tt_label=": %{x}",
             flat_threshold=None,  # we can make violins always interactive!
@@ -446,6 +446,7 @@ class ViolinPlot(Plot):
         # - do not add a table
         # - plot a Violin in Python, and serialise the figure instead of the datasets
         show_table = True
+        max_n_samples = max(len(x) for x in samples_per_dataset)
         if max_n_samples > config.max_table_rows and not no_violin:
             show_table = False
             if show_table_by_default:

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -63,6 +63,7 @@ modules: List["BaseMultiqcModule"]  # list of BaseMultiqcModule objects
 general_stats_html: str
 lint_errors: List[str]
 num_flat_plots: int
+some_plots_are_deferred: bool
 saved_raw_data: Dict[str, Dict[str, Any]]  # indexed by unique key, then sample name
 last_found_file: Optional[str]
 runtimes: Runtimes
@@ -94,6 +95,7 @@ def reset():
     global general_stats_html
     global lint_errors
     global num_flat_plots
+    global some_plots_are_deferred
     global saved_raw_data
     global last_found_file
     global runtimes
@@ -118,6 +120,7 @@ def reset():
     general_stats_html = ""
     lint_errors = []
     num_flat_plots = 0
+    some_plots_are_deferred = False
     saved_raw_data = dict()
     last_found_file = None
     runtimes = Runtimes()

--- a/multiqc/templates/default/assets/js/multiqc.js
+++ b/multiqc/templates/default/assets/js/multiqc.js
@@ -37,7 +37,7 @@ $(function () {
 
   // Hide welcome alert if setting saved
   try {
-    var hide_welcome = localStorage.getItem("mqc_hide_welcome");
+    let hide_welcome = localStorage.getItem("mqc_hide_welcome");
     if (hide_welcome !== "true") {
       $("#mqc_header_hr").show();
       $("#mqc_welcome").show();
@@ -60,7 +60,7 @@ $(function () {
   $(".module-doi").click(function (e) {
     // Don't follow the link
     e.preventDefault();
-    var el = $(this);
+    let el = $(this);
 
     // Check if we already have a popover
     if (el.data("bs.popover")) {

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -45,7 +45,7 @@ $(function () {
       let violinId = $(this).data("violin-id");
       $("#mqc_violintable_wrapper_" + tableId).hide();
       $("#mqc_violintable_wrapper_" + violinId).show();
-      _renderPlot(violinId);
+      renderPlot(violinId);
     });
 
     $(".mqc-violin-to-table").click(function (e) {
@@ -161,7 +161,7 @@ $(function () {
             dataset["header_by_metric"][metric]["hidden"] = metricsHidden[metric];
           });
         });
-        _renderPlot(violinId);
+        renderPlot(violinId);
       }
     }
 

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -45,7 +45,7 @@ $(function () {
       let violinId = $(this).data("violin-id");
       $("#mqc_violintable_wrapper_" + tableId).hide();
       $("#mqc_violintable_wrapper_" + violinId).show();
-      renderPlot(violinId);
+      _renderPlot(violinId);
     });
 
     $(".mqc-violin-to-table").click(function (e) {
@@ -161,7 +161,7 @@ $(function () {
             dataset["header_by_metric"][metric]["hidden"] = metricsHidden[metric];
           });
         });
-        renderPlot(violinId);
+        _renderPlot(violinId);
       }
     }
 

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -107,8 +107,8 @@ $(function () {
   // Listener to re-plot graphs if config loaded
   $(document).on("mqc_config_loaded", function (e) {
     $(".hc-plot").each(function () {
-      var target = $(this).attr("id");
-      plot_graph(target, undefined, mqc_config["num_datasets_plot_limit"]);
+      let target = $(this).attr("id");
+      maybeRenderPlot(target);
     });
   });
 

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -106,9 +106,9 @@ $(function () {
 
   // Listener to re-plot graphs if config loaded
   $(document).on("mqc_config_loaded", function (e) {
-    $(".hc-plot").each(function () {
+    $(".hc-plot:not(.not_rendered)").each(function () {
       let target = $(this).attr("id");
-      maybeRenderPlot(target);
+      renderPlot(target);
     });
   });
 

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -20,7 +20,7 @@ page contents, it's machine-readable tags for browsers and search engines.
 
 <script type="application/json" id="mqc_config">{{
 {
-    "num_datasets_plot_limit": config.num_datasets_plot_limit,
+    "plots_num_samples_do_not_automatically_load": config.plots_num_samples_do_not_automatically_load,
     "sample_names_rename": config.sample_names_rename,
     "show_hide_patterns": config.show_hide_patterns,
     "show_hide_regex": config.show_hide_regex,

--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -121,9 +121,4 @@ was generated and the button that launches the welcome tour.
   Because this report contains a lot of samples, you may need to click 'Show plot' to see some graphs.
   <button id="mqc-render-all-plots" class="btn btn-default btn-sm">Render all plots</button>
 </div>
-{% else %}
-  <p class="glyphicon glyphicon-warning-sign" aria-hidden="true"></p>
-  <p>config.plots_num_samples_do_not_automatically_load={{config.plots_num_samples_do_not_automatically_load}}</p>
-  <p>report.general_stats_data | length={{report.general_stats_data | length}}</p>
-  <p>report.plot_data | length={{report.plot_data | length}}</p>
 {% endif %}

--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -114,11 +114,16 @@ was generated and the button that launches the welcome tour.
   &nbsp; <small><em>(6:06)</em></small>
 </div>
 
-{% if report.plot_data | length > 0 and report.general_stats_data | length > config.num_datasets_plot_limit %}
+{% if report.plot_data | length > 0 and hide_by_default_by_default %}
 <div id="mqc-warning-many-samples" class="alert alert-warning alert-dismissible hidden-print">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
   Because this report contains a lot of samples, you may need to click 'Show plot' to see some graphs.
   <button id="mqc-render-all-plots" class="btn btn-default btn-sm">Render all plots</button>
 </div>
+{% else %}
+  <p class="glyphicon glyphicon-warning-sign" aria-hidden="true"></p>
+  <p>config.plots_num_samples_do_not_automatically_load={{config.plots_num_samples_do_not_automatically_load}}</p>
+  <p>report.general_stats_data | length={{report.general_stats_data | length}}</p>
+  <p>report.plot_data | length={{report.plot_data | length}}</p>
 {% endif %}

--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -114,7 +114,7 @@ was generated and the button that launches the welcome tour.
   &nbsp; <small><em>(6:06)</em></small>
 </div>
 
-{% if report.plot_data | length > 0 and hide_by_default_by_default %}
+{% if report.plot_data | length > 0 and report.some_plots_are_deferred %}
 <div id="mqc-warning-many-samples" class="alert alert-warning alert-dismissible hidden-print">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>


### PR DESCRIPTION
Defer render of plots if number of samples > `config.plots_num_samples_do_not_automatically_load`. Default value is 200. Will help loading reports quicker.

Helps with https://github.com/MultiQC/MultiQC/issues/2280