### PR TITLE
Fix docker build: remove docs from `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,4 @@ demo
 # Other things
 .idea
 .vscode
-docs
 test-data


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2992