### PR TITLE
bcl2fastq: fix missing `R1_*`/`R2_*` metrics

### DIFF
--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -319,9 +319,9 @@ class MultiqcModule(BaseMultiqcModule):
                     # Undetermined samples did not have R1 and R2 information
                     for r_num in range(1, 5):
                         try:
-                            s[f"R{r}_yield"] += sample[f"R{r_num}_yield"]
-                            s[f"R{r}_Q30"] += sample[f"R{r_num}_Q30"]
-                            s[f"R{r}_trimmed_bases"] += sample[f"R{r_num}_trimmed_bases"]
+                            s[f"R{r_num}_yield"] += sample[f"R{r_num}_yield"]
+                            s[f"R{r_num}_Q30"] += sample[f"R{r_num}_Q30"]
+                            s[f"R{r_num}_trimmed_bases"] += sample[f"R{r_num}_trimmed_bases"]
                         except KeyError:
                             pass
                     try:
@@ -345,7 +345,7 @@ class MultiqcModule(BaseMultiqcModule):
                     for r_num in range(1, 5):
                         try:
                             if (
-                                not self.bcl2fastq_bysample[sample_id][f"R{r}_yield"]
+                                not self.bcl2fastq_bysample[sample_id][f"R{r_num}_yield"]
                                 and not self.bcl2fastq_bysample[sample_id][f"R{r_num}_Q30"]
                                 and not self.bcl2fastq_bysample[sample_id][f"R{r_num}_trimmed_bases"]
                             ):

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -282,8 +282,8 @@ class MultiqcModule(BaseMultiqcModule):
                     sample["mean_qscore"] = "NA"
 
     def split_data_by_lane_and_sample(self):
-        for run_id, r in self.bcl2fastq_data.items():
-            for lane_id, lane in r.items():
+        for run_id, run_dict in self.bcl2fastq_data.items():
+            for lane_id, lane in run_dict.items():
                 uniqLaneName = self.prepend_runid(run_id, lane_id)
                 self.bcl2fastq_bylane[uniqLaneName] = {
                     "total": lane["total"],

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -207,10 +207,10 @@ class MultiqcModule(BaseMultiqcModule):
                 }
                 # simplify the population of dictionaries
                 lsample = run_data[lane]["samples"][sample]
-                for r in range(1, 5):
-                    lsample[f"R{r}_yield"] = 0
-                    lsample[f"R{r}_Q30"] = 0
-                    lsample[f"R{r}_trimmed_bases"] = 0
+                for r_num in range(1, 5):
+                    lsample[f"R{r_num}_yield"] = 0
+                    lsample[f"R{r_num}_Q30"] = 0
+                    lsample[f"R{r_num}_trimmed_bases"] = 0
                 rlane["total"] += demuxResult["NumberReads"]
                 rlane["total_yield"] += demuxResult["Yield"]
                 lsample["total"] += demuxResult["NumberReads"]
@@ -219,20 +219,24 @@ class MultiqcModule(BaseMultiqcModule):
                     rlane["perfectIndex"] += indexMetric["MismatchCounts"]["0"]
                     lsample["perfectIndex"] += indexMetric["MismatchCounts"]["0"]
                 for readMetric in demuxResult.get("ReadMetrics", []):
-                    r = readMetric["ReadNumber"]
+                    r_num = readMetric["ReadNumber"]
                     rlane["yieldQ30"] += readMetric["YieldQ30"]
                     rlane["qscore_sum"] += readMetric["QualityScoreSum"]
                     lsample["yieldQ30"] += readMetric["YieldQ30"]
                     lsample["qscore_sum"] += readMetric["QualityScoreSum"]
-                    lsample[f"R{r}_yield"] += readMetric["Yield"]
-                    lsample[f"R{r}_Q30"] += readMetric["YieldQ30"]
-                    lsample[f"R{r}_trimmed_bases"] += readMetric["TrimmedBases"]
+                    lsample[f"R{r_num}_yield"] += readMetric["Yield"]
+                    lsample[f"R{r_num}_Q30"] += readMetric["YieldQ30"]
+                    lsample[f"R{r_num}_trimmed_bases"] += readMetric["TrimmedBases"]
                 # Remove unpopulated read keys
