### PR TITLE
Separate anchors and IDs for sections: use IDs for Python configation, and anchors in HTML

### DIFF
--- a/multiqc/core/order_modules_and_sections.py
+++ b/multiqc/core/order_modules_and_sections.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Dict
+from typing import Dict, Union
 
 from multiqc import config, report
 from multiqc.core.file_search import include_or_exclude_modules
+from multiqc.types import AnchorT, SectionIdT
 
 logger = logging.getLogger(__name__)
 
@@ -71,12 +72,11 @@ def order_modules_and_sections():
     if len(config.report_section_order) > 0:
         # Go through each module
         for midx, mod in enumerate(report.modules):
-            section_id_order = dict()
+            section_id_order: Dict[Union[AnchorT, SectionIdT], int] = dict()
             # Get a list of the section anchors
             idx = 10
             for s in mod.sections:
                 section_id_order[s.id] = idx
-                section_id_order[s.anchor] = idx
                 idx += 10
             # Go through each section to be reordered
             for sec_or_mod_id_or_anchor, ss in config.report_section_order.items():
@@ -93,7 +93,7 @@ def order_modules_and_sections():
                 if ss.get("before") in section_id_order.keys():
                     section_id_order[sec_or_mod_id_or_anchor] = section_id_order[ss["before"]] - 1
             # Remove module sections
-            section_id_order = {s: o for s, o in section_id_order.items() if o is not False}
+            section_id_order = {sec_id: order for sec_id, order in section_id_order.items() if order is not False}
             # Sort the module sections
-            sorted_ids = sorted(section_id_order.keys(), key=lambda k: section_id_order[k])
+            sorted_ids = sorted(section_id_order.keys(), key=lambda sec_id: section_id_order[sec_id])
             report.modules[midx].sections = [s for i in sorted_ids for s in mod.sections if s.anchor == i or s.id == i]

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -249,8 +249,8 @@ def render_and_export_plots(plots_dir_name: str):
     """
 
     def update_fn(_, s: Section):
-        if s.plot_id:
-            _plot = report.plot_by_id[s.plot_id]
+        if s.plot_anchor:
+            _plot = report.plot_by_id[s.plot_anchor]
             if isinstance(_plot, Plot):
                 s.plot = _plot.add_to_report(plots_dir_name=plots_dir_name)
             elif isinstance(_plot, str):
@@ -266,8 +266,8 @@ def render_and_export_plots(plots_dir_name: str):
     show_progress = config.export_plots
     if not show_progress:
         for s in sections:
-            if s.plot_id:
-                plot = report.plot_by_id[s.plot_id]
+            if s.plot_anchor:
+                plot = report.plot_by_id[s.plot_anchor]
                 if isinstance(plot, Plot) and plot.flat:
                     show_progress = True
                     break
@@ -282,9 +282,9 @@ def render_and_export_plots(plots_dir_name: str):
     )
 
     report.some_plots_are_deferred = any(
-        isinstance(report.plot_by_id[s.plot_id], Plot) and report.plot_by_id[s.plot_id].defer_render
+        isinstance(report.plot_by_id[s.plot_anchor], Plot) and report.plot_by_id[s.plot_anchor].defer_render
         for s in sections
-        if s.plot_id
+        if s.plot_anchor
     )
 
 
@@ -345,8 +345,8 @@ def _write_data_files(data_dir: Path) -> None:
     # Exporting plots to files if requested
     logger.debug("Exporting plot data to files")
     for s in report.get_all_sections():
-        if s.plot_id and isinstance(report.plot_by_id.get(s.plot_id), Plot):
-            report.plot_by_id[s.plot_id].save_data_files()
+        if s.plot_anchor and isinstance(report.plot_by_id.get(s.plot_anchor), Plot):
+            report.plot_by_id[s.plot_anchor].save_data_files()
 
     # Modules have run, so data directory should be complete by now. Move its contents.
     logger.debug(f"Moving data file from '{report.data_tmp_dir()}' to '{data_dir}'")

--- a/multiqc/interactive.py
+++ b/multiqc/interactive.py
@@ -25,6 +25,7 @@ from multiqc.plots.plotly.line import LinePlot
 from multiqc.plots.plotly.plot import PlotType, Plot
 from multiqc.plots.plotly.scatter import ScatterPlot
 from multiqc.plots.plotly.violin import ViolinPlot
+from multiqc.types import ModuleIdT
 
 logger = logging.getLogger("multiqc")
 
@@ -185,21 +186,21 @@ def list_plots() -> Dict:
     @return: Dict of plot names indexed by module and section
     """
 
-    result: Dict = {}
+    result: Dict[ModuleIdT, List] = {}
     for module in report.modules:
-        result[module.anchor] = list()
+        result[module.id] = list()
         for section in module.sections:
-            if not section.plot_id:
+            if not section.plot_anchor:
                 continue
             section_id = section.name or section.anchor
-            plot_id = section.plot_id
-            if plot_id not in report.plot_by_id:
-                raise ValueError(f'CRITICAL: Plot "{plot_id}" not found in report.plot_by_id')
-            plot = report.plot_by_id[plot_id]
+            plot_anchor = section.plot_anchor
+            if plot_anchor not in report.plot_by_id:
+                raise ValueError(f'CRITICAL: Plot "{plot_anchor}" not found in report.plot_by_id')
+            plot = report.plot_by_id[plot_anchor]
             if len(plot.datasets) == 1:
-                result[module.anchor].append(section_id)
+                result[module.id].append(section_id)
             if len(plot.datasets) > 1:
-                result[module.anchor].append({section_id: [d.label for d in plot.datasets]})
+                result[module.id].append({section_id: [d.label for d in plot.datasets]})
 
     return result
 
