### PR TITLE
Section order and custom content order: allow skip the `-module` suffix from ID

### DIFF
--- a/multiqc/core/file_search.py
+++ b/multiqc/core/file_search.py
@@ -95,9 +95,10 @@ def _module_list_to_search() -> Tuple[List[Dict[str, Dict]], List[str]]:
     mod_dicts_in_order: List[Dict[str, Dict]] = [
         m for m in report.top_modules if list(m.keys())[0] in config.avail_modules.keys()
     ]
-    mod_keys = set(list(m.keys())[0] for m in report.module_order)
+
+    mod_order_keys = set(list(m.keys())[0] for m in report.module_order)
     mod_dicts_in_order.extend(
-        [{m: {}} for m in config.avail_modules.keys() if m not in mod_keys and m not in mod_dicts_in_order]
+        [{m: {}} for m in config.avail_modules.keys() if m not in mod_order_keys and m not in mod_dicts_in_order]
     )
     mod_dicts_in_order.extend(
         [
@@ -110,7 +111,7 @@ def _module_list_to_search() -> Tuple[List[Dict[str, Dict]], List[str]]:
 
     # Always run software_versions module to collect version YAML files
     # Use config.skip_versions_section to exclude from report
-    if "software_versions" not in mod_keys:
+    if "software_versions" not in mod_order_keys:
         mod_dicts_in_order.append({"software_versions": {}})
 
     mod_ids = include_or_exclude_modules([list(m.keys())[0] for m in mod_dicts_in_order])

--- a/multiqc/core/order_modules_and_sections.py
+++ b/multiqc/core/order_modules_and_sections.py
@@ -43,6 +43,8 @@ def order_modules_and_sections():
         idx = 10
         for mod in reversed(report.modules):
             section_id_order[mod.anchor] = idx
+            if not mod.anchor.endswith("-module"):  # back-compat with < 1.24
+                section_id_order[mod.anchor + "-module"] = idx
             idx += 10
         for anchor, ss in config.report_section_order.items():
             if anchor not in section_id_order.keys():

--- a/multiqc/modules/cellranger/count.py
+++ b/multiqc/modules/cellranger/count.py
@@ -131,7 +131,7 @@ class CellRangerCountMixin:
         self.add_section(
             name="Count - BC rank plot",
             anchor="cellranger-count-bcrank-plot",
-            description=self.cellrangercount_plots_conf["bc"].get("description"),
+            description=self.cellrangercount_plots_conf["bc"]["description"],
             helptext=self.cellrangercount_plots_conf["bc"]["helptext"],
             plot=linegraph.plot(self.cellrangercount_plots_data["bc"], self.cellrangercount_plots_conf["bc"]["config"]),
         )
@@ -325,65 +325,58 @@ class CellRangerCountMixin:
 
         # Extract data for plots
         help_dict = {x[0]: x[1][0] for x in summary["summary_tab"]["cells"]["help"]["data"]}
-        plots = {}
-        plots_data = {}
-        if "analysis_tab" in summary:
-            plots.update(
-                {
-                    "bc": {
-                        "config": {
-                            "id": "mqc_cellranger_count_bc_knee",
-                            "title": f"Cell Ranger count: {summary['summary_tab']['cells']['barcode_knee_plot']['layout']['title']}",
-                            "xlab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["xaxis"]["title"],
-                            "ylab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["yaxis"]["title"],
-                            "ylog": True,
-                            "xlog": True,
-                        },
-                        "description": "Barcode knee plot",
-                        "helptext": help_dict["Barcode Rank Plot"],
-                    },
-                    "genes": {
-                        "config": {
-                            "id": "mqc_cellranger_count_genesXcell",
-                            "title": f"Cell Ranger count: {summary['analysis_tab']['median_gene_plot']['help']['title']}",
-                            "xlab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["xaxis"]["title"],
-                            "ylab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["yaxis"]["title"],
-                            "ylog": False,
-                            "xlog": False,
-                        },
-                        "description": "Median gene counts per cell",
-                        "helptext": summary["analysis_tab"]["median_gene_plot"]["help"]["helpText"],
-                    },
-                }
-            )
-            try:
-                plots["saturation"] = {
-                    "config": {
-                        "id": "mqc_cellranger_count_saturation",
-                        "title": f"Cell Ranger count: {summary['analysis_tab']['seq_saturation_plot']['help']['title']}",
-                        "xlab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["xaxis"]["title"],
-                        "ylab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["yaxis"]["title"],
-                        "ylog": False,
-                        "xlog": False,
-                        "ymin": 0,
-                        "ymax": 1,
-                    },
-                    "description": "Sequencing saturation",
-                    "helptext": summary["analysis_tab"]["seq_saturation_plot"]["help"]["helpText"],
-                }
-            except KeyError:
-                pass
+        plots = {
+            "bc": {
+                "config": {
+                    "id": "mqc_cellranger_count_bc_knee",
+                    "title": f"Cell Ranger count: {summary['summary_tab']['cells']['barcode_knee_plot']['layout']['title']}",
+                    "xlab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["xaxis"]["title"],
+                    "ylab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["yaxis"]["title"],
+                    "ylog": True,
+                    "xlog": True,
+                },
+                "description": "Barcode knee plot",
+                "helptext": help_dict["Barcode Rank Plot"],
+            },
+            "genes": {
+                "config": {
+                    "id": "mqc_cellranger_count_genesXcell",
+                    "title": f"Cell Ranger count: {summary['analysis_tab']['median_gene_plot']['help']['title']}",
+                    "xlab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["xaxis"]["title"],
+                    "ylab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["yaxis"]["title"],
+                    "ylog": False,
+                    "xlog": False,
+                },
+                "description": "Median gene counts per cell",
+                "helptext": summary["analysis_tab"]["median_gene_plot"]["help"]["helpText"],
+            },
+        }
+        try:
+            plots["saturation"] = {
+                "config": {
+                    "id": "mqc_cellranger_count_saturation",
+                    "title": f"Cell Ranger count: {summary['analysis_tab']['seq_saturation_plot']['help']['title']}",
+                    "xlab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["xaxis"]["title"],
+                    "ylab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["yaxis"]["title"],
+                    "ylog": False,
+                    "xlog": False,
+                    "ymin": 0,
+                    "ymax": 1,
+                },
+                "description": "Sequencing saturation",
+                "helptext": summary["analysis_tab"]["seq_saturation_plot"]["help"]["helpText"],
+            }
+        except KeyError:
+            pass
 
-            plots_data.update(
-                {
-                    "bc": parse_bcknee_data(summary["summary_tab"]["cells"]["barcode_knee_plot"]["data"], s_name),
-                    "genes": {s_name: transform_data(summary["analysis_tab"]["median_gene_plot"]["plot"]["data"][0])},
-                }
-            )
-            if "seq_saturation_plot" in summary["analysis_tab"]:
-                plots_data["saturation"] = {
-                    s_name: transform_data(summary["analysis_tab"]["seq_saturation_plot"]["plot"]["data"][0])
-                }
+        plots_data = {
+            "bc": parse_bcknee_data(summary["summary_tab"]["cells"]["barcode_knee_plot"]["data"], s_name),
+            "genes": {s_name: transform_data(summary["analysis_tab"]["median_gene_plot"]["plot"]["data"][0])},
+        }
+        if "seq_saturation_plot" in summary["analysis_tab"]:
+            plots_data["saturation"] = {
+                s_name: transform_data(summary["analysis_tab"]["seq_saturation_plot"]["plot"]["data"][0])
+            }
 
         # Store full data for ANTIBODY capture
         antibody_data = dict()

--- a/multiqc/modules/cellranger/count.py
+++ b/multiqc/modules/cellranger/count.py
@@ -131,7 +131,7 @@ class CellRangerCountMixin:
         self.add_section(
             name="Count - BC rank plot",
             anchor="cellranger-count-bcrank-plot",
-            description=self.cellrangercount_plots_conf["bc"]["description"],
+            description=self.cellrangercount_plots_conf["bc"].get("description"),
             helptext=self.cellrangercount_plots_conf["bc"]["helptext"],
             plot=linegraph.plot(self.cellrangercount_plots_data["bc"], self.cellrangercount_plots_conf["bc"]["config"]),
         )
@@ -325,58 +325,65 @@ class CellRangerCountMixin:
 
         # Extract data for plots
         help_dict = {x[0]: x[1][0] for x in summary["summary_tab"]["cells"]["help"]["data"]}
-        plots = {
-            "bc": {
-                "config": {
-                    "id": "mqc_cellranger_count_bc_knee",
-                    "title": f"Cell Ranger count: {summary['summary_tab']['cells']['barcode_knee_plot']['layout']['title']}",
-                    "xlab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["xaxis"]["title"],
-                    "ylab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["yaxis"]["title"],
-                    "ylog": True,
-                    "xlog": True,
-                },
-                "description": "Barcode knee plot",
-                "helptext": help_dict["Barcode Rank Plot"],
-            },
-            "genes": {
-                "config": {
-                    "id": "mqc_cellranger_count_genesXcell",
-                    "title": f"Cell Ranger count: {summary['analysis_tab']['median_gene_plot']['help']['title']}",
-                    "xlab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["xaxis"]["title"],
-                    "ylab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["yaxis"]["title"],
-                    "ylog": False,
-                    "xlog": False,
-                },
-                "description": "Median gene counts per cell",
-                "helptext": summary["analysis_tab"]["median_gene_plot"]["help"]["helpText"],
-            },
-        }
-        try:
-            plots["saturation"] = {
-                "config": {
-                    "id": "mqc_cellranger_count_saturation",
-                    "title": f"Cell Ranger count: {summary['analysis_tab']['seq_saturation_plot']['help']['title']}",
-                    "xlab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["xaxis"]["title"],
-                    "ylab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["yaxis"]["title"],
-                    "ylog": False,
-                    "xlog": False,
-                    "ymin": 0,
-                    "ymax": 1,
-                },
-                "description": "Sequencing saturation",
-                "helptext": summary["analysis_tab"]["seq_saturation_plot"]["help"]["helpText"],
-            }
-        except KeyError:
-            pass
+        plots = {}
+        plots_data = {}
+        if "analysis_tab" in summary:
+            plots.update(
+                {
+                    "bc": {
+                        "config": {
+                            "id": "mqc_cellranger_count_bc_knee",
+                            "title": f"Cell Ranger count: {summary['summary_tab']['cells']['barcode_knee_plot']['layout']['title']}",
+                            "xlab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["xaxis"]["title"],
+                            "ylab": summary["summary_tab"]["cells"]["barcode_knee_plot"]["layout"]["yaxis"]["title"],
+                            "ylog": True,
+                            "xlog": True,
+                        },
+                        "description": "Barcode knee plot",
+                        "helptext": help_dict["Barcode Rank Plot"],
+                    },
+                    "genes": {
+                        "config": {
+                            "id": "mqc_cellranger_count_genesXcell",
+                            "title": f"Cell Ranger count: {summary['analysis_tab']['median_gene_plot']['help']['title']}",
+                            "xlab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["xaxis"]["title"],
+                            "ylab": summary["analysis_tab"]["median_gene_plot"]["plot"]["layout"]["yaxis"]["title"],
+                            "ylog": False,
+                            "xlog": False,
+                        },
+                        "description": "Median gene counts per cell",
+                        "helptext": summary["analysis_tab"]["median_gene_plot"]["help"]["helpText"],
+                    },
+                }
+            )
+            try:
+                plots["saturation"] = {
+                    "config": {
+                        "id": "mqc_cellranger_count_saturation",
+                        "title": f"Cell Ranger count: {summary['analysis_tab']['seq_saturation_plot']['help']['title']}",
+                        "xlab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["xaxis"]["title"],
+                        "ylab": summary["analysis_tab"]["seq_saturation_plot"]["plot"]["layout"]["yaxis"]["title"],
+                        "ylog": False,
+                        "xlog": False,
+                        "ymin": 0,
+                        "ymax": 1,
+                    },
+                    "description": "Sequencing saturation",
+                    "helptext": summary["analysis_tab"]["seq_saturation_plot"]["help"]["helpText"],
+                }
+            except KeyError:
+                pass
 
-        plots_data = {
-            "bc": parse_bcknee_data(summary["summary_tab"]["cells"]["barcode_knee_plot"]["data"], s_name),
-            "genes": {s_name: transform_data(summary["analysis_tab"]["median_gene_plot"]["plot"]["data"][0])},
-        }
-        if "seq_saturation_plot" in summary["analysis_tab"]:
-            plots_data["saturation"] = {
-                s_name: transform_data(summary["analysis_tab"]["seq_saturation_plot"]["plot"]["data"][0])
-            }
+            plots_data.update(
+                {
+                    "bc": parse_bcknee_data(summary["summary_tab"]["cells"]["barcode_knee_plot"]["data"], s_name),
+                    "genes": {s_name: transform_data(summary["analysis_tab"]["median_gene_plot"]["plot"]["data"][0])},
+                }
+            )
+            if "seq_saturation_plot" in summary["analysis_tab"]:
+                plots_data["saturation"] = {
+                    s_name: transform_data(summary["analysis_tab"]["seq_saturation_plot"]["plot"]["data"][0])
+                }
 
         # Store full data for ANTIBODY capture
         antibody_data = dict()

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -269,8 +269,6 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
             mod_id = mod_dict["config"].get("parent_id", mod_dict["config"].get("anchor"))
             if mod_id is None:
                 mod_id = c_id
-            if mod_id == c_id:  # make sure the anchors are unique
-                c_id = c_id + "-section"
             # If we have any custom configuration from a MultiQC config file, update here
             # This is done earlier for tsv files too, but we do it here so that it overwrites what was in the file
             if mod_id in mod_cust_config:
@@ -280,7 +278,7 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                 parsed_modules[mod_id] = MultiqcModule(mod_id, mod_dict)
             else:
                 # New sub-section
-                parsed_modules[mod_id].update_init(c_id, mod_dict)
+                parsed_modules[mod_id].update_init(mod_id, mod_dict)
             parsed_modules[mod_id].add_cc_section(c_id, mod_dict)
             if mod_dict["config"].get("plot_type") == "html":
                 log.info(f"{c_id}: Found 1 sample (html)")
@@ -368,6 +366,9 @@ class MultiqcModule(BaseMultiqcModule):
         section_name = mod["config"].get("section_name", c_id.replace("_", " ").title())
         if section_name == "" or section_name is None:
             section_name = "Custom Content"
+
+        if self.id == c_id:  # make sure the anchors are unique
+            c_id = c_id + "-section"
 
         pconfig = mod["config"].get("pconfig", {})
         if pconfig.get("id") is None:

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -146,14 +146,14 @@ def test_wrong_fields(tmp_path, capsys, strict, monkeypatch):
     if not strict:
         # Still should produce output unless strict mode:
         assert len(report.plot_by_id) == 1
-        assert f"{id}-plot" in report.plot_by_id
-        assert report.plot_by_id[f"{id}-plot"].id == f"{id}-plot"
-        assert report.plot_by_id[f"{id}-plot"].plot_type == "xy_line"
-        assert report.plot_by_id[f"{id}-plot"].pconfig.title == "DupRadar General Linear Model"
-        assert report.plot_by_id[f"{id}-plot"].pconfig.xlog is True
-        assert report.plot_by_id[f"{id}-plot"].pconfig.xlab is None  # wrong type
-        assert report.plot_by_id[f"{id}-plot"].pconfig.ymax == 100
-        assert report.plot_by_id[f"{id}-plot"].pconfig.ymin is None  # wrong type
+        assert f"{id}-section-plot" in report.plot_by_id
+        assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
+        assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
+        assert report.plot_by_id[f"{id}-section-plot"].pconfig.title == "DupRadar General Linear Model"
+        assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlog is True
+        assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlab is None  # wrong type
+        assert report.plot_by_id[f"{id}-section-plot"].pconfig.ymax == 100
+        assert report.plot_by_id[f"{id}-section-plot"].pconfig.ymin is None  # wrong type
 
 
 def test_missing_id_and_title(tmp_path, capsys):
@@ -174,10 +174,10 @@ def test_missing_id_and_title(tmp_path, capsys):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{id}-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-plot"].id == f"{id}-plot"
-    assert report.plot_by_id[f"{id}-plot"].plot_type == "xy_line"
-    assert report.plot_by_id[f"{id}-plot"].pconfig.xlab == "expression"
+    assert f"{id}-section-plot" in report.plot_by_id
+    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
+    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
+    assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlab == "expression"
 
 
 def test_with_separate_config(tmp_path, capsys):
@@ -292,9 +292,9 @@ sp:
 
     # Expecting to see only one table, and no bar plot from the _mqc file
     assert len(report.plot_by_id) == 1
-    assert "last_o2o-plot" in report.plot_by_id
-    assert report.plot_by_id["last_o2o-plot"].id == "last_o2o-plot"
-    assert report.plot_by_id["last_o2o-plot"].plot_type == "violin"
+    assert "last_o2o-section-plot" in report.plot_by_id
+    assert report.plot_by_id["last_o2o-section-plot"].id == "last_o2o-section-plot"
+    assert report.plot_by_id["last_o2o-section-plot"].plot_type == "violin"
 
 
 @pytest.mark.parametrize(
@@ -362,10 +362,10 @@ def test_from_tsv(tmp_path, section_name, is_good, contents):
 
     custom_module_classes()
     assert len(report.plot_by_id) == 1
-    assert "mysample-plot" in report.plot_by_id
-    assert report.plot_by_id["mysample-plot"].plot_type == "violin"
-    assert len(report.plot_by_id["mysample-plot"].datasets) == 1
-    assert report.plot_by_id["mysample-plot"].datasets[0].header_by_metric.keys() == {
+    assert "mysample-section-plot" in report.plot_by_id
+    assert report.plot_by_id["mysample-section-plot"].plot_type == "violin"
+    assert len(report.plot_by_id["mysample-section-plot"].datasets) == 1
+    assert report.plot_by_id["mysample-section-plot"].datasets[0].header_by_metric.keys() == {
         "SEQUENCE",
         "START",
         "END",
@@ -373,14 +373,14 @@ def test_from_tsv(tmp_path, section_name, is_good, contents):
         "GENE",
     }
 
-    assert report.plot_by_id["mysample-plot"].datasets[0].violin_value_by_sample_by_metric == {
+    assert report.plot_by_id["mysample-section-plot"].datasets[0].violin_value_by_sample_by_metric == {
         "SEQUENCE": {"myfile.fasta": "chr1"},
         "START": {"myfile.fasta": 55312.0},
         "END": {"myfile.fasta": 56664.0},
         "STRAND": {"myfile.fasta": "+"},
         "GENE": {"myfile.fasta": "GENE"},
     }
-    assert report.plot_by_id["mysample-plot"].layout.title.text == "My section" if section_name else "mysample"
+    assert report.plot_by_id["mysample-section-plot"].layout.title.text == "My section" if section_name else "mysample"
 
 
 def test_on_all_example_files(data_dir):

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -53,9 +53,9 @@ def test_custom_content(tmp_path):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{id}-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-plot"].id == f"{id}-plot"
-    assert report.plot_by_id[f"{id}-plot"].plot_type == "xy_line"
+    assert f"{id}-section-plot" in report.plot_by_id
+    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
+    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
 
 
 def test_deprecated_fields(tmp_path, capsys):
@@ -89,9 +89,9 @@ def test_deprecated_fields(tmp_path, capsys):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{id}-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-plot"].id == f"{id}-plot"
-    assert report.plot_by_id[f"{id}-plot"].plot_type == "xy_line"
+    assert f"{id}-section-plot" in report.plot_by_id
+    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
+    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
 
     err = str(capsys.readouterr().err)
     assert "Line plot's x_lines or y_lines 'label' field is expected to be a string" in err
@@ -249,8 +249,8 @@ sp:
     )
 
     out = capsys.readouterr().out
-    assert '<h2 class="mqc-module-title" id="concordance-module">Concordance Rates</h2>' in out
-    assert '<div class="mqc-section mqc-section-concordance-module">' in out
+    assert '<h2 class="mqc-module-title" id="concordance">Concordance Rates</h2>' in out
+    assert '<div class="mqc-section mqc-section-concordance">' in out
     assert 'value="0.378"' in out
 
 


### PR DESCRIPTION
Order can be specified for custom content specifically, e.g.:

```yaml
custom_content:
  order:
    - abricate_card
```

Or:

```yaml
report_section_order:
  abricate_card:
    order: 100
```

When we add "custom content" submodules, to assure unique HTML IDs between module, section, and plots, we add add the `-module` to the module anchor, so users had to add it to the configs as well. We should allow avoid this. So not adding the `-module` suffix anymore, but allowing configs with the suffix for back-compatibility.