### PR TITLE
Make tables Configure Column max columns configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # MultiQC results
 multiqc_config.yaml
-*multiqc_report.html
-multiqc_data/
-multiqc_plots/
+*multiqc_report*.html
+multiqc_data*/
+multiqc_plots*/
 *multiqc_report_data/
 *multiqc_report_plots/
 

--- a/docs/markdown/development/plots.md
+++ b/docs/markdown/development/plots.md
@@ -712,6 +712,11 @@ in ascending order, then by "Starting Amount (ng)", in descending (default) orde
 table with the ID `quast_table` (which you can find by clicking the "Configure Columns"
 button above the table in the report) will be sorted by "Largest contig".
 
+### Configurable columns
+
+Table columns can be reodered and change visibility using the "Configure Columns" button
+in the report. However, for very wide tables, the performance degrades, so the button is disabled when the number of rows exceeds `config.max_configurable_table_columns` (default is 100). You can adjust this value in the config file.
+
 ## Violin plots
 
 Violin plots work from the exact same data structure as tables, so the

--- a/docs/markdown/development/plots.md
+++ b/docs/markdown/development/plots.md
@@ -715,7 +715,7 @@ button above the table in the report) will be sorted by "Largest contig".
 ### Configurable columns
 
 Table columns can be reodered and change visibility using the "Configure Columns" button
-in the report. However, for very wide tables, the performance degrades, so the button is disabled when the number of rows exceeds `config.max_configurable_table_columns` (default is 100). You can adjust this value in the config file.
+in the report. However, for very wide tables, the performance degrades, so the button is disabled when the number of rows exceeds `config.max_configurable_table_columns` (default is 200). You can adjust this value in the config file.
 
 ## Violin plots
 

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -126,6 +126,7 @@ violin_min_threshold_no_points: int
 
 collapse_tables: bool
 max_table_rows: int
+max_configurable_table_columns: int
 table_columns_visible: Dict[str, Union[bool, Dict[str, bool]]]
 table_columns_placement: Dict[str, Dict[str, float]]
 table_columns_name: Dict[str, Union[str, Dict[str, str]]]

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -76,6 +76,7 @@ violin_min_threshold_no_points: 1000 # for more than this number of samples, sho
 
 collapse_tables: true
 max_table_rows: 500
+max_configurable_table_columns: 100
 table_columns_visible: {}
 table_columns_placement: {}
 table_columns_name: {}

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -76,7 +76,7 @@ violin_min_threshold_no_points: 1000 # for more than this number of samples, sho
 
 collapse_tables: true
 max_table_rows: 500
-max_configurable_table_columns: 100
+max_configurable_table_columns: 200
 table_columns_visible: {}
 table_columns_placement: {}
 table_columns_name: {}

--- a/multiqc/plots/plotly/table.py
+++ b/multiqc/plots/plotly/table.py
@@ -1,12 +1,12 @@
 import logging
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+from natsort import natsorted
 
 from multiqc import config, report
 from multiqc.plots.table_object import ColumnAnchor, DataTable, SampleGroup, SampleName, ValueT
 from multiqc.utils import mqc_colour
-from typing import TYPE_CHECKING
-from natsort import natsorted
 
 if TYPE_CHECKING:  # to avoid circular import
     from multiqc.plots.plotly.violin import ViolinPlot
@@ -359,13 +359,13 @@ def make_table(
         )
 
         # "Showing x of y columns" text
-        row_visibilities = [
+        not_empty_rows_bool_vector = [
             all(group_to_sample_to_anchor_to_empty[s_name].values()) for s_name in group_to_sample_to_anchor_to_empty
         ]
-        visible_rows = [x for x in row_visibilities if not x]
+        n_visible_rows = len([x for x in not_empty_rows_bool_vector if x is True])
 
         # Visible rows
-        t_showing_rows_txt = f'Showing <sup id="{dt.anchor}_numrows" class="mqc_table_numrows">{len(visible_rows)}</sup>/<sub>{len(group_to_sample_to_anchor_to_td)}</sub> rows'
+        t_showing_rows_txt = f'Showing <sup id="{dt.anchor}_numrows" class="mqc_table_numrows">{n_visible_rows}</sup>/<sub>{len(group_to_sample_to_anchor_to_td)}</sub> rows'
 
         # How many columns are visible?
         ncols_vis = (len(col_to_th) + 1) - hidden_cols
@@ -568,4 +568,4 @@ def _get_sortlist(dt: DataTable) -> str:
 
 
 def _is_configure_columns_disabled(num_columns: int) -> bool:
-    return num_columns > 50
+    return num_columns > config.max_configurable_table_columns


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/3042

* Make it configurable the number of columns before "Configure Columns" is hidden. Default is `config.max_configurable_table_columns = 100` (bumped from 50).
* Fix the number of visible rows indicator.