### PR TITLE
Naturally sort bar graph samples

### DIFF
--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 from importlib_metadata import EntryPoint
+from natsort import natsorted
 
 from multiqc import config
 from multiqc.core.exceptions import RunError
@@ -135,7 +136,7 @@ def plot(
             # want to keep the sample order https://github.com/MultiQC/MultiQC/issues/2204
             pass
         elif pconf.sort_samples:
-            hc_samples = sorted([SampleName(s) for s in d.keys()])
+            hc_samples = natsorted([SampleName(s) for s in d.keys()])
         hc_data: List[CatDataDict] = list()
         sample_d_count: Dict[SampleName, int] = dict()
         for cat_idx, c in enumerate(categories_per_ds[ds_idx].keys()):


### PR DESCRIPTION
Naturally sort bar graph samples when `sort_samples=True`

Before:

<img width="629" alt="Screenshot 2024-12-05 at 01 12 32" src="https://github.com/user-attachments/assets/541c80e0-46e4-4f90-8326-a61b777ce606">

After:

<img width="610" alt="Screenshot 2024-12-05 at 01 12 13" src="https://github.com/user-attachments/assets/dbec33c7-2856-40b2-b46f-7068799cae5f">