-                for r in range(1, 5):
-                    if not lsample[f"R{r}_yield"] and not lsample[f"R{r}_Q30"] and not lsample[f"R{r}_trimmed_bases"]:
-                        lsample.pop(f"R{r}_yield")
-                        lsample.pop(f"R{r}_Q30")
-                        lsample.pop(f"R{r}_trimmed_bases")
+                for r_num in range(1, 5):
+                    if (
+                        not lsample[f"R{r_num}_yield"]
+                        and not lsample[f"R{r_num}_Q30"]
+                        and not lsample[f"R{r_num}_trimmed_bases"]
+                    ):
+                        lsample.pop(f"R{r_num}_yield")
+                        lsample.pop(f"R{r_num}_Q30")
+                        lsample.pop(f"R{r_num}_trimmed_bases")
             undeterminedYieldQ30 = 0
             undeterminedQscoreSum = 0
             undeterminedTrimmedBases = 0
@@ -359,14 +363,14 @@ class MultiqcModule(BaseMultiqcModule):
         data: Dict[str, Dict[str, ValueT]] = dict()
         for sample_id, sample in self.bcl2fastq_bysample.items():
             percent_R_Q30 = dict()
-            for r in range(1, 5):
+            for r_num in range(1, 5):
                 # Zero division is possible
                 try:
-                    percent_R_Q30[r] = "{0:.1f}".format(
-                        float(100.0 * sample["R{}_Q30".format(r)] / sample["R{}_yield".format(r)])
+                    percent_R_Q30[r_num] = "{0:.1f}".format(
+                        float(100.0 * sample[f"R{r_num}_Q30"] / sample[f"R{r_num}_yield"])
                     )
                 except ZeroDivisionError:
-                    percent_R_Q30[r] = "0.0"
+                    percent_R_Q30[r_num] = "0.0"
                 except KeyError:
                     pass
             try:
@@ -379,10 +383,10 @@ class MultiqcModule(BaseMultiqcModule):
                 "total": sample["total"],
                 "perfectPercent": perfect_percent,
             }
-            for r in range(1, 5):
+            for r_num in range(1, 5):
                 try:
-                    data[sample_id][f"percent_R{r}_Q30"] = percent_R_Q30[r]
-                    data[sample_id][f"R{r}_trimmed_bases"] = sample[f"R{r}_trimmed_bases"]
+                    data[sample_id][f"percent_R{r_num}_Q30"] = percent_R_Q30[r_num]
+                    data[sample_id][f"R{r_num}_trimmed_bases"] = sample[f"R{r_num}_trimmed_bases"]
                 except KeyError:
                     pass
 
@@ -402,10 +406,10 @@ class MultiqcModule(BaseMultiqcModule):
             },
         }
         # If no data for a column, header will be automatically ignored
-        for r in range(1, 5):
-            headers[f"percent_R{r}_Q30"] = {
-                "title": f"R{r} yield ≥ Q30",
-                "description": f"Percent of bases in R{r} with a Phred score of 30 or higher",
+        for r_num in range(1, 5):
+            headers[f"percent_R{r_num}_Q30"] = {
+                "title": f"R{r_num} yield ≥ Q30",
+                "description": f"Percent of bases in R{r_num} with a Phred score of 30 or higher",
                 "scale": "RdYlGn",
                 "max": 100,
                 "min": 0,
@@ -420,17 +424,17 @@ class MultiqcModule(BaseMultiqcModule):
             "suffix": "%",
         }
         # If no data for a column, header will be automatically ignored
-        for r in range(1, 5):
+        for r_num in range(1, 5):
             hide_col = True
             for sname in data:
                 try:
-                    if data[sname][f"R{r}_trimmed_bases"] > 0:
+                    if data[sname][f"R{r_num}_trimmed_bases"] > 0:
                         hide_col = False
                 except KeyError:
                     pass
             try:
-                headers[f"R{r}_trimmed_bases"] = {
-                    "title": f"{config.base_count_prefix} R{r} trimmed",
+                headers[f"R{r_num}_trimmed_bases"] = {
+                    "title": f"{config.base_count_prefix} R{r_num} trimmed",
                     "description": f"Number of bases trimmed ({config.base_count_desc})",
                     "scale": "RdYlBu",
                     "modify": lambda x: x * 0.000001,


### PR DESCRIPTION
Fixes critical bug [https://github.com/MultiQC/MultiQC/issues/2964](https://github.com/MultiQC/MultiQC/issues/2964).

