### PR TITLE
Suppress "SyntaxWarning: invalid escape sequence" warning from `colormath`

### DIFF
--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -8,6 +8,9 @@ Makes the following available under the main multiqc namespace:
 """
 
 import sys
+import warnings
+
+warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 OLDEST_SUPPORTED_PYTHON_VERSION = "3.9"
 


### PR DESCRIPTION
Suppress "SyntaxWarning: invalid escape sequence" warning from `colormath` that show in the Docker image.