@@ -222,10 +223,10 @@ def get_plot(
     if not sec:
         raise ValueError(f'Section "{section}" is not found in module "{module}"')
 
-    if sec.plot_id is None:
+    if sec.plot_anchor is None:
         raise ValueError(f"Section {section} doesn't contain a Plot object")
 
-    return report.plot_by_id[sec.plot_id]
+    return report.plot_by_id[sec.plot_anchor]
 
 
 def _load_plot(dump: Dict) -> Plot:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -304,12 +304,11 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
             if mod_id in mod_cust_config:
                 mod_dict["config"].update(mod_cust_config[mod_id])
 
-            # We've not seen this module section before (normal for most custom content)
-            if mod_id not in parsed_modules:
-                parsed_modules[mod_id] = MultiqcModule(mod_id, anchor=mod_anchor, mod=mod_dict)
-            else:
-                # New sub-section
+            if mod_id in parsed_modules:
+                # We've seen this module section before
                 parsed_modules[mod_id].update_init(mod_dict)
+            else:
+                parsed_modules[mod_id] = MultiqcModule(mod_id, anchor=mod_anchor, mod=mod_dict)
 
             parsed_modules[mod_id].add_cc_section(section_id, section_anchor, mod_dict)
             if mod_dict["config"].get("plot_type") == "html":

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -367,14 +367,10 @@ class MultiqcModule(BaseMultiqcModule):
         if section_name == "" or section_name is None:
             section_name = "Custom Content"
 
-        if self.id == c_id:  # make sure the anchors are unique
-            c_id = c_id + "-section"
-
         pconfig = mod["config"].get("pconfig", {})
         if pconfig.get("id") is None:
-            pconfig["id"] = f"{c_id}-plot"
-        if pconfig["id"] == c_id or pconfig["id"] == mod["config"].get("id"):
-            pconfig["id"] += "-plot"
+            pconfig["id"] = c_id
+
         if pconfig.get("title") is None:
             pconfig["title"] = section_name
 
@@ -472,7 +468,12 @@ class MultiqcModule(BaseMultiqcModule):
         if section_name == self.name:
             section_name = None
 
-        self.add_section(name=section_name, anchor=c_id, plot=plot, content=content)
+        # make sure the anchors are unique
+        anchor = c_id
+        if self.id == anchor or pconfig["id"] == anchor:
+            anchor += "-section"
+
+        self.add_section(name=section_name, anchor=anchor, plot=plot, content=content)
 
 
 def _find_file_header(f) -> Tuple[Optional[Dict], List[str]]:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -397,17 +397,23 @@ class MultiqcModule(BaseMultiqcModule):
         section_name: str = mod["config"].get("section_name", section_id.replace("_", " ").title())
         if section_name == "":
             section_name = "Custom Content"
-        # But don't repeat if it's the same title as the module title
-        if section_name == self.name:
-            section_name = ""
 
         pconfig = mod["config"].get("pconfig", {})
+        if pconfig.get("anchor") is None:
+            if pconfig.get("id") is not None:
+                pconfig["anchor"] = pconfig["id"]
+                if pconfig["anchor"] == section_anchor:  # making sure plot anchor is globally unique
+                    pconfig["anchor"] += "-plot"
+            else:
+                pconfig["anchor"] = section_anchor + "-plot"  # making sure anchor is globally unique
         if pconfig.get("id") is None:
             pconfig["id"] = section_id
         if pconfig.get("title") is None:
             pconfig["title"] = section_name
-        if pconfig.get("anchor") is None:
-            pconfig["anchor"] = section_anchor + "-plot"  # making sure anchor is globally unique
+
+        # But don't repeat header if it's the same title as the module title
+        if section_name == self.name:
+            section_name = ""
 
         plot: Optional[Union[Plot, str]] = None
         content = None
@@ -451,8 +457,6 @@ class MultiqcModule(BaseMultiqcModule):
 
             # Line plot
             elif plot_type == "linegraph":
-                del pconfig["anchor"]
-                print(pconfig)
                 plot = linegraph.plot(mod["data"], pconfig=LinePlotConfig(**pconfig))
 
             # Scatter plot

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -91,7 +91,7 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
         mod_cust_config[cust_mod_id] = config_custom_data_item
 
     # Now go through each of the file search patterns
-    bm: BaseMultiqcModule = BaseMultiqcModule(name="Custom content", anchor="custom_content")
+    bm: BaseMultiqcModule = BaseMultiqcModule(name="Custom content", anchor=AnchorT("custom_content"))
     for config_cust_data_id in search_pattern_keys:
         num_sp_found_files = 0
         for f in bm.find_log_files(config_cust_data_id):
@@ -394,12 +394,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.intro = self._get_intro()
 
     def add_cc_section(self, section_id: SectionIdT, section_anchor: AnchorT, mod: Dict):
-        section_name = mod["config"].get("section_name", section_id.replace("_", " ").title())
+        section_name: str = mod["config"].get("section_name", section_id.replace("_", " ").title())
         if section_name == "":
             section_name = "Custom Content"
         # But don't repeat if it's the same title as the module title
         if section_name == self.name:
-            section_name = None
+            section_name = ""
 
         pconfig = mod["config"].get("pconfig", {})
         if pconfig.get("id") is None:
@@ -451,6 +451,8 @@ class MultiqcModule(BaseMultiqcModule):
 
             # Line plot
             elif plot_type == "linegraph":
+                del pconfig["anchor"]
+                print(pconfig)
                 plot = linegraph.plot(mod["data"], pconfig=LinePlotConfig(**pconfig))
 
             # Scatter plot

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -27,7 +27,7 @@ check_plotly_version()
 
 class PConfig(ValidatedConfig):
     id: str
-    anchor: Optional[AnchorT]  # unlike id, has to be globally unique
+    anchor: Optional[AnchorT] = None  # unlike id, has to be globally unique
     table_title: Optional[str] = Field(None, deprecated="title")
     title: str
     height: Optional[int] = None

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -749,10 +749,10 @@ def fig_to_static_html(
         img_buffer.close()
 
     # Should this plot be hidden on report load?
-    hiding = "" if active else ' style="display:none;"'
+    style = "" if active else "display:none;"
     return "".join(
         [
-            f'<div class="mqc_mplplot" {hiding}>',
+            f'<div class="mqc_mplplot" style="{style}" id="{file_name}">',
             f'<img src="{img_src}" height="{fig.layout.height}px" width="{fig.layout.width}px"/>',
             "</div>",
         ]

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -17,13 +17,13 @@ def plot(dt: List[DataTable]):
 
 def make_table(
     dt: DataTable,
-    violin_id: Optional[str] = None,
+    violin_anchor: Optional[str] = None,
     add_control_panel: bool = True,
 ) -> Tuple[str, str]:
     """
     Build HTML for a MultiQC table, and HTML for the modal for configuring the table.
     :param dt: MultiQC datatable object
-    :param violin_id: optional, will add a button to switch to a violin plot with this ID
+    :param violin_anchor: optional, will add a button to switch to a violin plot with this ID
     :param add_control_panel: whether to add the control panel with buttons above the table
     """
 
@@ -74,9 +74,9 @@ def make_table(
         empty_cells[rid] = f'<td class="data-coloured {rid} {hide}"></td>'
 
         # Build the modal table row
-        data = f"data-table-id='{dt.id}'"
-        if violin_id:
-            data += f" data-violin-id='{violin_id}'"
+        data = f"data-table-anchor='{dt.anchor}'"
+        if violin_anchor:
+            data += f" data-violin-anchor='{violin_anchor}'"
         t_modal_headers[rid] = f"""
         <tr class="{rid}{muted}" style="background-color: rgba({header.color}, 0.15);">
           <td class="sorthandle ui-sortable-handle">||</span></td>
@@ -209,7 +209,7 @@ def make_table(
                     hash(val)
                 except TypeError:
                     hashable = False
-                    print(f"Value {val} is not hashable for table {dt.id}, column {metric}, sample {s_name}")
+                    print(f"Value {val} is not hashable for table {dt.anchor}, column {metric}, sample {s_name}")
 
                 # Categorical background colours supplied
                 if isinstance(val, str) and val in header.bgcols.keys():
@@ -222,7 +222,7 @@ def make_table(
                 elif hashable and header.scale:
                     if c_scale is not None:
                         col = " background-color:{} !important;".format(
-                            c_scale.get_colour(val, source=f'Table "{dt.id}", column "{metric}"')
+                            c_scale.get_colour(val, source=f'Table "{dt.anchor}", column "{metric}"')
                         )
                     else:
                         col = ""
@@ -267,7 +267,7 @@ def make_table(
 
         buttons.append(
             f"""
-        <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="table#{dt.id}">
+        <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="table#{dt.anchor}">
             <span class="glyphicon glyphicon-copy"></span> Copy table
         </button>
         """
@@ -285,8 +285,8 @@ def make_table(
 
             buttons.append(
                 f"""
-            <button type="button" class="mqc_table_configModal_btn btn btn-default btn-sm {disabled_class}" data-toggle="modal"
-                data-target="#{dt.id}_configModal" {disabled_attrs}>
+            <button type="button" class="mqc_table_config_modal_btn btn btn-default btn-sm {disabled_class}" data-toggle="modal"
+                data-target="#{dt.anchor}_config_modal" {disabled_attrs}>
                 <span class="glyphicon glyphicon-th"></span> Configure columns
             </button>
             """
@@ -296,7 +296,7 @@ def make_table(
         buttons.append(
             f"""
         <button type="button" class="mqc_table_sortHighlight btn btn-default btn-sm"
-            data-target="#{dt.id}" data-direction="desc" style="display:none;">
+            data-table-anchor="{dt.anchor}" data-direction="desc" style="display:none;">
             <span class="glyphicon glyphicon-sort-by-attributes-alt"></span> Sort by highlight
         </button>
         """
@@ -306,18 +306,18 @@ def make_table(
         if len(t_headers) > 1:
             buttons.append(
                 f"""
-            <button type="button" class="mqc_table_makeScatter btn btn-default btn-sm"
-                data-toggle="modal" data-target="#tableScatterModal" data-table="#{dt.id}">
+            <button type="button" class="mqc_table_make_scatter btn btn-default btn-sm"
+                data-toggle="modal" data-target="#table_scatter_modal" data-table-anchor="{dt.anchor}">
                 <span class="glyphicon glyphicon glyphicon-equalizer"></span> Scatter plot
             </button>
             """
             )
 
-        if violin_id is not None:
+        if violin_anchor is not None:
             buttons.append(
                 f"""
             <button type="button" class="mqc-table-to-violin btn btn-default btn-sm"
-                data-table-id="{dt.id}" data-violin-id="{violin_id}">
+                data-table-anchor="{dt.anchor}" data-violin-anchor="{violin_anchor}">
                 <span class="glyphicon glyphicon-align-left"></span> Violin plot
             </button>
             """
@@ -326,7 +326,7 @@ def make_table(
         buttons.append(
             f"""
         <button type="button" class="export-plot btn btn-default btn-sm"
-            data-pid="{violin_id or dt.id}" data-type="table"
+            data-plot-anchor="{violin_anchor or dt.anchor}" data-type="table"
         >Export as CSV</button>
         """
         )
@@ -336,18 +336,18 @@ def make_table(
         visible_rows = [x for x in row_visibilities if not x]
 
         # Visible rows
-        t_showing_rows_txt = f'Showing <sup id="{dt.id}_numrows" class="mqc_table_numrows">{len(visible_rows)}</sup>/<sub>{len(t_rows)}</sub> rows'
+        t_showing_rows_txt = f'Showing <sup id="{dt.anchor}_numrows" class="mqc_table_numrows">{len(visible_rows)}</sup>/<sub>{len(t_rows)}</sub> rows'
 
         # How many columns are visible?
         ncols_vis = (len(t_headers) + 1) - hidden_cols
         t_showing_cols_txt = ""
         if len(t_headers) > 1:
-            t_showing_cols_txt = f' and <sup id="{dt.id}_numcols" class="mqc_table_numcols">{ncols_vis}</sup>/<sub>{len(t_headers)}</sub> columns'
+            t_showing_cols_txt = f' and <sup id="{dt.anchor}_numcols" class="mqc_table_numcols">{ncols_vis}</sup>/<sub>{len(t_headers)}</sub> columns'
 
         # Build table header text
         buttons.append(
             f"""
-        <small id="{dt.id}_numrows_text" class="mqc_table_numrows_text">{t_showing_rows_txt}{t_showing_cols_txt}.</small>
+        <small id="{dt.anchor}_numrows_text" class="mqc_table_numrows_text">{t_showing_rows_txt}{t_showing_cols_txt}.</small>
         """
         )
 
@@ -359,9 +359,9 @@ def make_table(
     # Build the table itself
     collapse_class = "mqc-table-collapse" if len(t_rows) > 10 and config.collapse_tables else ""
     html += f"""
-        <div id="{dt.id}_container" class="mqc_table_container">
+        <div id="{dt.anchor}_container" class="mqc_table_container">
             <div class="table-responsive mqc-table-responsive {collapse_class}">
-                <table id="{dt.id}" class="table table-condensed mqc_table" data-title="{table_title}" data-sortlist="{_get_sortlist(dt)}">
+                <table id="{dt.anchor}" class="table table-condensed mqc_table" data-title="{table_title}" data-sortlist="{_get_sortlist(dt)}">
         """
 
     # Build the header row
@@ -389,30 +389,30 @@ def make_table(
 
     # Save the raw values to a file if requested
     if dt.pconfig.save_file:
-        fn = dt.pconfig.raw_data_fn or f"multiqc_{dt.id}"
-        report.write_data_file(raw_vals, fn)
-        report.saved_raw_data[fn] = raw_vals
+        fname = dt.pconfig.raw_data_fn or f"multiqc_{dt.anchor}"
+        report.write_data_file(raw_vals, fname)
+        report.saved_raw_data[fname] = raw_vals
 
     # Build the bootstrap modal to customise columns and order
     modal = ""
     if not config.simple_output and add_control_panel and not _is_configure_columns_disabled(len(t_headers)):
         modal = _configuration_modal(
-            tid=dt.id,
+            table_anchor=dt.anchor,
             title=table_title,
             trows="".join(t_modal_headers.values()),
-            violin_id=violin_id,
+            violin_anchor=violin_anchor,
         )
 
     return html, modal
 
 
-def _configuration_modal(tid: str, title: str, trows: str, violin_id: Optional[str] = None) -> str:
-    data = f"data-table-id='{tid}'"
-    if violin_id is not None:
-        data += f" data-violin-id='{violin_id}'"
+def _configuration_modal(table_anchor: str, title: str, trows: str, violin_anchor: Optional[str] = None) -> str:
+    data = f"data-table-anchor='{table_anchor}'"
+    if violin_anchor is not None:
+        data += f" data-violin-anchor='{violin_anchor}'"
     return f"""
     <!-- MultiQC Table Columns Modal -->
-    <div class="modal fade mqc_configModal" id="{tid}_configModal" tabindex="-1">
+    <div class="modal fade mqc_config_modal" id="{table_anchor}_config_modal" tabindex="-1">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
           <div class="modal-header">
@@ -420,12 +420,12 @@ def _configuration_modal(tid: str, title: str, trows: str, violin_id: Optional[s
             <h4 class="modal-title">{title}: Columns</h4>
           </div>
           <div class="modal-body">
-            <p>Uncheck the tick box to hide columns. Click and drag the handle on the left to change order. Table ID: <code>{tid}</code></p>
+            <p>Uncheck the tick box to hide columns. Click and drag the handle on the left to change order. Table ID: <code>{table_anchor}</code></p>
             <p>
-                <button class="btn btn-default btn-sm mqc_configModal_bulkVisible" {data} data-action="showAll">Show All</button>
-                <button class="btn btn-default btn-sm mqc_configModal_bulkVisible" {data} data-action="showNone">Show None</button>
+                <button class="btn btn-default btn-sm mqc_config_modal_bulk_visible" {data} data-action="showAll">Show All</button>
+                <button class="btn btn-default btn-sm mqc_config_modal_bulk_visible" {data} data-action="showNone">Show None</button>
             </p>
-            <table class="table mqc_table mqc_sortable mqc_configModal_table" id="{tid}_configModal_table" data-title="{title}">
+            <table class="table mqc_table mqc_sortable mqc_config_modal_table" id="{table_anchor}_config_modal_table" data-title="{title}">
               <thead>
                 <tr>
                   <th class="sorthandle" style="text-align:center;">Sort</th>

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -404,7 +404,6 @@ class ViolinPlot(Plot):
             flat_if_very_large=False,
         )
 
-        main_table_dt.id = "table-" + main_table_dt.id  # make it different from the violin id
         no_violin = model.pconfig.no_violin
         show_table_by_default = show_table_by_default or no_violin
 
@@ -453,7 +452,7 @@ class ViolinPlot(Plot):
             show_table = False
             if show_table_by_default:
                 logger.debug(
-                    f"Table '{model.id}': sample number {max_n_samples} > {config.max_table_rows}, "
+                    f"Table '{model.anchor}': sample number {max_n_samples} > {config.max_table_rows}, "
                     "Will render only a violin plot instead of the table"
                 )
 
@@ -472,9 +471,9 @@ class ViolinPlot(Plot):
         if not flat and any(len(ds.metrics) > 1 for ds in self.datasets):
             buttons.append(
                 self._btn(
-                    cls="mqc_table_configModal_btn",
+                    cls="mqc_table_config_modal_btn",
                     label="<span class='glyphicon glyphicon-th'></span> Configure columns",
-                    data_attrs={"toggle": "modal", "target": f"#{self.main_table_dt.id}_configModal"},
+                    data_attrs={"toggle": "modal", "target": f"{self.main_table_dt.anchor}_config_modal"},
                 )
             )
         if self.show_table:
@@ -482,7 +481,7 @@ class ViolinPlot(Plot):
                 self._btn(
                     cls="mqc-violin-to-table",
                     label="<span class='glyphicon glyphicon-th-list'></span> Table",
-                    data_attrs={"table-id": self.main_table_dt.id, "violin-id": self.id},
+                    data_attrs={"table-anchor": self.main_table_dt.anchor, "violin-anchor": self.anchor},
                 )
             )
 
@@ -576,7 +575,7 @@ class ViolinPlot(Plot):
         warning = ""
         if self.show_table_by_default and not self.show_table:
             warning = (
-                f'<p class="text-muted" id="table-violin-info-{self.id}">'
+                f'<p class="text-muted" id="table-violin-info-{self.anchor}">'
                 + '<span class="glyphicon glyphicon-exclamation-sign" '
                 + 'title="An interactive table is not available because of the large number of samples. '
                 + "A violin plot is generated instead, showing density of values for each metric, as "
@@ -585,7 +584,7 @@ class ViolinPlot(Plot):
             )
         elif not self.show_table:
             warning = (
-                f'<p class="text-muted" id="table-violin-info-{self.id}">'
+                f'<p class="text-muted" id="table-violin-info-{self.anchor}">'
                 + '<span class="glyphicon glyphicon-exclamation-sign" '
                 + 'title="An interactive table is not available because of the large number of samples. '
                 + "The violin plot displays hoverable points only for outlier samples in each metric, "
@@ -606,14 +605,16 @@ class ViolinPlot(Plot):
         else:
             assert self.main_table_dt is not None
             # Render both, add a switch between table and violin
-            table_html, configuration_modal = make_table(self.main_table_dt, violin_id=self.id)
+            table_html, configuration_modal = make_table(self.main_table_dt, violin_anchor=self.anchor)
             violin_html = super().add_to_report(plots_dir_name=plots_dir_name)
 
             violin_visibility = "style='display: none;'" if self.show_table_by_default else ""
-            html = f"<div id='mqc_violintable_wrapper_{self.id}' {violin_visibility}>{warning}{violin_html}</div>"
+            html = f"<div id='mqc_violintable_wrapper_{self.anchor}' {violin_visibility}>{warning}{violin_html}</div>"
 
             table_visibility = "style='display: none;'" if not self.show_table_by_default else ""
-            html += f"<div id='mqc_violintable_wrapper_{self.main_table_dt.id}' {table_visibility}>{table_html}</div>"
+            html += (
+                f"<div id='mqc_violintable_wrapper_{self.main_table_dt.anchor}' {table_visibility}>{table_html}</div>"
+            )
 
             html += configuration_modal
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -799,6 +799,11 @@ def save_htmlid(html_id, skiplint=False):
     global html_ids
     global lint_errors
 
+    # print("html_id:", html_id)
+    # import traceback
+    #
+    # traceback.print_stack()
+
     # Clean up the HTML ID
     html_id_clean = clean_htmlid(html_id)
 

--- a/multiqc/templates/default/assets/css/default_multiqc.css
+++ b/multiqc/templates/default/assets/css/default_multiqc.css
@@ -761,7 +761,7 @@ tbody .sorthandle {
   cursor: pointer;
   color: #ccc;
 }
-.mqc_configModal_table tbody .sorthandle {
+.mqc_config_modal_table tbody .sorthandle {
   color: #999;
 }
 .mqc_table .rowheader {

--- a/multiqc/templates/default/assets/js/flat.js
+++ b/multiqc/templates/default/assets/js/flat.js
@@ -5,25 +5,23 @@
 // On page load
 $(function () {
   function switchPlot(button) {
-    let plotgroup = $(button).closest(".mqc_mplplot_plotgroup");
-    let pid = plotgroup.data("pid");
-    let activeDs = plotgroup.find(".dataset-switch-group button.active");
-    if (activeDs !== undefined && activeDs.length > 0) pid = activeDs.data("datasetUid");
+    let plotGroup = $(button).closest(".mqc_mplplot_plotgroup");
+    let plotAnchor = plotGroup.data("plot-anchor");
+    let activeDs = plotGroup.find(".dataset-switch-group button.active");
+    if (activeDs !== undefined && activeDs.length > 0) plotAnchor = activeDs.data("datasetUid");
 
-    let target = "#" + pid;
-
-    let p = plotgroup.find(".percent-switch");
-    let l = plotgroup.find(".log10-switch");
+    let p = plotGroup.find(".percent-switch");
+    let l = plotGroup.find(".log10-switch");
     if (p.length > 0 || l.length > 0) {
       let pActive = p.length > 0 && p.hasClass("active");
       let lActive = l.length > 0 && l.hasClass("active");
-      if (pActive) target += "-pct";
-      if (lActive) target += "-log";
-      if (!pActive && !lActive) target += "-cnt";
+      if (pActive) plotAnchor += "-pct";
+      if (lActive) plotAnchor += "-log";
+      if (!pActive && !lActive) plotAnchor += "-cnt";
     }
 
-    plotgroup.find(".mqc_mplplot").hide();
-    $(target).show();
+    plotGroup.find(".mqc_mplplot").hide();
+    $("#" + plotAnchor).show();
   }
 
   // Switch between counts and percentages in a bar plot

--- a/multiqc/templates/default/assets/js/plots/heatmap.js
+++ b/multiqc/templates/default/assets/js/plots/heatmap.js
@@ -100,11 +100,11 @@ class HeatmapPlot extends Plot {
 $(function () {
   // Listeners for range slider
   $(".mqc_hcplot_range_sliders input").on("keyup change input", function () {
-    let target = $(this).data("target");
+    let anchor = $(this).data("anchor");
     let minmax = $(this).data("minmax");
-    if (minmax === "min") Plotly.restyle(target, { zmin: $(this).val() });
-    if (minmax === "max") Plotly.restyle(target, { zmax: $(this).val() });
-    $("#" + target + "_range_slider_" + minmax + ", #" + target + "_range_slider_" + minmax + "_txt").val(
+    if (minmax === "min") Plotly.restyle(anchor, { zmin: $(this).val() });
+    if (minmax === "max") Plotly.restyle(anchor, { zmax: $(this).val() });
+    $("#" + anchor + "_range_slider_" + minmax + ", #" + anchor + "_range_slider_" + minmax + "_txt").val(
       $(this).val(),
     );
   });

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -95,11 +95,11 @@ class ViolinPlot extends Plot {
       }
     });
     if (outliersWarning)
-      $("#table-violin-info-" + this.target).append(" For efficiency, separate points are shown only for outliers.");
+      $("#table-violin-info-" + this.anchor).append(" For efficiency, separate points are shown only for outliers.");
 
     let layout = this.layout;
     layout.height = this.violinHeight * metrics.length + this.extraHeight;
-    $("#" + this.target + "-wrapper").css("height", layout.height + "px");
+    $("#" + this.anchor + "-wrapper").css("height", layout.height + "px");
     if (metrics.length === 0) return [];
 
     layout.grid.rows = metrics.length;
@@ -298,8 +298,8 @@ class ViolinPlot extends Plot {
   }
 
   afterPlotCreated() {
-    let target = this.target;
-    let plot = document.getElementById(target);
+    let anchor = this.anchor;
+    let plot = document.getElementById(anchor);
 
     plot.on("plotly_hover", function (eventdata) {
       if (!eventdata.points) return;
@@ -312,7 +312,7 @@ class ViolinPlot extends Plot {
         });
         // console.log("hover", point.curveNumber);
         // hoverInfoDiv.html(point.data.text);
-        Plotly.Fx.hover(target, points, curveAxis);
+        Plotly.Fx.hover(anchor, points, curveAxis);
       }
     });
   }

--- a/multiqc/templates/default/assets/js/plotting.js
+++ b/multiqc/templates/default/assets/js/plotting.js
@@ -17,7 +17,7 @@ window.mqc_hide_regex_mode = false;
 
 class Plot {
   constructor(dump) {
-    this.target = dump["id"];
+    this.anchor = dump["anchor"];
     this.layout = dump["layout"];
     this.datasets = dump["datasets"];
     this.pctAxisUpdate = dump["pct_axis_update"];
@@ -53,7 +53,7 @@ class Plot {
     } else {
       this.layout.width = null;
     }
-    Plotly.relayout(this.target, this.layout);
+    Plotly.relayout(this.anchor, this.layout);
   }
 
   buildTraces() {
@@ -150,22 +150,22 @@ $(function () {
 });
 
 callAfterDecompressed.push(function (mqc_plotdata) {
-  mqc_plots = Object.fromEntries(Object.values(mqc_plotdata).map((data) => [data.id, initPlot(data)]));
+  mqc_plots = Object.fromEntries(Object.values(mqc_plotdata).map((data) => [data.anchor, initPlot(data)]));
 
   let shouldLoad = $(".hc-plot.not_loaded:visible");
 
   // Show plots on page load: either render, or show the "Show Plot" button
   shouldLoad.each(function () {
-    let target = $(this).attr("id");
-    let plot = mqc_plots[target];
+    let anchor = $(this).attr("id");
+    let plot = mqc_plots[anchor];
     setTimeout(function () {
       // Deferring each plot call prevents browser from locking up
       if (plot.deferRender) {
-        $("#" + target)
+        $("#" + anchor)
           .removeClass("not_loaded")
           .html('<button class="btn btn-default btn-lg render_plot">Show plot</button>');
       } else {
-        renderPlot(target);
+        renderPlot(anchor);
       }
       if ($(".hc-plot.not_loaded:visible").length === 0)
         // All plots loaded successfully (rendered or deferred with "Show Plot"), so hiding the warning
@@ -178,8 +178,8 @@ callAfterDecompressed.push(function (mqc_plotdata) {
 
   // Render a plot when clicked (heavy plots are not automatically rendered by default)
   $("body").on("click", ".render_plot", function (e) {
-    let target = $(this).parent().attr("id");
-    renderPlot(target);
+    let plotAnchor = $(this).parent().attr("id");
+    renderPlot(plotAnchor);
   });
 
   // Button "Render all plots" clicked, so rendering everything, and hiding the parent button object
@@ -201,70 +201,73 @@ callAfterDecompressed.push(function (mqc_plotdata) {
   // A "Percentages" button above a plot is clicked
   $("button.interactive-switch-group.percent-switch").click(function (e) {
     e.preventDefault();
-    let target = $(this).data("pid");
+    let plotAnchor = $(this).data("plot-anchor");
 
     // Toggling flags
-    mqc_plots[target].pActive = !$(this).hasClass("active");
+    mqc_plots[plotAnchor].pActive = !$(this).hasClass("active");
     $(this).toggleClass("active");
 
-    if (mqc_plots[target].rendered) {
-      renderPlot(target); // re-render
+    if (mqc_plots[plotAnchor].rendered) {
+      renderPlot(plotAnchor); // re-render
     }
   });
 
   // A "Log" button above a plot is clicked
   $("button.interactive-switch-group.log10-switch").click(function (e) {
     e.preventDefault();
-    let target = $(this).data("pid");
+    let plotAnchor = $(this).data("plot-anchor");
 
     // Toggling flags
-    mqc_plots[target].lActive = !$(this).hasClass("active");
+    mqc_plots[plotAnchor].lActive = !$(this).hasClass("active");
     $(this).toggleClass("active");
 
-    if (mqc_plots[target].rendered) {
-      renderPlot(target); // re-render
+    if (mqc_plots[plotAnchor].rendered) {
+      renderPlot(plotAnchor); // re-render
     }
   });
 
   // Switch data source
   $(".interactive-switch-group.dataset-switch-group button").click(function (e) {
     e.preventDefault();
-    if ($(this).hasClass("active")) return;
-    $(this).siblings("button.active").removeClass("active");
-    $(this).addClass("active");
-    let target = $(this).data("pid");
-    let activeDatasetIdx = mqc_plots[target].activeDatasetIdx;
-    let newDatasetIdx = $(this).data("datasetIndex");
-    mqc_plots[target].activeDatasetIdx = newDatasetIdx;
+    let el = $(this);
+    if (el.hasClass("active")) return;
+    el.siblings("button.active").removeClass("active");
+    el.addClass("active");
+    let plotAnchor = el.data("plot-anchor");
+    let activeDatasetIdx = mqc_plots[plotAnchor].activeDatasetIdx;
+    let newDatasetIdx = el.data("datasetIndex");
+    mqc_plots[plotAnchor].activeDatasetIdx = newDatasetIdx;
     if (activeDatasetIdx === newDatasetIdx) return;
 
-    if (mqc_plots[target].rendered) {
-      renderPlot(target); // re-render
+    if (mqc_plots[plotAnchor].rendered) {
+      renderPlot(plotAnchor); // re-render
     }
   });
 
   // Make divs height-draggable
   // http://jsfiddle.net/Lkwb86c8/
   $(".hc-plot:not(.no-handle)").each(function () {
-    if (!$(this).parent().hasClass("hc-plot-wrapper")) {
-      $(this).wrap('<div class="hc-plot-wrapper"></div>');
+    let el = $(this);
+    if (!el.parent().hasClass("hc-plot-wrapper")) {
+      el.wrap('<div class="hc-plot-wrapper"></div>');
     }
-    if (!$(this).siblings().hasClass("hc-plot-handle")) {
-      $(this).after('<div class="hc-plot-handle"><span></span><span></span><span></span></div>');
+    if (!el.siblings().hasClass("hc-plot-handle")) {
+      el.after('<div class="hc-plot-handle"><span></span><span></span><span></span></div>');
     }
-    $(this).css({ height: "auto", top: 0, bottom: "6px", position: "absolute" });
+    el.css({ height: "auto", top: 0, bottom: "6px", position: "absolute" });
   });
 
   $(".hc-plot-handle").on("mousedown", function (e) {
     let wrapper = $(this).parent();
-    let target = wrapper.children(".hc-plot")[0].id;
+    let plotAnchor = wrapper.children(".hc-plot")[0].id;
     let startHeight = wrapper.height();
     let pY = e.pageY;
 
-    $(document).on("mouseup", function () {
+    let doc = $(document);
+    doc.on("mouseup", function () {
       // Clear listeners now that we've let go
-      $(document).off("mousemove");
-      $(document).off("mouseup");
+      doc.off("mousemove");
+      doc.off("mouseup");
       // Fire off a custom jQuery event for other javascript chunks to tie into
       // Bind to the plot div, which should have a custom ID
       $(wrapper.parent().find(".hc-plot, .beeswarm-plot")).trigger("mqc_plotresize");
@@ -273,40 +276,23 @@ callAfterDecompressed.push(function (mqc_plotdata) {
     $(document).on("mousemove", function (me) {
       let newHeight = startHeight + (me.pageY - pY) + 2; // 2 px for the border or something
       wrapper.css("height", newHeight);
-      if (mqc_plots[target] !== undefined) mqc_plots[target].resize(newHeight - 7); // 7 is the height of the handle overlapping the plot wrapper
+      if (mqc_plots[plotAnchor] !== undefined) mqc_plots[plotAnchor].resize(newHeight - 7); // 7 is the height of the handle overlapping the plot wrapper
     });
-  });
-
-  // Sort a heatmap by highlighted names  // TODO: fix for Plotly
-  $(".mqc_heatmap_sortHighlight").click(function (e) {
-    e.preventDefault();
-    let target = $(this).data("target").substr(1);
-    if (mqc_plots[target].sort_highlights === true) {
-      mqc_plots[target].sort_highlights = false;
-      $(this).removeClass("active");
-    } else {
-      mqc_plots[target].sort_highlights = true;
-      $(this).addClass("active");
-    }
-    $(this).blur();
-    if (mqc_plots[target].rendered) {
-      renderPlot(target); // re-render
-    }
   });
 });
 
 // Highlighting, hiding and renaming samples. Takes a list of samples, returns
 // a list of objects: {"name": "new_name", "highlight": "#cccccc", "hidden": false}
-function applyToolboxSettings(samples, target) {
+function applyToolboxSettings(samples, plotAnchor) {
   // init object with default values
   let objects = samples.map((name) => ({ name: name, highlight: null, hidden: false }));
 
   // Rename samples
   if (window.mqc_rename_f_texts.length > 0) {
     objects.map((obj) => {
-      for (let p_idx = 0; p_idx < window.mqc_rename_f_texts.length; p_idx++) {
-        let pattern = window.mqc_rename_f_texts[p_idx];
-        let new_text = window.mqc_rename_t_texts[p_idx];
+      for (let patternIdx = 0; patternIdx < window.mqc_rename_f_texts.length; patternIdx++) {
+        let pattern = window.mqc_rename_f_texts[patternIdx];
+        let new_text = window.mqc_rename_t_texts[patternIdx];
         obj.name = obj.name.replace(pattern, new_text);
       }
     });
@@ -331,7 +317,7 @@ function applyToolboxSettings(samples, target) {
 
   // Hide samples
   if (window.mqc_hide_f_texts.length > 0) {
-    let groupDiv = $("#" + target).closest(".mqc_hcplot_plotgroup");
+    let groupDiv = $("#" + plotAnchor).closest(".mqc_hcplot_plotgroup");
     groupDiv.parent().find(".samples-hidden-warning").remove();
     groupDiv.show();
 
@@ -374,12 +360,12 @@ function applyToolboxSettings(samples, target) {
 }
 
 // Call to render any plot
-function renderPlot(target) {
-  let plot = mqc_plots[target];
+function renderPlot(plotAnchor) {
+  let plot = mqc_plots[plotAnchor];
   if (plot === undefined) return false;
   if (plot.datasets.length === 0) return false;
 
-  let container = $("#" + target);
+  let container = $("#" + plotAnchor);
 
   // When the plot was already rendered, it's faster to call Plotly.react, using the same signature
   // https://plotly.com/javascript/plotlyjs-function-reference/#plotlyreact
@@ -426,11 +412,11 @@ function renderPlot(target) {
   }
 
   container.show();
-  func(target, traces, plot.layout, {
+  func(plotAnchor, traces, plot.layout, {
     responsive: true,
     displaylogo: false,
     displayModeBar: true,
-    toImageButtonOptions: { filename: target },
+    toImageButtonOptions: { filename: plotAnchor },
     modeBarButtonsToRemove: [
       "lasso2d",
       "autoScale2d",

--- a/multiqc/templates/default/assets/js/tables.js
+++ b/multiqc/templates/default/assets/js/tables.js
@@ -41,19 +41,19 @@ $(function () {
 
     $(".mqc-table-to-violin").click(function (e) {
       e.preventDefault();
-      let tableId = $(this).data("table-id");
-      let violinId = $(this).data("violin-id");
-      $("#mqc_violintable_wrapper_" + tableId).hide();
-      $("#mqc_violintable_wrapper_" + violinId).show();
-      renderPlot(violinId);
+      let tableAnchor = $(this).data("table-anchor");
+      let violinAnchor = $(this).data("violin-anchor");
+      $("#mqc_violintable_wrapper_" + tableAnchor).hide();
+      $("#mqc_violintable_wrapper_" + violinAnchor).show();
+      renderPlot(violinAnchor);
     });
 
     $(".mqc-violin-to-table").click(function (e) {
       e.preventDefault();
-      let tableId = $(this).data("table-id");
-      let violinId = $(this).data("violin-id");
-      $("#mqc_violintable_wrapper_" + tableId).show();
-      $("#mqc_violintable_wrapper_" + violinId).hide();
+      let tableAnchor = $(this).data("table-anchor");
+      let violinAnchor = $(this).data("violin-anchor");
+      $("#mqc_violintable_wrapper_" + tableAnchor).show();
+      $("#mqc_violintable_wrapper_" + violinAnchor).hide();
     });
 
     $(".mqc_table_copy_btn").click(function () {
@@ -103,24 +103,24 @@ $(function () {
     /////// COLUMN CONFIG
     // show + hide columns
     $(".mqc_table_col_visible").change(function () {
-      let tableId = $(this).data("table-id");
-      let violinId = $(this).data("violin-id");
-      mqc_table_col_updateVisible(tableId, violinId);
+      let tableAnchor = $(this).data("table-anchor");
+      let violinAnchor = $(this).data("violin-anchor");
+      mqc_table_col_updateVisible(tableAnchor, violinAnchor);
     });
     // Bulk set visible / hidden
-    $(".mqc_configModal_bulkVisible").click(function (e) {
+    $(".mqc_config_modal_bulk_visible").click(function (e) {
       e.preventDefault();
-      let tableId = $(this).data("table-id");
-      let violinId = $(this).data("violin-id");
+      let tableAnchor = $(this).data("table-anchor");
+      let violinAnchor = $(this).data("violin-anchor");
       let visible = $(this).data("action") === "showAll";
-      $("#" + tableId + "_configModal_table tbody .mqc_table_col_visible").prop("checked", visible);
-      mqc_table_col_updateVisible(tableId, violinId);
+      $("#" + tableAnchor + "_config_modal_table tbody .mqc_table_col_visible").prop("checked", visible);
+      mqc_table_col_updateVisible(tableAnchor, violinAnchor);
     });
-    function mqc_table_col_updateVisible(tableId, violinId) {
-      let target = "#" + tableId;
+    function mqc_table_col_updateVisible(tableAnchor, violinAnchor) {
+      let target = "#" + tableAnchor;
 
       let metricsHidden = {};
-      $(target + "_configModal_table .mqc_table_col_visible").each(function () {
+      $(target + "_config_modal_table .mqc_table_col_visible").each(function () {
         let metric = $(this).val();
         metricsHidden[metric] = !$(this).is(":checked");
       });
@@ -128,10 +128,10 @@ $(function () {
       Object.entries(metricsHidden).map(([metric, hidden]) => {
         if (hidden) {
           $(target + " ." + metric).addClass("hidden");
-          $(target + "_configModal_table ." + metric).addClass("text-muted");
+          $(target + "_config_modal_table ." + metric).addClass("text-muted");
         } else {
           $(target + " ." + metric).removeClass("hidden");
-          $(target + "_configModal_table ." + metric).removeClass("text-muted");
+          $(target + "_config_modal_table ." + metric).removeClass("text-muted");
         }
       });
       // Hide empty rows
@@ -154,19 +154,19 @@ $(function () {
       $(target + "_numcols").text($(target + " thead th:visible").length - 1);
 
       // Also update the violin plot
-      if (violinId !== undefined) {
-        let plot = mqc_plots[violinId];
+      if (violinAnchor !== undefined) {
+        let plot = mqc_plots[violinAnchor];
         plot.datasets.map((dataset) => {
           dataset["metrics"].map((metric) => {
             dataset["header_by_metric"][metric]["hidden"] = metricsHidden[metric];
           });
         });
-        renderPlot(violinId);
+        renderPlot(violinAnchor);
       }
     }
 
     // Make rows in MultiQC "Configure Columns" tables sortable
-    $(".mqc_configModal").on("show.bs.modal", function (e) {
+    $(".mqc_config_modal").on("show.bs.modal", function (e) {
       $(e.target)
         .find(".mqc_table.mqc_sortable tbody")
         .sortable({
@@ -181,10 +181,10 @@ $(function () {
     });
 
     // Change order of columns
-    $(".mqc_configModal_table").on("sortstop", function (e, ui) {
+    $(".mqc_config_modal_table").on("sortstop", function (e, ui) {
       change_mqc_table_col_order($(this));
     });
-    $(".mqc_configModal_table").bind("sortEnd", function () {
+    $(".mqc_config_modal_table").bind("sortEnd", function () {
       change_mqc_table_col_order($(this));
     });
 
@@ -212,9 +212,9 @@ $(function () {
     // Sort MultiQC tables by highlight
     $(".mqc_table_sortHighlight").click(function (e) {
       e.preventDefault();
-      let target = $(this).data("target");
+      let tableAnchor = $(this).data("table-anchor");
       // collect highlighted rows
-      let hrows = $(target + " tbody th.highlighted")
+      let hrows = $("#" + tableAnchor + " tbody th.highlighted")
         .parent()
         .detach();
       hrows = hrows.sort(function (a, b) {
@@ -222,10 +222,10 @@ $(function () {
       });
       if ($(this).data("direction") === "desc") {
         hrows = hrows.get().reverse();
-        $(target + " tbody").prepend(hrows);
+        $("#" + tableAnchor + " tbody").prepend(hrows);
         $(this).data("direction", "asc");
       } else {
-        $(target + " tbody").append(hrows);
+        $("#" + tableAnchor + " tbody").append(hrows);
         $(this).data("direction", "desc");
       }
     });
@@ -307,35 +307,41 @@ $(function () {
   } // End of check for table
 
   // Table Scatter Modal
-  $("#tableScatterForm").submit(function (e) {
+  $("#table_scatter_form").submit(function (e) {
     e.preventDefault();
   });
-  $(".mqc_table_makeScatter").click(function (e) {
+  $(".mqc_table_make_scatter").click(function (e) {
     // Reset dropdowns
-    if ($("#tableScatter_tid").val() !== $(this).data("table")) {
-      $("#tableScatter_col1, #tableScatter_col2").html('<option value="">Select Column</option>');
+    let tableAnchor = $(this).data("table-anchor");
+    let table_scatter_table_anchor_el = $("#table_scatter_table_anchor");
+    if (table_scatter_table_anchor_el.val() !== tableAnchor) {
+      $("#table_scatter_col1, #table_scatter_col2").html('<option value="">Select Column</option>');
       // Add columns to dropdowns
-      $($(this).data("table") + " thead tr th").each(function (e) {
-        let c_id = $(this).attr("id");
-        if (c_id !== undefined) {
-          let c_name = $(this).attr("data-namespace") + ": " + $(this).text();
-          $("#tableScatter_col1, #tableScatter_col2").append('<option value="' + c_id + '">' + c_name + "</select>");
+      $("#" + tableAnchor + " thead tr th").each(function (e) {
+        let thId = $(this).attr("id");
+        if (thId !== undefined) {
+          let name = $(this).text();
+          let namespace = $(this).data("namespace");
+          if (namespace) {
+            name = namespace + ": " + name;
+          }
+          $("#table_scatter_col1, #table_scatter_col2").append('<option value="' + thId + '">' + name + "</select>");
         }
       });
-      $("#tableScatter_tid").val($(this).data("table"));
-      $("#tableScatterPlot").html("<small>Please select two table columns.</small>").addClass("not_rendered");
+      table_scatter_table_anchor_el.val(tableAnchor);
+      $("#table_scatter_plot").html("<small>Please select two table columns.</small>").addClass("not_rendered");
     }
   });
-  $("#tableScatterForm select").change(function (e) {
-    let tid = $("#tableScatter_tid").val();
-    let col1 = $("#tableScatter_col1").val().replace("header_", "");
-    let col2 = $("#tableScatter_col2").val().replace("header_", "");
-    let col1_name = $("#tableScatter_col1 option:selected").text();
-    let col2_name = $("#tableScatter_col2 option:selected").text();
-    let col1_max = parseFloat($(tid + " thead th#header_" + col1).data("dmax"));
-    let col1_min = parseFloat($(tid + " thead th#header_" + col1).data("dmin"));
-    let col2_max = parseFloat($(tid + " thead th#header_" + col2).data("dmax"));
-    let col2_min = parseFloat($(tid + " thead th#header_" + col2).data("dmin"));
+  $("#table_scatter_form select").change(function (e) {
+    let tableAnchor = $("#table_scatter_table_anchor").val();
+    let col1 = $("#table_scatter_col1").val().replace("header_", "");
+    let col2 = $("#table_scatter_col2").val().replace("header_", "");
+    let col1_name = $("#table_scatter_col1 option:selected").text();
+    let col2_name = $("#table_scatter_col2 option:selected").text();
+    let col1_max = parseFloat($("#" + tableAnchor + " thead th#header_" + col1).data("dmax"));
+    let col1_min = parseFloat($("#" + tableAnchor + " thead th#header_" + col1).data("dmin"));
+    let col2_max = parseFloat($("#" + tableAnchor + " thead th#header_" + col2).data("dmax"));
+    let col2_min = parseFloat($("#" + tableAnchor + " thead th#header_" + col2).data("dmin"));
     if (isNaN(col1_max)) {
       col1_max = undefined;
     }
@@ -348,30 +354,35 @@ $(function () {
     if (isNaN(col2_min)) {
       col2_min = undefined;
     }
+    let plotDiv = $("#table_scatter_plot");
     if (col1 !== "" && col2 !== "") {
-      $("#tableScatterPlot").html("<small>loading..</small>");
-      if ($(tid).attr("data-title")) {
-        plot_title = $(tid).attr("data-title");
+      plotDiv.html("<small>loading..</small>");
+      let plotTitle;
+      if ($("#" + tableAnchor).data("title")) {
+        plotTitle = $("#" + tableAnchor).data("title");
       } else {
-        plot_title = tid.replace(/^#/, "").replace(/_/g, " ");
+        plotTitle = tableAnchor.replace(/_/g, " ");
       }
       // Get the data values
-      mqc_plots["tableScatterPlot"] = {
-        plot_type: "scatter",
-        config: {
-          id: "tableScatter_" + tid,
-          title: plot_title,
-          xlab: col1_name,
-          ylab: col2_name,
-          xmin: col1_min,
-          xmax: col1_max,
-          ymin: col2_min,
-          ymax: col2_max,
-        },
-        datasets: [[]],
-      };
-      $(tid + " tbody tr").each(function (e) {
-        let s_name = $(this).children("th.rowheader").text();
+      // let plot = {
+      //   plot_type: "scatter",
+      //   config: {
+      //     anchor: "table_scatter_" + tableAnchor,
+      //     title: plotTitle,
+      //     xlab: col1_name,
+      //     ylab: col2_name,
+      //     xmin: col1_min,
+      //     xmax: col1_max,
+      //     ymin: col2_min,
+      //     ymax: col2_max,
+      //   },
+      //   datasets: [[]],
+      //   // activeDatasetIdx: 0,
+      //   // axisControlledBySwitches: [],
+      // };
+      let plotDataset = [];
+      $("#" + tableAnchor + " tbody tr").each(function (e) {
+        let sName = $(this).children("th.rowheader").text();
         let val_1 = $(this)
           .children("td." + col1)
           .text()
@@ -381,16 +392,16 @@ $(function () {
           .text()
           .replace(/[^\d\.]/g, "");
         if (!isNaN(parseFloat(val_1)) && isFinite(val_1) && !isNaN(parseFloat(val_2)) && isFinite(val_2)) {
-          mqc_plots["tableScatterPlot"]["datasets"][0].push({
-            name: s_name,
+          plotDataset.push({
+            name: sName,
             x: parseFloat(val_1),
             y: parseFloat(val_2),
           });
         }
       });
-      if (Object.keys(mqc_plots["tableScatterPlot"]["datasets"][0]).length > 0) {
-        let target = "tableScatterPlot";
-        let traces = mqc_plots["tableScatterPlot"]["datasets"][0].map(function (point) {
+      if (Object.keys(plotDataset).length > 0) {
+        let target = "table_scatter_plot";
+        let traces = plotDataset.map(function (point) {
           return {
             type: "scatter",
             x: [point.x],
@@ -400,7 +411,7 @@ $(function () {
           };
         });
         let layout = {
-          title: plot_title,
+          title: plotTitle,
           xaxis: {
             title: col1_name,
             range: [col1_min, col1_max],
@@ -429,18 +440,18 @@ $(function () {
         };
         let plot = Plotly.newPlot(target, traces, layout, config);
         if (!plot) {
-          $("#tableScatterPlot").html("<small>Error: Something went wrong when plotting the scatter plot.</small>");
-          $("#tableScatterPlot").addClass("not_rendered");
+          plotDiv.html("<small>Error: Something went wrong when plotting the scatter plot.</small>");
+          plotDiv.addClass("not_rendered");
         } else {
-          $("#tableScatterPlot").removeClass("not_rendered");
+          plotDiv.removeClass("not_rendered");
         }
       } else {
-        $("#tableScatterPlot").html("<small>Error: No data pairs found for these columns.</small>");
-        $("#tableScatterPlot").addClass("not_rendered");
+        plotDiv.html("<small>Error: No data pairs found for these columns.</small>");
+        plotDiv.addClass("not_rendered");
       }
     } else {
-      $("#tableScatterPlot").html("<small>Please select two table columns.</small>");
-      $("#tableScatterPlot").addClass("not_rendered");
+      plotDiv.html("<small>Please select two table columns.</small>");
+      plotDiv.addClass("not_rendered");
     }
   });
 });
@@ -451,7 +462,7 @@ $(function () {
 function change_mqc_table_col_order(table) {
   // Find the targets of this sorting
   let elemId = table.attr("id");
-  let tableId = elemId.replace("_configModal_table", "");
+  let tableAnchor = elemId.replace("_config_modal_table", "");
 
   // Collect the desired order of columns
   let classes = [];
@@ -459,7 +470,7 @@ function change_mqc_table_col_order(table) {
     classes.push($(this).attr("class"));
   });
   // Go through each row
-  $("#" + tableId + " tr").each(function () {
+  $("#" + tableAnchor + " tr").each(function () {
     let cols = {};
     let row = $(this);
     // Detach any cell that matches a known class from above

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -497,8 +497,8 @@ $(function () {
     $("#mqc_export_selectplots input").prop("checked", false);
     $('#mqc_export_selectplots input[value="' + id + '"]').prop("checked", true);
     // Special case - Table scatter plots are in a modal, need to close this first
-    if (id === "tableScatterPlot") {
-      $("#tableScatterModal").modal("hide");
+    if (id === "table_scatter_plot") {
+      $("#table_scatter_modal").modal("hide");
     }
     mqc_toolbox_openclose(
       "#mqc_exportplots",

--- a/multiqc/templates/default/foot.html
+++ b/multiqc/templates/default/foot.html
@@ -9,7 +9,7 @@ eg. Modals / other HTML to be hidden out of the way.
 
 
 <!-- Table Scatter Plot Modal -->
-<div class="modal fade" id="tableScatterModal" tabindex="-1" role="dialog">
+<div class="modal fade" id="table_scatter_modal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -17,22 +17,22 @@ eg. Modals / other HTML to be hidden out of the way.
         <h3 class="modal-title">Plot Table Data</h3>
       </div>
       <div class="modal-body">
-        <form id="tableScatterForm">
-          <input type="hidden" id="tableScatter_tid" name="tableScatter_tid" value="" />
+        <form id="table_scatter_form">
+          <input type="hidden" id="table_scatter_table_anchor" name="table_scatter_table_anchor" value="" />
           <div class="row">
             <div class="col-sm-6">
-              <select id="tableScatter_col1" name="tableScatter_col1" class="form-control">
+              <select id="table_scatter_col1" name="table_scatter_col1" class="form-control">
                 <option value="">Select Column</option>
               </select>
             </div>
             <div class="col-sm-6">
-              <select id="tableScatter_col2" name="tableScatter_col2" class="form-control">
+              <select id="table_scatter_col2" name="table_scatter_col2" class="form-control">
                 <option value="">Select Column</option>
               </select>
             </div>
           </div>
           <div class="hc-plot-wrapper">
-            <div id="tableScatterPlot" class="hc-plot not_rendered hc-scatter-plot no-handle" style="width:566px; height: 510px;">
+            <div id="table_scatter_plot" class="hc-plot not_rendered hc-scatter-plot no-handle" style="width:566px; height: 510px;">
               <small>Please select two table columns.</small>
             </div>
           </div>

--- a/multiqc/types.py
+++ b/multiqc/types.py
@@ -1,0 +1,6 @@
+from typing_extensions import NewType
+
+
+AnchorT = NewType("AnchorT", str)
+ModuleIdT = NewType("ModuleIdT", str)
+SectionIdT = NewType("SectionIdT", str)

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -295,9 +295,10 @@ sp:
 
     # Expecting to see only one table, and no bar plot from the _mqc file
     assert len(report.plot_by_id) == 1
-    assert "last_o2o-section-plot" in report.plot_by_id
-    assert report.plot_by_id["last_o2o-section-plot"].id == "last_o2o-section-plot"
-    assert report.plot_by_id["last_o2o-section-plot"].plot_type == "violin"
+    anchor = AnchorT("last_o2o-section-plot")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == "last_o2o"
+    assert report.plot_by_id[anchor].plot_type == "violin"
 
 
 @pytest.mark.parametrize(
@@ -352,7 +353,8 @@ myfile.fasta	chr1	55312	56664	+	GENE""",
     ],
 )
 def test_from_tsv(tmp_path, section_name, is_good, contents):
-    tmp_path.joinpath("mysample_mqc.tsv").write_text(contents)
+    id = "mysample"
+    tmp_path.joinpath(f"{id}_mqc.tsv").write_text(contents)
 
     report.analysis_files = [tmp_path]
     update_config(cfg=ClConfig(run_modules=["custom_content"]))
@@ -365,10 +367,11 @@ def test_from_tsv(tmp_path, section_name, is_good, contents):
 
     custom_module_classes()
     assert len(report.plot_by_id) == 1
-    assert "mysample-section-plot" in report.plot_by_id
-    assert report.plot_by_id["mysample-section-plot"].plot_type == "violin"
-    assert len(report.plot_by_id["mysample-section-plot"].datasets) == 1
-    assert report.plot_by_id["mysample-section-plot"].datasets[0].header_by_metric.keys() == {
+    anchor = AnchorT(f"{id}-section-plot")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].plot_type == "violin"
+    assert len(report.plot_by_id[anchor].datasets) == 1
+    assert report.plot_by_id[anchor].datasets[0].header_by_metric.keys() == {
         "SEQUENCE",
         "START",
         "END",
@@ -376,14 +379,17 @@ def test_from_tsv(tmp_path, section_name, is_good, contents):
         "GENE",
     }
 
-    assert report.plot_by_id["mysample-section-plot"].datasets[0].violin_value_by_sample_by_metric == {
+    assert report.plot_by_id[anchor].datasets[0].violin_value_by_sample_by_metric == {
         "SEQUENCE": {"myfile.fasta": "chr1"},
         "START": {"myfile.fasta": 55312.0},
         "END": {"myfile.fasta": 56664.0},
         "STRAND": {"myfile.fasta": "+"},
         "GENE": {"myfile.fasta": "GENE"},
     }
-    assert report.plot_by_id["mysample-section-plot"].layout.title.text == "My section" if section_name else "mysample"
+    if section_name:
+        assert report.plot_by_id[anchor].layout.title.text == section_name
+    else:
+        assert report.plot_by_id[anchor].layout.title.text == id.title()
 
 
 def test_heatmap_with_numerical_cats(tmp_path):
@@ -410,9 +416,10 @@ def test_heatmap_with_numerical_cats(tmp_path):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{plot_id}-section-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{plot_id}-section-plot"].id == f"{plot_id}-section-plot"
-    assert report.plot_by_id[f"{plot_id}-section-plot"].plot_type == "heatmap"
+    anchor = AnchorT(f"{plot_id}-section-plot")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == plot_id
+    assert report.plot_by_id[anchor].plot_type == "heatmap"
 
 
 def test_on_all_example_files(data_dir):

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -1,15 +1,14 @@
 import tempfile
-from pathlib import Path
 
 import pytest
 
 import multiqc
 from multiqc import report, config
+from multiqc.core.file_search import file_search
 from multiqc.core.update_config import update_config, ClConfig
 from multiqc.modules.custom_content import custom_module_classes
-from multiqc.utils import testing
+from multiqc.types import AnchorT
 from multiqc.validation import ConfigValidationError
-from multiqc.core.file_search import file_search
 
 
 def test_custom_content(tmp_path):
@@ -52,10 +51,11 @@ def test_custom_content(tmp_path):
     report.search_files(["custom_content"])
     custom_module_classes()
 
+    anchor = AnchorT(f"{id}-section-plot")
     assert len(report.plot_by_id) == 1
-    assert f"{id}-section-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
-    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == id
+    assert report.plot_by_id[anchor].plot_type == "xy_line"
 
 
 def test_deprecated_fields(tmp_path, capsys):
@@ -89,9 +89,10 @@ def test_deprecated_fields(tmp_path, capsys):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{id}-section-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
-    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
+    anchor = AnchorT(f"{id}-section-plot")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == id
+    assert report.plot_by_id[anchor].plot_type == "xy_line"
 
     err = str(capsys.readouterr().err)
     assert "Line plot's x_lines or y_lines 'label' field is expected to be a string" in err
@@ -102,7 +103,7 @@ def test_deprecated_fields(tmp_path, capsys):
 
 
 @pytest.mark.parametrize("strict", [True, False])
-def test_wrong_fields(tmp_path, capsys, strict, monkeypatch):
+def test_wrong_fields(tmp_path, caplog, strict, monkeypatch):
     """
     Values of wrong types. Should fail in strict mode, but still produce output in non-strict mode.
     """
@@ -135,28 +136,28 @@ def test_wrong_fields(tmp_path, capsys, strict, monkeypatch):
     else:
         custom_module_classes()
 
-    err = str(capsys.readouterr().err)
-    assert "unrecognized field 'y__lab'" in err
+    assert "unrecognized field 'y__lab'" in caplog.text
     assert (
-        "'xlab': expected type 'Optional[str]', got 'bool' True" in err
-        or "'xlab': expected type 'Union[str, NoneType]', got 'bool' True" in err
+        "'xlab': expected type 'Optional[str]', got 'bool' True" in caplog.text
+        or "'xlab': expected type 'Union[str, NoneType]', got 'bool' True" in caplog.text
     )
-    assert "'ymin': expected type 'Union[float, int, NoneType]', got 'str' '0'" in err
+    assert "'ymin': expected type 'Union[float, int, NoneType]', got 'str' '0'" in caplog.text
 
     if not strict:
         # Still should produce output unless strict mode:
         assert len(report.plot_by_id) == 1
-        assert f"{id}-section-plot" in report.plot_by_id
-        assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
-        assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
-        assert report.plot_by_id[f"{id}-section-plot"].pconfig.title == "DupRadar General Linear Model"
-        assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlog is True
-        assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlab is None  # wrong type
-        assert report.plot_by_id[f"{id}-section-plot"].pconfig.ymax == 100
-        assert report.plot_by_id[f"{id}-section-plot"].pconfig.ymin is None  # wrong type
+        anchor = AnchorT(f"{id}-section-plot")
+        assert anchor in report.plot_by_id
+        assert report.plot_by_id[anchor].id == id
+        assert report.plot_by_id[anchor].plot_type == "xy_line"
+        assert report.plot_by_id[anchor].pconfig.title == "DupRadar General Linear Model"
+        assert report.plot_by_id[anchor].pconfig.xlog is True
+        assert report.plot_by_id[anchor].pconfig.xlab is None  # wrong type
+        assert report.plot_by_id[anchor].pconfig.ymax == 100
+        assert report.plot_by_id[anchor].pconfig.ymin is None  # wrong type
 
 
-def test_missing_id_and_title(tmp_path, capsys):
+def test_missing_id_and_title(tmp_path):
     id = "mysample"
     file = tmp_path / f"{id}_mqc.txt"
     file.write_text(
@@ -174,10 +175,11 @@ def test_missing_id_and_title(tmp_path, capsys):
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert f"{id}-section-plot" in report.plot_by_id
-    assert report.plot_by_id[f"{id}-section-plot"].id == f"{id}-section-plot"
-    assert report.plot_by_id[f"{id}-section-plot"].plot_type == "xy_line"
-    assert report.plot_by_id[f"{id}-section-plot"].pconfig.xlab == "expression"
+    anchor = AnchorT(f"{id}-section-plot")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == id
+    assert report.plot_by_id[anchor].plot_type == "xy_line"
+    assert report.plot_by_id[anchor].pconfig.xlab == "expression"
 
 
 def test_with_separate_config(tmp_path, capsys):
@@ -208,13 +210,14 @@ sp:
     custom_module_classes()
 
     assert len(report.plot_by_id) == 1
-    assert "concordance_heatmap" in report.plot_by_id
-    assert report.plot_by_id["concordance_heatmap"].id == "concordance_heatmap"
-    assert report.plot_by_id["concordance_heatmap"].plot_type == "heatmap"
-    assert len(report.plot_by_id["concordance_heatmap"].datasets) == 1
-    assert report.plot_by_id["concordance_heatmap"].datasets[0].rows == [[1.0, 0.378]]
-    assert report.plot_by_id["concordance_heatmap"].datasets[0].xcats == ["08021342", "08027127"]
-    assert report.plot_by_id["concordance_heatmap"].datasets[0].ycats == ["08021342"]
+    anchor = AnchorT("concordance_heatmap")
+    assert anchor in report.plot_by_id
+    assert report.plot_by_id[anchor].id == anchor
+    assert report.plot_by_id[anchor].plot_type == "heatmap"
+    assert len(report.plot_by_id[anchor].datasets) == 1
+    assert report.plot_by_id[anchor].datasets[0].rows == [[1.0, 0.378]]
+    assert report.plot_by_id[anchor].datasets[0].xcats == ["08021342", "08027127"]
+    assert report.plot_by_id[anchor].datasets[0].ycats == ["08021342"]
 
 
 def test_full_run_with_config(tmp_path, capsys):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -246,7 +246,10 @@ def test_flat_plot(tmp_path, monkeypatch, development, export_plot_formats, expo
     monkeypatch.setattr(tempfile, "mkdtemp", lambda: tmp_path)
 
     plot_id = "test_plot"
-    plot = linegraph.plot({"Sample1": {0: 1, 1: 1}}, {"id": plot_id, "title": "Line Graph"})
+    plot = linegraph.plot(
+        {"Sample1": {0: 1, 1: 1}},
+        {"id": plot_id, "title": "Line Graph"},
+    )
     assert isinstance(plot, Plot)
 
     plot.flat = True
@@ -260,12 +263,12 @@ def test_flat_plot(tmp_path, monkeypatch, development, export_plot_formats, expo
     assert len(report.plot_data) == 0
     assert html is not None
     if not development:
-        assert f'<div class="mqc_mplplot" id="{plot_id}"><img src="data:image/png;base64' in html
+        assert f'<div class="mqc_mplplot" style="" id="{plot_id}"><img src="data:image/png;base64' in html
         if not export_plots:
             for fmt in ["png", "pdf", "svg"]:
                 assert not (tmp_path / f"multiqc_plots/{fmt}/{plot_id}.{fmt}").is_file()
     else:
-        assert f'<div class="mqc_mplplot" id="{plot_id}"><img src="multiqc_plots/png/{plot_id}.png' in html
+        assert f'<div class="mqc_mplplot" style="" id="{plot_id}"><img src="multiqc_plots/png/{plot_id}.png' in html
         assert (tmp_path / f"multiqc_plots/png/{plot_id}.png").is_file()
         assert (tmp_path / f"multiqc_plots/png/{plot_id}.png").stat().st_size > 0
         if not export_plots:


### PR DESCRIPTION
Because in HTML we require element IDs to be unique, we have to somehow work around the custom content situation, where same ID can be used for a plot, a section, and a module:

```yaml
custom_data:
  summary_stats:
    id: "summary_stats"
    section_name: "Summary Stats"
    plot_type: "table"
    anchor: "summary_stats"
    namespace: "summary_stats"
    pconfig:
      id: "summary_stats"
      title: "Summary statistics"
```

Config options such as `report_section_order`, `custom_table_header_config`, `table_columns_placement`, etc rely on those IDs. If we change them in runtime for uniqueness, the configs would break.

Proposing to seperate the concepts of `id`s and `anchor`s. Configs would rely on `id`s primarily, and a section and a plot can share the same `id`. `anchor`, however, will be modified in runtime to stay unique globally.