### PR TITLE
Samtools: Add insert size to general stats table

### DIFF
--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -124,7 +124,7 @@ def parse_samtools_stats(module: BaseMultiqcModule):
             "shared_key": "read_count",
         },
         "insert_size_average": {
-            "title": "Mean Insert",
+            "title": "Mean insert",
             "description": "Average insert size",
             "suffix": "bp",
             "format": "{:,.1f}",

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -123,6 +123,14 @@ def parse_samtools_stats(module: BaseMultiqcModule):
             "description": f"Total sequences in the bam file ({config.read_count_desc})",
             "shared_key": "read_count",
         },
+        "insert_size_average": {
+            "title": "Mean Insert",
+            "description": "Average insert size",
+            "suffix": "bp",
+            "format": "{:,.1f}",
+            "scale": "Oranges",
+            "hidden": True,
+        },
     }
     module.general_stats_addcols(samtools_stats, stats_headers, namespace="stats")
 


### PR DESCRIPTION
fix #2897 

This PR adds the average insert size from `samtools stats` output. The field is hidden by default as it may not be useful for everyone. 

![image](https://github.com/user-attachments/assets/92c685de-75fc-49b0-923b-5903921a3477)

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
