### PR TITLE
Heatmap: add clustering view

### DIFF
--- a/multiqc/modules/deeptools/plotCorrelation.py
+++ b/multiqc/modules/deeptools/plotCorrelation.py
@@ -36,10 +36,9 @@ class plotCorrelationMixin:
             config = {
                 "id": "deeptools_correlation_plot",
                 "title": "deeptools: Correlation Plot",
-                # "show_dendrogram": True,
-                # "dendrogram_method": "complete",
                 "cluster_rows": True,
                 "cluster_cols": True,
+                "cluster_switch_clustered_active": True,
             }
             samples = sorted(self.deeptools_plotCorrelationData.keys())
             rows = []

--- a/multiqc/modules/deeptools/plotCorrelation.py
+++ b/multiqc/modules/deeptools/plotCorrelation.py
@@ -36,6 +36,10 @@ class plotCorrelationMixin:
             config = {
                 "id": "deeptools_correlation_plot",
                 "title": "deeptools: Correlation Plot",
+                # "show_dendrogram": True,
+                # "dendrogram_method": "complete",
+                "cluster_rows": True,
+                "cluster_cols": True,
             }
             samples = sorted(self.deeptools_plotCorrelationData.keys())
             rows = []

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -931,7 +931,7 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
         Add buttons: percentage on/off, log scale on/off, datasets switch panel
         """
         buttons = "\n".join(self.buttons(flat=flat))
-        html = f"<div class='row'>\n<div class='col-xs-12'>\n{buttons}\n</div>\n</div>\n\n"
+        html = f"<div class='row' style='align-items: center;'>\n<div class='col-xs-12'>\n{buttons}\n</div>\n</div>\n\n"
         return html
 
 

--- a/multiqc/templates/default/assets/js/plots/heatmap.js
+++ b/multiqc/templates/default/assets/js/plots/heatmap.js
@@ -6,6 +6,7 @@ class HeatmapPlot extends Plot {
     this.square = dump["square"];
     this.filtXCatsSettings = [];
     this.filtYCatsSettings = [];
+    this.clustered = false;
   }
 
   activeDatasetSize() {
@@ -18,9 +19,9 @@ class HeatmapPlot extends Plot {
   prepData() {
     // Prepare data to either build Plotly traces or export as a file
     let dataset = this.datasets[this.activeDatasetIdx];
-    let rows = dataset["rows"];
-    let xcats = dataset["xcats"];
-    let ycats = dataset["ycats"];
+    let rows = this.clustered && dataset["rows_clustered"] ? dataset["rows_clustered"] : dataset["rows"];
+    let xcats = this.clustered && dataset["xcats_clustered"] ? dataset["xcats_clustered"] : dataset["xcats"];
+    let ycats = this.clustered && dataset["ycats_clustered"] ? dataset["ycats_clustered"] : dataset["ycats"];
 
     if (this.xCatsAreSamples) {
       let xcatsSettings = applyToolboxSettings(xcats);
@@ -107,5 +108,20 @@ $(function () {
     $("#" + anchor + "_range_slider_" + minmax + ", #" + anchor + "_range_slider_" + minmax + "_txt").val(
       $(this).val(),
     );
+  });
+
+  // Listener for clustering toggle
+  $('button[data-action="unclustered"], button[data-action="clustered"]').on("click", function (e) {
+    e.preventDefault();
+    let $btn = $(this);
+    let plotAnchor = $(this).data("plot-anchor");
+    let plot = mqc_plots[plotAnchor];
+
+    // Toggle buttons
+    $btn.addClass("active").siblings().removeClass("active");
+
+    // Update plot
+    plot.clustered = $btn.data("action") === "clustered";
+    renderPlot(plotAnchor); // re-render
   });
 });

--- a/multiqc/templates/default/assets/js/plots/heatmap.js
+++ b/multiqc/templates/default/assets/js/plots/heatmap.js
@@ -6,7 +6,7 @@ class HeatmapPlot extends Plot {
     this.square = dump["square"];
     this.filtXCatsSettings = [];
     this.filtYCatsSettings = [];
-    this.clustered = false;
+    this.clusterSwitchClusteredActive = dump["cluster_switch_clustered_active"];
   }
 
   activeDatasetSize() {
@@ -19,9 +19,12 @@ class HeatmapPlot extends Plot {
   prepData() {
     // Prepare data to either build Plotly traces or export as a file
     let dataset = this.datasets[this.activeDatasetIdx];
-    let rows = this.clustered && dataset["rows_clustered"] ? dataset["rows_clustered"] : dataset["rows"];
-    let xcats = this.clustered && dataset["xcats_clustered"] ? dataset["xcats_clustered"] : dataset["xcats"];
-    let ycats = this.clustered && dataset["ycats_clustered"] ? dataset["ycats_clustered"] : dataset["ycats"];
+    let rows =
+      this.clusterSwitchClusteredActive && dataset["rows_clustered"] ? dataset["rows_clustered"] : dataset["rows"];
+    let xcats =
+      this.clusterSwitchClusteredActive && dataset["xcats_clustered"] ? dataset["xcats_clustered"] : dataset["xcats"];
+    let ycats =
+      this.clusterSwitchClusteredActive && dataset["ycats_clustered"] ? dataset["ycats_clustered"] : dataset["ycats"];
 
     if (this.xCatsAreSamples) {
       let xcatsSettings = applyToolboxSettings(xcats);
@@ -118,10 +121,10 @@ $(function () {
     let plot = mqc_plots[plotAnchor];
 
     // Toggle buttons
-    $btn.addClass("active").siblings().removeClass("active");
+    $btn.toggleClass("active").siblings().toggleClass("active");
 
     // Update plot
-    plot.clustered = $btn.data("action") === "clustered";
+    plot.clusterSwitchClusteredActive = $btn.data("action") === "clustered";
     renderPlot(plotAnchor); // re-render
   });
 });


### PR DESCRIPTION
Add clustered view for the heatmap. On by default.

```py
plot=heatmap.plot(rows, samples, samples, {
    "id": "deeptools_correlation_plot",
    "title": "deeptools: Correlation Plot",
    "cluster_rows": True,
    "cluster_cols": True,
    "cluster_switch_clustered_active": True,
}),
```

<img width="720" alt="Screenshot 2024-12-29 at 23 47 22" src="https://github.com/user-attachments/assets/68ec43f6-f152-459a-86b7-82e2e0f05be9" />

