### PR TITLE
bclconvert: fix undetermined barcodes plot

### DIFF
--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -238,7 +238,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         self._clusters_by_sample_barplot(data_by_sample)
 
-        TOP_N_UNDETERMINED_BARCODES = 20
+        TOP_N_UNDETERMINED_BARCODES = 40
 
         # Add section with undetermined barcodes
         if len(data_by_run) == 1:
@@ -257,6 +257,7 @@ class MultiqcModule(BaseMultiqcModule):
                             "ylab": "Count",
                             "use_legend": True,
                             "tt_suffix": "reads",
+                            "sort_samples": False,
                         },
                     ),
                 )


### PR DESCRIPTION
* Fix: sort by sum across all lanes before slicing top barcodes - fixes https://github.com/MultiQC/MultiQC/issues/2975
* Improvement: show in order from most abundant to least
* Show top 40 instead of 20
* Display the number of selected barcodes in plot description

