### PR TITLE
Allow `x_band`, `x_lines`, `x_minrange` for any plot type (specifically scatter)

### DIFF
--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -189,7 +189,7 @@ def _make_series_dict(
     if pconfig.smooth_points is not None:
         pairs = smooth_array(pairs, pconfig.smooth_points)
 
-    return Series(name=s, pairs=pairs, color=colors.get(s))
+    return Series(name=s, pairs=pairs, color=colors.get(s), _clss=[LinePlotConfig])
 
 
 def smooth_line_data(data_by_sample: DatasetT, numpoints: int) -> DatasetT:

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -42,18 +42,18 @@ class Series(ValidatedConfig, Generic[KeyTV, ValueTV]):
     marker: Optional[Marker] = None
 
     def __init__(self, _clss: Optional[List[Type]] = None, **data):
-        _clss = (_clss or []) + [self.__class__]
+        _clss = _clss or []
         if "dashStyle" in data:
             add_validation_warning(
                 [LinePlotConfig, Series], "'dashStyle' field is deprecated. Please use 'dash' instead"
             )
-            data["dash"] = convert_dash_style(data.pop("dashStyle"), _clss=_clss)
+            data["dash"] = convert_dash_style(data.pop("dashStyle"), _clss=_clss + [self.__class__])
         elif "dash" in data:
-            data["dash"] = convert_dash_style(data["dash"], _clss=_clss)
+            data["dash"] = convert_dash_style(data["dash"], _clss=_clss + [self.__class__])
 
         tuples: List[Tuple[KeyTV, ValueTV]] = []
         if "data" in data:
-            add_validation_warning(_clss, "'data' field is deprecated. Please use 'pairs' instead")
+            add_validation_warning(_clss + [self.__class__], "'data' field is deprecated. Please use 'pairs' instead")
         for p in data.pop("data") if "data" in data else data.get("pairs", []):
             if isinstance(p, list):
                 tuples.append(tuple(p))

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -3,7 +3,7 @@ import logging
 import math
 import os
 import random
-from typing import Any, Dict, Generic, List, Literal, Mapping, Optional, Tuple, TypeVar, Union, Type
+from typing import Any, Dict, Generic, List, Literal, Mapping, Optional, Tuple, Type, TypeVar, Union
 
 import plotly.graph_objects as go  # type: ignore
 from plotly.graph_objs.layout.shape import Label  # type: ignore
@@ -62,16 +62,16 @@ class Series(ValidatedConfig, Generic[KeyTV, ValueTV]):
 
         super().__init__(**data, _parent_class=LinePlotConfig)
 
-    def get_x_range(self) -> Tuple[Optional[KeyTV], Optional[KeyTV]]:
+    def get_x_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         xs = [x[0] for x in self.pairs]
         if len(xs) > 0:
-            return min(xs), max(xs)
+            return min(xs), max(xs)  # type: ignore
         return None, None
 
-    def get_y_range(self) -> Tuple[Optional[ValueTV], Optional[ValueTV]]:
+    def get_y_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         ys = [x[1] for x in self.pairs if x[1] is not None]
         if len(ys) > 0:
-            return min(ys), max(ys)
+            return min(ys), max(ys)  # type: ignore
         return None, None
 
 
@@ -119,28 +119,28 @@ def plot(lists_of_lines: List[List[Series]], pconfig: LinePlotConfig) -> "LinePl
 class Dataset(BaseDataset):
     lines: List[Series]
 
-    def get_x_range(self) -> Tuple[Optional[KeyTV], Optional[KeyTV]]:
+    def get_x_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         if not self.lines:
             return None, None
         xmax, xmin = None, None
         for line in self.lines:
             _xmin, _xmax = line.get_x_range()
             if _xmin is not None:
-                xmin = _xmin if xmin is None else min(xmin, _xmin)
+                xmin = min(xmin, _xmin) if xmin is not None else _xmin  # type: ignore
             if _xmax is not None:
-                xmax = _xmax if xmax is None else max(xmax, _xmax)
+                xmax = max(xmax, _xmax) if xmax is not None else _xmax  # type: ignore
         return xmin, xmax
 
-    def get_y_range(self) -> Tuple[Optional[ValueTV], Optional[ValueTV]]:
+    def get_y_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         if not self.lines:
             return None, None
         ymax, ymin = None, None
         for line in self.lines:
             _ymin, _ymax = line.get_y_range()
             if _ymin is not None:
-                ymin = _ymin if ymin is None else min(ymin, _ymin)
+                ymin = min(ymin, _ymin) if ymin is not None else _ymin  # type: ignore
             if _ymax is not None:
-                ymax = _ymax if ymax is None else max(ymax, _ymax)
+                ymax = max(ymax, _ymax) if ymax is not None else _ymax  # type: ignore
         return ymin, ymax
 
     @staticmethod

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -66,8 +66,8 @@ class LineBand(ValidatedConfig):
     to: Union[float, int]
     color: Optional[str] = None
 
-    def __init__(self, parent_cls: Type = "PConfig", **data):
-        super().__init__(**data, _parent_class=parent_cls)
+    def __init__(self, parent_cls: Optional[Type] = None, **data):
+        super().__init__(**data, _parent_class=parent_cls or PConfig)
 
 
 class PConfig(ValidatedConfig):

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -153,7 +153,7 @@ class PConfig(ValidatedConfig):
             return cls(**pconfig)
 
     def __init__(self, **data):
-        super().__init__(**data)
+        super().__init__(**data, _clss=[self.__class__])
 
         self._actual_cls = self.__class__
 

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -183,26 +183,26 @@ class Dataset(BaseDataset):
         fig.layout.height += len(in_legend) * 5  # extra space for legend
         return fig
 
-    def get_x_range(self) -> Tuple[Optional[ValueT], Optional[ValueT]]:
+    def get_x_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         if not self.points:
             return None, None
         xmax, xmin = None, None
         for point in self.points:
             x = point["x"]
             if x is not None:
-                xmax = x if xmax is None else max(xmax, x)
-                xmin = x if xmin is None else min(xmin, x)
+                xmax = x if xmax is None else max(xmax, x)  # type: ignore
+                xmin = x if xmin is None else min(xmin, x)  # type: ignore
         return xmin, xmax
 
-    def get_y_range(self) -> Tuple[Optional[ValueT], Optional[ValueT]]:
+    def get_y_range(self) -> Tuple[Optional[Any], Optional[Any]]:
         if not self.points:
             return None, None
         ymax, ymin = None, None
         for point in self.points:
             y = point["y"]
             if y is not None:
-                ymax = y if ymax is None else max(ymax, y)
-                ymin = y if ymin is None else min(ymin, y)
+                ymax = y if ymax is None else max(ymax, y)  # type: ignore
+                ymin = y if ymin is None else min(ymin, y)  # type: ignore
         return ymin, ymax
 
     def save_data_file(self) -> None:

--- a/multiqc/validation.py
+++ b/multiqc/validation.py
@@ -37,9 +37,13 @@ def add_validation_warning(cls: Union[type, List[type]], warning: str):
 
 class ValidatedConfig(BaseModel):
     def __init__(self, _clss: Optional[List[Type]] = None, **data):
-        _clss = (_clss or []) + [self.__class__]
         _cls_name = self.__class__.__name__
-        _full_cls_name = ".".join(_c.__name__ for _c in _clss)
+        _classes = []
+        if _clss:
+            for _c in _clss:
+                _classes.append(_c)
+        _classes.append(self.__class__)
+        _full_cls_name = ".".join(_c.__name__ for _c in _classes)
 
         try:
             super().__init__(**data, _clss=_clss)

--- a/multiqc/validation.py
+++ b/multiqc/validation.py
@@ -91,7 +91,7 @@ class ValidatedConfig(BaseModel):
         if not isinstance(values, dict):
             return values
 
-        _clss = values.pop("_clss", [cls])
+        _clss = values.pop("_clss", None) or [cls]
 
         # Remove underscores from field names (used for names matching reserved keywords, e.g. from_)
         for k, v in cls.model_fields.items():


### PR DESCRIPTION
The problem in https://github.com/MultiQC/MultiQC/issues/1953 was fixed with major refactoring, however, same refactoring removed that functionality for scatter plots. Restoring it now, and allowing bands and lines for arbitrary plot types as long as its underlying data has order (i.e. the dataset supports `get_x_range()` or `get_y_range()`).