### PR TITLE
Support Python 3.13, drop 3.8

### DIFF
--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -11,8 +11,9 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out source-code repository
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
+        with:
+          check-latest: true
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -11,10 +11,8 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out source-code repository
 
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  docs_deploy:
     name: "Request deployment"
     runs-on: ubuntu-latest
     if: github.repository == 'MultiQC/MultiQC'

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -5,9 +5,9 @@ on:
     paths: ["docs/**"]
 
 jobs:
-  deploy:
+  docs_preview:
     runs-on: ubuntu-latest
-    if: github.repository == 'MultiQC/MultiQC'
+    if: github.repository == "MultiQC/MultiQC"
     permissions:
       pull-requests: write
 
@@ -19,9 +19,10 @@ jobs:
           path: MultiQC
 
       - uses: actions/setup-python@v5
+        with:
+          check-latest: true
 
-      - name: Install MultiQC
-        run: pip install -e MultiQC
+      - run: pip install -e MultiQC
 
       - name: Download test data
         uses: actions/checkout@v4

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -19,8 +19,6 @@ jobs:
           path: MultiQC
 
       - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
 
       - name: Install MultiQC
         run: pip install -e MultiQC

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   docs_preview:
     runs-on: ubuntu-latest
-    if: github.repository == "MultiQC/MultiQC"
+    if: github.repository == 'MultiQC/MultiQC'
     permissions:
       pull-requests: write
 

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - run: pip install -e MultiQC
 

--- a/.github/workflows/fix_linting.yml
+++ b/.github/workflows/fix_linting.yml
@@ -25,6 +25,8 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
 
       - uses: actions/setup-python@v5
+        with:
+          check-latest: true
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/fix_linting.yml
+++ b/.github/workflows/fix_linting.yml
@@ -26,7 +26,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"] # Oldest and newest supported Python versions
+        python-version: ["3.9", "3.13"] # Oldest and newest supported Python versions
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: "Install MultiQC"
         run: pip install .

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -13,7 +13,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - uses: pre-commit/action@v2.0.3
 
@@ -25,7 +26,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - run: pip install rich
 

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
+        with:
+          check-latest: true
+
       - uses: pre-commit/action@v2.0.3
 
   code_checks:
@@ -19,8 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install dependencies"
-        run: pip install rich
+      - uses: actions/setup-python@v5
+        with:
+          check-latest: true
+
+      - run: pip install rich
 
       - name: "Run manual code style checks"
         run: python ${GITHUB_WORKSPACE}/.github/workflows/code_checks.py

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          check-latest: true
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"] # Oldest and newest supported Python versions
+        python-version: ["3.9", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - run: pip install '.[dev]'
       - run: mypy multiqc

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          check-latest: true
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"] # Oldest and newest supported Python versions
+        python-version: ["3.9", "3.13"] # Oldest and newest supported Python versions
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -11,7 +11,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install MultiQC
         run: pip install .

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -9,8 +9,9 @@ jobs:
       - name: Check out MultiQC code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
+        with:
+          check-latest: true
 
       - name: Install MultiQC
         run: pip install .

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -11,8 +11,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Install MultiQC
         run: pip install .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"] # Oldest and newest supported Python versions
+        python-version: ["3.9", "3.13"]
 
     env:
       # GitHub currently has 4 cores available for Linux runners
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: "Install MultiQC"
         run: pip install -e '.[dev]'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"] # Oldest and newest supported Python versions
+        python-version: ["3.9", "3.13"] # Oldest and newest supported Python versions
 
     env:
       # GitHub currently has 4 cores available for Linux runners

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,10 +26,7 @@ jobs:
       - name: "Visual Studio Command Prompt tool"
         run: cmd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - uses: actions/setup-python@v5
 
       - name: "Cache pip"
         uses: actions/cache@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,8 @@ jobs:
         run: cmd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
 
       - uses: actions/setup-python@v5
+        with:
+          check-latest: true
 
       - name: "Cache pip"
         uses: actions/cache@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          check-latest: true
+          python-version: "3.12"
+          cache: "pip"
 
       - name: "Cache pip"
         uses: actions/cache@v3

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -61,11 +61,11 @@ docker run -t -v `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc .
 MultiQC is written in Python and needs a Python installation to run.
 
 To run MultiQC manually install, you'll typically install it into a local Python environment.
-MultiQC requires Python version 3.8 or above.
+MultiQC requires Python version 3.9 or above.
 
 ### System Python
 
-Python comes installed on most operating systems. You can install MultiQC directly here, but it is _not_ recommended. This often causes problems and it's a little risky to mess with it.
+Python comes installed on most operating systems. You can install MultiQC directly here, but it is _not_ recommended. This often causes problems, and it's a little risky to mess with it.
 
 :::danger
 If you find yourself prepending `sudo` to any MultiQC commands, take a step back and think about Python virtual environments / conda instead.
@@ -74,21 +74,21 @@ If you find yourself prepending `sudo` to any MultiQC commands, take a step back
 ### Python with Conda
 
 To see if you have python installed, run `python --version` on the command line.
-MultiQC needs Python version 3.8+.
+MultiQC needs Python version 3.9+.
 
 We recommend using virtual environments to manage your Python installation.
 Our favourite is _conda_, a cross-platform tool to manage Python environments.
-You can installation instructions for Miniconda
+You can follow installation instructions for Miniconda
 [here](https://docs.conda.io/en/latest/miniconda.html).
 
 Once conda is installed, you can create a Python environment with the following commands:
 
 ```bash
-conda create --name py3.11 python=3.11
-conda activate py3.11
+conda create --name py3.13 python=3.13
+conda activate py3.13
 ```
 
-You'll want to add the `conda activate py3.11` line to your `.bashrc` file,
+You'll want to add the `conda activate py3.13` line to your `.bashrc` file,
 so that the environment is loaded every time you load the terminal.
 
 ### Using a specific python interpreter

--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -9,7 +9,7 @@ Makes the following available under the main multiqc namespace:
 
 import sys
 
-OLDEST_SUPPORTED_PYTHON_VERSION = "3.8"
+OLDEST_SUPPORTED_PYTHON_VERSION = "3.9"
 
 if sys.version_info < tuple(map(int, OLDEST_SUPPORTED_PYTHON_VERSION.split("."))):
     raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "typeguard",
     "tqdm",  # progress bar in notebooks
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Phil Ewels", email = "phil.ewels@seqera.io"},
     {name = "Vlad Savelyev", email = "vladislav.savelyev@seqera.io"},


### PR DESCRIPTION
Will start gradually moving towards using `list`, `dict`, etc in type hints instead of `typing.List`, `typing.Dict`, etc.