### PR TITLE
phantompeakqualtools: Adjust minimum value to 1 for NSC coeff

### DIFF
--- a/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
+++ b/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
@@ -75,7 +75,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "title": "NSC",
                 "description": "Normalized strand cross-correlation",
                 "max": 10,
-                "min": 0,
+                "min": 1,
                 "format": "{:,.2f}",
                 "scale": "RdYlGn-rev",
             },


### PR DESCRIPTION
Normalized strand cross-correlation has a minimum value of 1

see: https://hbctraining.github.io/In-depth-NGS-Data-Analysis-Course/sessionV/lessons/CC_metrics_extra.html


<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
