### PR TITLE
Use `typing.NewType` for all Python versions

### DIFF
--- a/multiqc/types.py
+++ b/multiqc/types.py
@@ -1,11 +1,4 @@
-import sys
-
-# NewType introduced in 3.10.
-# Previous version had typing_extensions.NewType, but it's not pickable.
-if sys.version_info[1] < 10:
-    from typing import NewType
-else:
-    from typing_extensions import NewType
+from typing import NewType
 
 AnchorT = NewType("AnchorT", str)
 ModuleIdT = NewType("ModuleIdT", str)


### PR DESCRIPTION
`typing_extentions.NewType` seems to not work properly, and `typing.NewType` works anyway. Try-catch to fallback just in case.

Address https://github.com/MultiQC/MultiQC/issues/2809