### PR TITLE
Base plot size thresholds on number of data points instead of samples

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,4 +51,4 @@ jobs:
           7z x test-data.zip -y -o"test-data"
 
       - run: |
-          multiqc --strict -v test-data\test-data-main\data\modules\
+          multiqc -m fastqc -m qualimap -m kallisto -m somalier -m cutadapt --strict -v test-data\test-data-main\data\modules\

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -108,9 +108,11 @@ make_pdf: bool
 plots_force_flat: bool
 plots_export_font_scale: float
 plots_force_interactive: bool
-plots_flat_numseries: int
-plots_num_samples_do_not_automatically_load: int
-num_datasets_plot_limit: int  # deprecated name of plots_num_samples_do_not_automatically_load
+plots_flat_numseries: int  # DEPRECATED (replaced with plots_flat_num_data_points)
+plots_flat_num_data_points: int  # after this num data points, plots will render flat (unless --flat)
+num_datasets_plot_limit: int  # DEPRECATED (replaced with plots_num_samples_do_not_automatically_load)
+plots_num_data_points_do_not_automatically_load: int  # after this num data points, plot will require user to press
+# button to render plot
 lineplot_number_of_points_to_hide_markers: int
 barplot_legend_on_bottom: bool
 violin_downsample_after: int

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -63,9 +63,9 @@ plots_force_flat: false
 plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
 plots_flat_numseries: 1000 # DEPRECATED (replaced with plots_flat_num_data_points)
-plots_flat_num_data_points: 100000 # after 100k data points (~200 line plot series), plots will render flat (unless --flat)
-plots_num_data_points_do_not_automatically_load: 10000 # after 10k data points (~20 line plot series), plot will require user to press button to render plot
-num_datasets_plot_limit: 200 # DEPRECATED (replaced with plots_num_samples_do_not_automatically_load)
+plots_flat_num_data_points: 50000 # after 50k data points (~100 line plot series), plots will render flat (unless --flat)
+plots_num_data_points_do_not_automatically_load: 5000 # after 5k data points (~10 line plot series), plot will require user to press button to render plot
+num_datasets_plot_limit: 200 # DEPRECATED (replaced with plots_num_data_points_do_not_automatically_load)
 lineplot_number_of_points_to_hide_markers: 50 # sum of data points in all samples
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -62,9 +62,10 @@ make_pdf: false
 plots_force_flat: false
 plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
-plots_flat_numseries: 2000
-plots_num_samples_do_not_automatically_load: 200
-num_datasets_plot_limit: 200 # deprecated name of plots_num_samples_do_not_automatically_load; left for back-compatibility
+plots_flat_numseries: 1000 # DEPRECATED (replaced with plots_flat_num_data_points)
+plots_flat_num_data_points: 100000 # after 100k data points (~200 line plot series), plots will render flat (unless --flat)
+plots_num_data_points_do_not_automatically_load: 10000 # after 10k data points (~20 line plot series), plot will require user to press button to render plot
+num_datasets_plot_limit: 200 # DEPRECATED (replaced with plots_num_samples_do_not_automatically_load)
 lineplot_number_of_points_to_hide_markers: 50 # sum of data points in all samples
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -164,9 +164,10 @@ class BarPlot(Plot[Dataset]):
             plot_type=PlotType.BAR,
             pconfig=pconfig,
             n_samples_per_dataset=[len(x) for x in samples_lists],
-            n_datapoints=n_datapoints,
             axis_controlled_by_switches=["xaxis"],
             default_tt_label="%{meta}: <b>%{x}</b>",
+            n_datapoints=n_datapoints,
+            defer_render_if_large=False,  # We hide samples on large heatmaps, so no need to defer render
         )
 
         model.datasets = [

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -156,10 +156,15 @@ class BarPlot(Plot[Dataset]):
         if len(cats_lists) != len(samples_lists):
             raise ValueError("Number of datasets and samples lists do not match")
 
+        n_datapoints = 0
+        for cats, samples in zip(cats_lists, samples_lists):
+            n_datapoints += len(cats) * len(samples)
+
         model = Plot.initialize(
             plot_type=PlotType.BAR,
             pconfig=pconfig,
             n_samples_per_dataset=[len(x) for x in samples_lists],
+            n_datapoints=n_datapoints,
             axis_controlled_by_switches=["xaxis"],
             default_tt_label="%{meta}: <b>%{x}</b>",
         )

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -106,10 +106,15 @@ class BoxPlot(Plot[Dataset]):
         pconfig: BoxPlotConfig,
         list_of_data_by_sample: List[Dict[str, BoxT]],
     ) -> "BoxPlot":
+        n_datapoints = 0
+        for data_by_sample in list_of_data_by_sample:
+            n_datapoints += len(data_by_sample)
+
         model = Plot.initialize(
             plot_type=PlotType.BOX,
             pconfig=pconfig,
             n_samples_per_dataset=[len(x) for x in list_of_data_by_sample],
+            n_datapoints=n_datapoints,
         )
 
         model.datasets = [

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -153,6 +153,7 @@ class HeatmapPlot(Plot):
             pconfig=pconfig,
             n_samples_per_dataset=[max_n_samples],
             n_datapoints=n_datapoints,
+            defer_render_if_large=False,  # We hide samples on large heatmaps, so no need to defer render
         )
 
         if isinstance(rows, list):

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -144,10 +144,15 @@ class HeatmapPlot(Plot):
             else:
                 max_n_samples = max(max_n_samples, len(rows[next(iter(rows))]))
 
