### PR TITLE
Custom content fixes

### DIFF
--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -207,7 +207,7 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                     s_name = m_config.get("sample_name")
                 else:
                     c_id = config_custom_data_id
-                    m_config = ccdict_by_id.setdefault(c_id, CcDict()).config
+                    m_config = (ccdict_by_id.get(c_id) or CcDict()).config
 
                 # Guess sample name if not given
                 if s_name is None:
@@ -356,6 +356,8 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
     mod_order = getattr(config, "custom_content", {}).get("order", [])
     # after each element, also add a version with a "-module" next to it for back-compat with < 1.24
     mod_order = [x for x in mod_order for x in [x, re.sub("-module$", "", x), f"{x}-module"]]
+    # remove duplicates, but keep order
+    mod_order = list(dict.fromkeys(mod_order))
     modules__not_in_order: List[BaseMultiqcModule] = [
         parsed_mod for parsed_mod in parsed_modules.values() if parsed_mod.anchor not in mod_order
     ]


### PR DESCRIPTION
1. Address the issue of custom content sections without search patterns and headers in files (fix https://github.com/MultiQC/MultiQC/issues/2916)
2. As an additional fix, fix duplicated cc sections in the report.