### PR TITLE
Fix Docker CI for forks: skip login step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,12 +35,14 @@ jobs:
 
       - name: "Log in to Docker Hub"
         uses: docker/login-action@v2
+        if: github.ref == 'refs/heads/main'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Login to GitHub Container Registry"
         uses: docker/login-action@v2
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The Docker CI step currently fails for fork PRs because it attempts to log in to dockerhub, even though it doesn't need that (it pushes only on merges to `main` and on releases). Fixing.