### PR TITLE
Samtools coverage: suppot `exclude_contigs` and `include_contigs`

### DIFF
--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -1,11 +1,10 @@
 import fnmatch
 import logging
 from collections import defaultdict
-from typing import Dict, Union, Optional, Tuple, List, Mapping
+from typing import Dict, List, Mapping, Optional, Tuple, Union
 
-from multiqc import config, Plot
+from multiqc import Plot, config
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
-
 from multiqc.modules.qualimap.QM_BamQC import coverage_histogram_helptext, genome_fraction_helptext
 from multiqc.plots import bargraph, linegraph
 from multiqc.plots.linegraph import smooth_array
@@ -484,7 +483,7 @@ class MultiqcModule(BaseMultiqcModule):
             cum_fraction_by_cov: Dict[int, float] = dict()
 
             for line in f["f"]:
-                contig, cutoff_reads, bases_fraction = line.split("\t")
+                contig, cutoff_reads, bases_fraction = str(line).split("\t")
                 if bases_fraction == "0.00\n":
                     continue
 

--- a/multiqc/modules/samtools/samtools.py
+++ b/multiqc/modules/samtools/samtools.py
@@ -3,12 +3,12 @@ from typing import Dict
 
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 
-from .stats import parse_samtools_stats
+from .coverage import parse_samtools_coverage
 from .flagstat import parse_samtools_flagstat
 from .idxstats import parse_samtools_idxstats
-from .rmdup import parse_samtools_rmdup
-from .coverage import parse_samtools_coverage
 from .markdup import parse_samtools_markdup
+from .rmdup import parse_samtools_rmdup
+from .stats import parse_samtools_stats
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +52,36 @@ class MultiqcModule(BaseMultiqcModule):
     # names that look like x, y, chrx or chry (case-insensitive search)
     samtools_idxstats_xchr: myXchr
     samtools_idxstats_ychr: myYchr
+    ```
+
+    ### coverage
+
+    You can include and exclude contigs based on name or pattern.
+
+    For example, you could add the following to your MultiQC config file:
+
+
+    ```yaml
+    samtools_coverage:
+      include_contigs:
+        - "chr*"
+      exclude_contigs:
+        - "*_alt"
+        - "*_decoy"
+        - "*_random"
+        - "chrUn*"
+        - "HLA*"
+        - "chrM"
+        - "chrEBV"
+    ```
+
+    Note that exclusion superseeds inclusion for the contig filters.
+
+    If you want to see what is being excluded, you can set `show_excluded_debug_logs` to `True`:
+
+    ```yaml
+    samtools_coverage:
+      show_excluded_debug_logs: True
     ```
     """
 

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -338,7 +338,7 @@ def create(
     x_bands = pconfig.x_bands
     x_lines = pconfig.x_lines
     y_lines = pconfig.y_lines
-    if y_minrange or y_bands or y_lines:
+    if y_bands or y_lines or y_minrange:
         # We don't want the bands to affect the calculated axis range, so we
         # find the min and the max from data points, and manually set the range.
         for dataset in model.datasets:
@@ -364,7 +364,7 @@ def create(
                 maxval = math.log10(maxval) if maxval is not None and maxval > 0 else None
             dataset.layout["yaxis"]["range"] = [minval, maxval]
 
-    if not pconfig.categories and x_minrange or x_bands or x_lines:
+    if x_bands or x_lines or (x_minrange and not pconfig.categories):
         # same as above but for x-axis
         for dataset in model.datasets:
             minval = dataset.layout["xaxis"]["autorangeoptions"]["minallowed"]

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -29,9 +29,9 @@ check_plotly_version()
 
 class PConfig(ValidatedConfig):
     id: str
+    title: str
     anchor: Optional[Anchor] = None  # unlike id, has to be globally unique
     table_title: Optional[str] = Field(None, deprecated="title")
-    title: str
     height: Optional[int] = None
     width: Optional[int] = None
     square: bool = False


### PR DESCRIPTION
Similar to mosdepth, supporting `exclude_contigs` and `include_contigs` options:

```
samtools_coverage:
  exclude_contigs:
    - "chrM"
    - "chr20"
```

Fix https://github.com/MultiQC/MultiQC/issues/2802