### PR TITLE
Preseq: fix parsing `nan` and add strict type hints

### DIFF
--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -196,7 +196,6 @@ class MultiqcModule(BaseMultiqcModule):
             tt_label="<b>" + y_tt_lbl + "</b>: " + x_tt_lbl,
             xsuffix=x_suffix,
             ysuffix=y_suffix,
-            extra_series=[],
         )
         if not is_basepairs:
             pconfig.title += " (molecule count)"

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -203,8 +203,6 @@ class Dataset(BaseDataset, Generic[KeyT, ValT]):
         for series in self.lines:
             xs = [x[0] for x in series.pairs]
             ys = [x[1] for x in series.pairs]
-            if series.dash:
-                print(series)
             params: Dict[str, Any] = {
                 "showlegend": series.showlegend,
                 "line": {


### PR DESCRIPTION
Fix preseq parsing files with `nan` (reported at https://github.com/MultiQC/MultiQC/issues/3037). (note to self: be careful in the future with `x = float(s)` as it wouldn't raise on `"nan"` or `"inf"` strings - gotta to add an extra check `not np.isfinite(x)`.

Add type hints into the module.