### PR TITLE
Run plot export in threads with a time out and handle freezes

### DIFF
--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -280,7 +280,7 @@ def render_and_export_plots(plots_dir_name: str):
         update_fn=update_fn,
         item_to_str_fn=lambda s: f"{s.module}/{s.name}" if s.name else s.module,
         desc="rendering plots",
-        disable_progress=not show_progress,
+        disable_progress=True,
     )
 
     report.some_plots_are_deferred = any(

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -692,7 +692,7 @@ class Plot(BaseModel, Generic[T]):
 
 # Run in a subprocess to avoid Kaleido freezing entire MultiQC process in a Docker container on MacOS
 # e.g. https://github.com/MultiQC/MultiQC/issues/2667
-def _export_plot_worker(q, fig, file_ext, plot_path, write_kwargs):
+def _export_plot_worker(q: queue.Queue, fig, file_ext, plot_path, write_kwargs):
     try:
         if file_ext == "svg":
             # Cannot add logo to SVGs
@@ -711,7 +711,7 @@ def _export_plot_worker(q, fig, file_ext, plot_path, write_kwargs):
         q.put(plot_path)
 
 
-def _export_plot_to_buffer_worker(q, fig, write_kwargs):
+def _export_plot_to_buffer_worker(q: queue.Queue, fig, write_kwargs):
     try:
         img_buffer = io.BytesIO()
         fig.write_image(img_buffer, **write_kwargs)
@@ -820,7 +820,7 @@ def fig_to_static_html(
 
 def _run_in_thread(func, args, timeout=60) -> Any:
     """Run function in a thread and return its result, assuming it puts the result in a queue."""
-    q = queue.Queue()
+    q: queue.Queue = queue.Queue()
     thread = threading.Thread(target=func, args=(q, *args))
     thread.start()
     thread.join(timeout=timeout)

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -769,7 +769,9 @@ def fig_to_static_html(
             plot_path.parent.mkdir(parents=True, exist_ok=True)
 
             try:
-                logger.info(f"Exporting plot to {file_ext.upper()} image: {file_name}...")
+                logger.info(
+                    f"Running a slow process to export plot to {file_ext.upper()} image: {file_name} (set config.export_plots=False to disable)"
+                )
                 _run_in_thread(_export_plot_worker, (fig, file_ext, plot_path, write_kwargs))
             except Exception as e:
                 msg = f"Unable to export plot to {file_ext.upper()} image: {plot_path.name}"

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -2,9 +2,11 @@ import base64
 import io
 import logging
 import math
+import queue
 import random
 import re
 import string
+import threading
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, cast
@@ -688,6 +690,43 @@ class Plot(BaseModel, Generic[T]):
         return html
 
 
+# Run in a subprocess to avoid Kaleido freezing entire MultiQC process in a Docker container on MacOS
+# e.g. https://github.com/MultiQC/MultiQC/issues/2667
+def _export_plot_worker(q, fig, file_ext, plot_path, write_kwargs):
+    try:
+        if file_ext == "svg":
+            # Cannot add logo to SVGs
+            fig.write_image(plot_path, **write_kwargs)
+        else:
+            img_buffer = io.BytesIO()
+            fig.write_image(img_buffer, **write_kwargs)
+            img_buffer = add_logo(img_buffer, format=file_ext)
+            with open(plot_path, "wb") as f:
+                f.write(img_buffer.getvalue())
+            img_buffer.close()
+    except Exception as e:
+        logger.error(f"Unable to export plot to {file_ext.upper()} image: {e}")
+        q.put(None)
+    else:
+        q.put(plot_path)
+
+
+def _export_plot_to_buffer_worker(q, fig, write_kwargs):
+    try:
+        img_buffer = io.BytesIO()
+        fig.write_image(img_buffer, **write_kwargs)
+        img_buffer = add_logo(img_buffer, format="PNG")
+        # Convert to a base64 encoded string
+        b64_img = base64.b64encode(img_buffer.getvalue()).decode("utf8")
+        img_src = f"data:image/png;base64,{b64_img}"
+        img_buffer.close()
+    except Exception as e:
+        logger.error(f"Unable to export PNG figure to static image: {e}")
+        q.put(None)
+    else:
+        q.put(img_src)
+
+
 def fig_to_static_html(
     fig: go.Figure,
     active: bool = True,
@@ -721,27 +760,21 @@ def fig_to_static_html(
 
     # Save the plot to the data directory if export is requested
     png_is_written = False
+
     if formats:
         if file_name is None:
             raise ValueError("file_name is required for export_plots")
         for file_ext in formats:
+            plot_path = tmp_dir.plots_tmp_dir() / file_ext / f"{file_name}.{file_ext}"
+            plot_path.parent.mkdir(parents=True, exist_ok=True)
+
             try:
-                plot_path = tmp_dir.plots_tmp_dir() / file_ext / f"{file_name}.{file_ext}"
-                plot_path.parent.mkdir(parents=True, exist_ok=True)
-                if file_ext == "svg":
-                    # Cannot add logo to SVGs
-                    fig.write_image(plot_path, **write_kwargs)
-                else:
-                    img_buffer = io.BytesIO()
-                    fig.write_image(img_buffer, **write_kwargs)
-                    img_buffer = add_logo(img_buffer, format=file_ext)
-                    with open(plot_path, "wb") as f:
-                        f.write(img_buffer.getvalue())
-                    img_buffer.close()
+                logger.info(f"Exporting plot to {file_ext.upper()} image: {file_name}...")
+                _run_in_thread(_export_plot_worker, (fig, file_ext, plot_path, write_kwargs))
             except Exception as e:
-                logger.error(
-                    f"Error: Unable to export {file_ext} figure to static image at {plot_path}. Exception: {e}"
-                )
+                msg = f"Unable to export plot to {file_ext.upper()} image: {plot_path.name}"
+                logger.error(f"{msg}. Exception: {e}")
+                raise ValueError(msg)  # Raising to the caller to fall back to interactive plots
             else:
                 if file_ext == "png":
                     png_is_written = True
@@ -755,17 +788,13 @@ def fig_to_static_html(
         # Using file written in the config.export_plots block above
         img_path = Path(plots_dir_name) / "png" / f"{file_name}.png"
         if not png_is_written:  # Could not write in the block above
-            raise ValueError(f"Unable to export plot to PNG plot image: {file_name}")
+            raise ValueError(f"Unable to export plot to PNG image: {file_name}")
         img_src = str(img_path)
     else:
         try:
-            img_buffer = io.BytesIO()
-            fig.write_image(img_buffer, **write_kwargs)
-            img_buffer = add_logo(img_buffer, format="PNG")
-            # Convert to a base64 encoded string
-            b64_img = base64.b64encode(img_buffer.getvalue()).decode("utf8")
-            img_src = f"data:image/png;base64,{b64_img}"
-            img_buffer.close()
+            logger.info("Exporting plot to PNG image" + (": " + file_name if file_name else "") + "...")
+            img_src = _run_in_thread(_export_plot_to_buffer_worker, (fig, write_kwargs))
+
         except Exception as e:
             logger.error(f"Unable to export PNG figure to static image: {e}")
             raise ValueError("Unable to export PNG figure to static image")
@@ -779,6 +808,20 @@ def fig_to_static_html(
             "</div>",
         ]
     )
+
+
+def _run_in_thread(func, args, timeout=10) -> Any:
+    """Run function in a thread and return its result, assuming it puts the result in a queue."""
+    q = queue.Queue()
+    thread = threading.Thread(target=func, args=(q, *args))
+    thread.start()
+    thread.join(timeout=timeout)
+    if thread.is_alive():
+        raise ValueError(f"Error: function did not complete in {timeout} seconds")
+        thread.join()  # Continue without blocking
+        return None
+    else:
+        return q.get()
 
 
 def add_logo(

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -531,7 +531,7 @@ class Plot(BaseModel, Generic[T]):
             try:
                 html = self.flat_plot(plots_dir_name=plots_dir_name)
             except ValueError:
-                logger.error(f"Unable to export plot '{self.id}' to flat images, falling back to interactive plot")
+                logger.error(f"{self.id}: Unable to export plot to flat images, falling back to interactive plot")
                 html = self.interactive_plot()
         else:
             html = self.interactive_plot()
@@ -539,7 +539,7 @@ class Plot(BaseModel, Generic[T]):
                 try:
                     self.flat_plot(embed_in_html=False, plots_dir_name=plots_dir_name)
                 except ValueError:
-                    logger.error(f"Unable to export plot '{self.id}' to flat images")
+                    logger.error(f"{self.id}: Unable to export plot to flat images")
 
         return html
 
@@ -770,12 +770,12 @@ def fig_to_static_html(
 
             try:
                 logger.info(
-                    f"Running a slow process to export plot to {file_ext.upper()} image: {file_name} (set config.export_plots=False to disable)"
+                    f"{file_name}: Running a slow process to export plot to {file_ext.upper()} image (set config.export_plots=False to disable)"
                 )
                 _run_in_thread(_export_plot_worker, (fig, file_ext, plot_path, write_kwargs))
             except Exception as e:
-                msg = f"Unable to export plot to {file_ext.upper()} image: {plot_path.name}"
-                logger.error(f"{msg}. Exception: {e}")
+                msg = f"{file_name}: Unable to export plot to {file_ext.upper()} image"
+                logger.error(f"{msg}. {e}")
                 raise ValueError(msg)  # Raising to the caller to fall back to interactive plots
             else:
                 if file_ext == "png":
@@ -819,7 +819,7 @@ def _run_in_thread(func, args, timeout=10) -> Any:
     thread.start()
     thread.join(timeout=timeout)
     if thread.is_alive():
-        raise ValueError(f"Error: function did not complete in {timeout} seconds")
+        raise ValueError(f"Function did not complete in {timeout} seconds")
         thread.join()  # Continue without blocking
         return None
     else:


### PR DESCRIPTION
Fixes and optionally adds a workaround for https://github.com/MultiQC/MultiQC/issues/2667

Under certain conditions (Docker on MacOS), Kaleido - that Plotly uses for static image export - might freeze the Python process. As a work-around, running it in a thread and cancelling after a timeout, and not trying to export plots any longer in this run.