### PR TITLE
Heatmap: allow numeric `xcats` and `ycats`

### DIFF
--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -1,7 +1,7 @@
 """MultiQC functions to plot a heatmap"""
 
 import logging
-from typing import Union, Dict
+from typing import Union, Dict, Optional, List
 
 from multiqc import config
 from multiqc.plots.plotly import heatmap
@@ -23,8 +23,8 @@ def get_template_mod():
 
 def plot(
     data,
-    xcats=None,
-    ycats=None,
+    xcats: Optional[List[Union[str, int]]] = None,
+    ycats: Optional[List[Union[str, int]]] = None,
     pconfig: Union[Dict, HeatmapConfig, None] = None,
 ) -> Union[heatmap.HeatmapPlot, str]:
     """Plot a 2D heatmap.

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -41,7 +41,7 @@ class HeatmapConfig(PConfig):
 
 
 def plot(
-    rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
+    rows: Union[List[List[ElemT]], Dict[Union[str, int], Dict[Union[str, int], ElemT]]],
     pconfig: HeatmapConfig,
     xcats: Optional[List[Union[str, int]]] = None,
     ycats: Optional[List[Union[str, int]]] = None,
@@ -276,7 +276,7 @@ class HeatmapPlot(Plot):
             model.layout.xaxis.ticktext = xcats
         if not pconfig.angled_xticks and x_px_per_elem >= 40 and xcats:
             # Break up the horizontal ticks by whitespace to make them fit better vertically:
-            model.layout.xaxis.ticktext = ["<br>".join(split_long_string(cat, 10)) for cat in xcats]
+            model.layout.xaxis.ticktext = ["<br>".join(split_long_string(str(cat), 10)) for cat in xcats]
             # And leave x ticks horizontal:
             model.layout.xaxis.tickangle = 0
         else:

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -43,8 +43,8 @@ class HeatmapConfig(PConfig):
 def plot(
     rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
     pconfig: HeatmapConfig,
-    xcats: Optional[List[str]] = None,
-    ycats: Optional[List[str]] = None,
+    xcats: Optional[List[Union[str, int]]] = None,
+    ycats: Optional[List[Union[str, int]]] = None,
 ) -> "HeatmapPlot":
     """
     Build and add the plot data to the report, return an HTML wrapper.
@@ -133,8 +133,8 @@ class HeatmapPlot(Plot):
     def create(
         rows: Union[List[List[ElemT]], Dict[str, Dict[str, ElemT]]],
         pconfig: HeatmapConfig,
-        xcats: Optional[List[str]],
-        ycats: Optional[List[str]],
+        xcats: Optional[List[Union[str, int]]],
+        ycats: Optional[List[Union[str, int]]],
     ) -> "HeatmapPlot":
         max_n_samples = 0
         if rows:
@@ -185,8 +185,8 @@ class HeatmapPlot(Plot):
             Dataset.create(
                 model.datasets[0],
                 rows=rows,
-                xcats=xcats,
-                ycats=ycats,
+                xcats=[str(x) for x in xcats],
+                ycats=[str(y) for y in ycats],
             )
         ]
 

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -383,6 +383,35 @@ def test_from_tsv(tmp_path, section_name, is_good, contents):
     assert report.plot_by_id["mysample-section-plot"].layout.title.text == "My section" if section_name else "mysample"
 
 
+def test_heatmap_with_numerical_cats(tmp_path):
+    plot_id = "my_plot"
+    file = tmp_path / "mysample_mqc.json"
+    file.write_text(
+        f"""\
+{{
+    "id": "{plot_id}",
+    "plot_type": "heatmap",
+    "pconfig": {{
+        "title": "Annotation stats (DRAMv)",
+        "min": 0
+    }},
+    "ycats": ["sample 1", "sample 2"],
+    "xcats": [1, 2, 3, 4],
+    "data": [[0.9, 0.87, 0.73, 0], [0, 1, 0, 0.7]]
+}}
+"""
+    )
+
+    report.analysis_files = [file]
+    report.search_files(["custom_content"])
+    custom_module_classes()
+
+    assert len(report.plot_by_id) == 1
+    assert f"{plot_id}-section-plot" in report.plot_by_id
+    assert report.plot_by_id[f"{plot_id}-section-plot"].id == f"{plot_id}-section-plot"
+    assert report.plot_by_id[f"{plot_id}-section-plot"].plot_type == "heatmap"
+
+
 def test_on_all_example_files(data_dir):
     """
     Run on all example in data/custom_content, verify it didn't fail.
@@ -393,39 +422,3 @@ def test_on_all_example_files(data_dir):
 
     file_search()
     custom_module_classes()
-
-
-# @pytest.mark.parametrize("input_file", list(Path(testing.data_dir() / "custom_content" / "embedded_config").iterdir()))
-# def test_custom_content_files(input_file, tmp_path):
-#     """
-#     Test other files in custom_content test-data dir that they don't fail and generate something
-#     """
-#
-#     report.analysis_files = [input_file]
-#     report.search_files(["custom_content"])
-#     modules = custom_module_classes()
-#
-#     # Verify some sections added:
-#     assert sum(len(m.sections) for m in modules) > 0
-
-
-# TODO: test each file separately
-# @pytest.mark.parametrize(
-#     "input_file", list(Path(testing.data_dir() / "custom_content" / "embedded_config").iterdir())[:1]
-# )
-# def test_custom_content_html(input_file, tmp_path, snapshot):
-#     """
-#     Test the custom content module with a snapshot of the output
-#     """
-#
-#     # Stubs for dynamic values to make the report snapshots identical
-#     config.creation_date = "CREATION_DATE"
-#     config.version = "VERSION"
-#
-#     report.analysis_files = [input_file]
-#     config.run_modules = ["custom_content"]
-#     file_search()
-#     custom_module_classes()
-#     multiqc.write_report(output_dir=str(tmp_path))
-#
-#     snapshot.assert_match((tmp_path / "multiqc_report.html").read_text())


### PR DESCRIPTION
Fixes custom content in https://github.com/nf-core/nanostring/actions/runs/10467756513/job/28987183655?pr=76

Adds a test.

Fixes https://github.com/MultiQC/MultiQC/issues/2785