### PR TITLE
Bugfix: Make the search pattern for DeDup more specific

### DIFF
--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -244,7 +244,9 @@ cutadapt:
 damageprofiler:
   fn: "*dmgprof.json"
 dedup:
-  fn: "*dedup.json"
+  - fn: "*dedup.json"
+    contents: '"tool_name": "DeDup"'
+    num_lines: 10
 deeptools/bamPEFragmentSizeTable:
   contents: "	Frag. Sampled	Frag. Len. Min.	Frag. Len. 1st. Qu.	Frag. Len. Mean	Frag. Len. Median	Frag. Len. 3rd Qu."
   num_lines: 1


### PR DESCRIPTION
Add file content requirement to the search pattern for the DeDup module. This fixes https://github.com/MultiQC/MultiQC/issues/2979, which caused the DeDup module to sometimes capture log files from other tools.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)