### PR TITLE
Show table in notebooks: respect `col1_header`

### DIFF
--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -520,8 +520,11 @@ class ViolinPlot(Plot[Dataset, TableConfig]):
 
             import pandas as pd  # type: ignore
 
-            df = pd.DataFrame(data).T
-            return df  # Jupyter knows how to display dataframes
+            df = pd.DataFrame(data)
+            # Showing the first column header if it's not default
+            if self.pconfig.col1_header != TableConfig.model_fields["col1_header"].default:
+                df.index.name = self.pconfig.col1_header
+            return df.T  # Jupyter knows how to display dataframes
 
         else:
             return super().show(dataset_id, flat, **kwargs)


### PR DESCRIPTION
Address https://community.seqera.io/t/why-do-the-structures-seem-to-differ-between-the-multiqc-report-and-usage-in-a-notebook/1255/7