### PR TITLE
Disable plot export in incompatible architecture containers (when running through rosetta)

### DIFF
--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -954,10 +954,6 @@ def _export_plot(fig, file_ext, plot_path, write_kwargs) -> Optional[str]:
         return plot_path
 
 
-def _export_plot_worker(q: queue.Queue, fig, file_ext, plot_path, write_kwargs):
-    q.put(_export_plot(fig, file_ext, plot_path, write_kwargs))
-
-
 def _export_plot_to_buffer(fig, write_kwargs) -> Optional[str]:
     try:
         img_buffer = io.BytesIO()
@@ -1054,12 +1050,10 @@ def fig_to_static_html(
             raise ValueError(f"Unable to export plot to PNG image {file_name}")
         img_src = str(img_path)
     else:
-        try:
-            img_src = _export_plot_to_buffer(fig, write_kwargs)
-
-        except Exception as e:
-            logger.error(f"Unable to export PNG figure to static image: {e}")
+        _img_src = _export_plot_to_buffer(fig, write_kwargs)
+        if _img_src is None:
             raise ValueError("Unable to export PNG figure to static image")
+        img_src = _img_src
 
     # Should this plot be hidden on report load?
     style = "" if active else "display:none;"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "importlib_metadata",
     "jinja2>=3.0.0",
     "kaleido",  # for flat plot export
+    # "orca",  # for flat plot export, alternative for kaleido
+    # "psutil",  # for flat plot export with orca
     "markdown",
     "numpy",
     "packaging",


### PR DESCRIPTION
MultiQC's plotting backend Plotly uses Kaleido for static image export, which is not stable when run under an incompatible architecture: specifically, x86 containers hosted by ARM macOS, e.g. the biocontainers image quay.io/biocontainers/multiqc. See:

    https://github.com/MultiQC/MultiQC/issues/2667
    https://github.com/MultiQC/MultiQC/issues/2812
    https://github.com/MultiQC/MultiQC/issues/2867

Since we maintain the official MultiQC image multiqc/multiqc:latest and it's built for multi-platforms, we can recommend using it instead of biocontainers. Under the biocontainers one we can detect that we are running through rosetta by checking `ps`, show a warning message, and disable plot export to avoid MultiQC freezing completely.