### PR TITLE
Custom content: allow quoting values in CSV

### DIFF
--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -715,16 +715,17 @@ def _parse_txt(
     strings_in_first_row = 0
     for i, sections in enumerate(matrix):
         for j, v in enumerate(sections):
-            try:
-                v = float(v)
-            except ValueError:
-                pass
+            # Count strings in first row (header?)
             if isinstance(v, str):
-                if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
-                    v = v[1:-1]
-                # Count strings in first row (header?)
-                if i == 0:
-                    strings_in_first_row += 1
+                if v.startswith('"') and v.endswith('"') or v.startswith("'") and v.endswith("'"):
+                    pass  # do not parse quoted strings
+                else:
+                    try:
+                        v = float(v)
+                    except ValueError:
+                        pass
+            if i == 0 and isinstance(v, str):
+                strings_in_first_row += 1
             matrix[i][j] = v
 
     all_numeric = all(isinstance(v, (float, int)) for s in matrix[1:] for v in s[1:])

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -537,7 +537,12 @@ def _process_and_format_value(val: ValueT, column: ColumnMeta) -> Tuple[ValueT, 
             val = column.modify(val)
         except Exception as e:  # User-provided modify function can raise any exception
             logger.error(f"Error modifying table value '{column.rid}': '{val}'. {e}")
-    # section.raw_data[s_name][col_key] = val
+
+    # Values can be quoted to avoid parsing as a number, so need to remove those quotes
+    if isinstance(val, str) and (
+        val.startswith('"') and val.endswith('"') or val.startswith("'") and val.endswith("'")
+    ):
+        val = val[1:-1]
 
     # Now also calculate formatted values
     valstr = str(val)


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/3019

So the last column stays a string and not a number in the table:

```
# section_name: "Family Metadata"
# description: "Family metadata table containing family ids and sizes along with representative sequences, ids and lengths."
# format: "csv"
# plot_type: "table"
Sample Name,Family Id,Size,Representative Length,Representative Id
mgnifams_test_5,mgnifams_test_5,39,129,"1446399400_1_131/2-130"
mgnifams_test_4,mgnifams_test_4,25,117,"782510898_278_395"
mgnifams_test_1,mgnifams_test_1,18,108,"1622851798_832_939"
mgnifams_test_2,mgnifams_test_2,34,127,"1546033206_1_127"
mgnifams_test_6,mgnifams_test_6,18,103,"4529851305_271_377"
```