### PR TITLE
Tweak organisaion of CLI flags in help

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -70,6 +70,7 @@ click.rich_click.OPTION_GROUPS = {
             "options": [
                 "--module",
                 "--exclude",
+                "--require-logs",
             ],
         },
         {
@@ -105,6 +106,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--data-format",
                 "--zip-data-dir",
                 "--no-report",
+                "--clean-up",
                 "--pdf",
             ],
         },
@@ -113,9 +115,9 @@ click.rich_click.OPTION_GROUPS = {
             "options": [
                 "--verbose",
                 "--quiet",
+                "--no-version-check",
                 "--strict",
                 "--development",
-                "--require-logs",
                 "--profile-runtime",
                 "--profile-memory",
                 "--no-megaqc-upload",
@@ -476,7 +478,12 @@ class RunResult:
         self.message = message
 
 
-def run(*analysis_dir, clean_up: bool = True, cfg: Optional[ClConfig] = None, interactive: bool = True) -> RunResult:
+def run(
+    *analysis_dir,
+    clean_up: bool = True,
+    cfg: Optional[ClConfig] = None,
+    interactive: bool = True,
+) -> RunResult:
     """
     MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
 
@@ -569,7 +576,10 @@ def run(*analysis_dir, clean_up: bool = True, cfg: Optional[ClConfig] = None, in
             logger.error(f"{len(report.lint_errors)} linting errors:\n" + "\n".join(report.lint_errors))
             sys_exit_code = 1
 
-        logger.info("MultiQC complete") if sys_exit_code == 0 else logger.error("MultiQC complete with errors")
+        if sys_exit_code == 0:
+            logger.info("MultiQC complete")
+        else:
+            logger.error("MultiQC complete with errors")
         return RunResult(sys_exit_code=sys_exit_code)
 
     finally:


### PR DESCRIPTION
Noticed that there were a couple of CLI flags that didn't have rich-click config. Moved them into sections. Also moved a couple of out the bottom "miscellaneous" category.