+        n_datapoints = 0
+        for row in rows:
+            n_datapoints += len(row)
+
         model = Plot.initialize(
             plot_type=PlotType.HEATMAP,
             pconfig=pconfig,
             n_samples_per_dataset=[max_n_samples],
+            n_datapoints=n_datapoints,
         )
 
         if isinstance(rows, list):

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -311,12 +311,17 @@ def create(
     pconfig: LinePlotConfig,
     lists_of_lines: List[List[Series]],
 ) -> "LinePlot":
+    n_datapoints = 0
+    for lines in lists_of_lines:
+        n_datapoints += sum(len(x.pairs) for x in lines)
+
     model = Plot.initialize(
         plot_type=PlotType.LINE,
         pconfig=pconfig,
         n_samples_per_dataset=[len(x) for x in lists_of_lines],
         axis_controlled_by_switches=["yaxis"],
         default_tt_label="<br>%{x}: %{y}",
+        n_datapoints=n_datapoints,
     )
 
     # Very large legend for automatically enabled flat plot mode is not very helpful

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -315,10 +315,12 @@ def create(
     for lines in lists_of_lines:
         n_datapoints += sum(len(x.pairs) for x in lines)
 
+    n_samples_per_dataset = [len(x) for x in lists_of_lines]
+
     model = Plot.initialize(
         plot_type=PlotType.LINE,
         pconfig=pconfig,
-        n_samples_per_dataset=[len(x) for x in lists_of_lines],
+        n_samples_per_dataset=n_samples_per_dataset,
         axis_controlled_by_switches=["yaxis"],
         default_tt_label="<br>%{x}: %{y}",
         n_datapoints=n_datapoints,

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -196,21 +196,21 @@ class Plot(BaseModel, Generic[T]):
         plot_type: PlotType,
         pconfig: PConfig,
         n_samples_per_dataset: List[int],
+        n_datapoints: Optional[int] = None,
         id: Optional[str] = None,
         axis_controlled_by_switches: Optional[List[str]] = None,
         default_tt_label: Optional[str] = None,
-        flat_threshold: Optional[int] = config.plots_flat_numseries,
     ):
         """
         Initialize a plot model with the given configuration.
         :param plot_type: plot type
         :param pconfig: plot configuration model
         :param n_samples_per_dataset: number of samples for each dataset, to pre-initialize the base dataset models
+        :param n_datapoints: total number of data points. If provided, config thresholds - to defer render or render flat - will be applied
         :param id: plot ID
         :param axis_controlled_by_switches: list of axis names that are controlled by the
             log10 scale and percentage switch buttons, e.g. ["yaxis"]
         :param default_tt_label: default tooltip label
-        :param flat_threshold: threshold for the number of samples to switch to flat plots
         """
         if n_samples_per_dataset == 0:
             raise ValueError("No datasets to plot")
@@ -236,15 +236,15 @@ class Plot(BaseModel, Generic[T]):
         flat = False
         if config.plots_force_flat:
             flat = True
-        elif (
-            flat_threshold is not None
+        if (
+            n_datapoints is not None
             and not config.plots_force_interactive
-            and max(x for x in n_samples_per_dataset) > flat_threshold
+            and n_datapoints > config.plots_flat_num_data_points
         ):
             flat = True
 
         defer_render = False
-        if n_samples_per_dataset[0] > config.plots_num_samples_do_not_automatically_load:
+        if n_datapoints is not None and n_datapoints > config.plots_num_data_points_do_not_automatically_load:
             defer_render = True
 
         showlegend = pconfig.showlegend

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -200,6 +200,10 @@ class ScatterPlot(Plot):
 
     @staticmethod
     def create(pconfig: ScatterConfig, points_lists: List[List[PointT]]) -> "ScatterPlot":
+        n_datapoints = 0
+        for points in points_lists:
+            n_datapoints += len(points)
+
         model = Plot.initialize(
             plot_type=PlotType.SCATTER,
             pconfig=pconfig,

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -209,6 +209,7 @@ class ScatterPlot(Plot):
             pconfig=pconfig,
             n_samples_per_dataset=[len(x) for x in points_lists],
             default_tt_label="<br><b>X</b>: %{x}<br><b>Y</b>: %{y}",
+            n_datapoints=n_datapoints,
         )
 
         model.datasets = [Dataset.create(d, points, pconfig) for d, points in zip(model.datasets, points_lists)]

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -399,7 +399,7 @@ class ViolinPlot(Plot):
             n_samples_per_dataset=[len(x) for x in samples_per_dataset],
             id=main_table_dt.id,
             default_tt_label=": %{x}",
-            flat_threshold=None,  # we can make violins always interactive!
+            n_datapoints=None,  # we can make violins always interactive and visible
         )
 
         main_table_dt.id = "table-" + main_table_dt.id  # make it different from the violin id

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -20,7 +20,7 @@ page contents, it's machine-readable tags for browsers and search engines.
 
 <script type="application/json" id="mqc_config">{{
 {
-    "plots_num_samples_do_not_automatically_load": config.plots_num_samples_do_not_automatically_load,
+    "plots_num_data_points_do_not_automatically_load": config.plots_num_data_points_do_not_automatically_load,
     "sample_names_rename": config.sample_names_rename,
     "show_hide_patterns": config.show_hide_patterns,
     "show_hide_regex": config.show_hide_regex,


### PR DESCRIPTION
Apply `config.plots_flat_num_data_points` and `config.plots_num_data_points_do_not_automatically_load` based on the number of data points, not series. Show number of samples in plots in the subtitle.