### PR TITLE
Custom content: Support `.gif`, `.webp` and `.tiff`

### DIFF
--- a/docs/markdown/custom_content/index.md
+++ b/docs/markdown/custom_content/index.md
@@ -39,12 +39,13 @@ general release.
 
 ## Images
 
-As of MultiQC v1.7, you can import custom images into your MultiQC reports.
-Simply add `_mqc` to the end of the filename for `.png`, `.jpg` or `.jpeg` files, for example:
+It is possible to import custom images into your MultiQC reports.
+Simply add `_mqc` to the end of the filename for `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` or `.tiff` files, for example:
 `my_image_file_mqc.png` or `summmary_diagram.jpeg`.
 
 Images will be embedded within the HTML file, so will be self contained.
 Note that this means that it's very possible to make the HTML file very very large if abused!
+Images are base64 encoded in the HTML and the report will often be larger than the binary source images.
 
 The report section name and description will be automatically based on the filename.
 

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -141,17 +141,22 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                     break
                 assert parsed_dict is not None
                 parsed_dict["id"] = parsed_dict.get("id", f["s_name"])
-            elif f_extension == ".png" or f_extension == ".jpeg" or f_extension == ".jpg":
+            elif f_extension in [".png", ".jpeg", ".jpg", ".gif", ".webp", ".tiff"]:
                 # image is an exception - will return a file handler
                 image_string = base64.b64encode(cast(BufferedReader, f["f"]).read()).decode("utf-8")
-                image_format = "png" if f_extension == ".png" else "jpg"
+                image_format = "jpg" if f_extension in [".jpeg", ".jpg"] else f_extension[1:]
                 img_html = '<div class="mqc-custom-content-image"><img src="data:image/{};base64,{}" /></div>'.format(
                     image_format, image_string
                 )
                 parsed_dict = {
                     "id": f["s_name"],
                     "plot_type": "image",
-                    "section_name": f["s_name"].replace("_", " ").replace("-", " ").replace(".", " "),
+                    "section_name": f["s_name"]
+                    .rstrip(f_extension)
+                    .rstrip("_mqc")
+                    .replace("_", " ")
+                    .replace("-", " ")
+                    .replace(".", " "),
                     "data": img_html,
                 }
                 # If the search pattern 'k' has an associated custom content section config, use it:

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -615,7 +615,7 @@ def run_search_files(spatterns: List[Dict[ModuleId, List[SearchPattern]]], searc
             return False
 
         # Use mimetypes to exclude binary files where possible
-        if not re.match(r".+_mqc\.(png|jpg|jpeg)", search_f.filename) and config.ignore_images:
+        if not re.match(r".+_mqc\.(png|jpg|jpeg|gif|webp|tiff)", search_f.filename) and config.ignore_images:
             (ftype, encoding) = mimetypes.guess_type(str(path))
             if encoding is not None and encoding != "gzip":
                 return False

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -229,7 +229,7 @@ checkqc:
   contents: "instrument_and_reagent_type"
   fn: "*.json"
 custom_content:
-  fn_re: '.+_mqc\.(yaml|yml|json|txt|csv|tsv|log|out|png|jpg|jpeg|html)'
+  fn_re: '.+_mqc\.(yaml|yml|json|txt|csv|tsv|log|out|png|jpg|jpeg|gif|webp|tiff|html)'
 clipandmerge:
   contents: "ClipAndMerge ("
   num_lines: 5


### PR DESCRIPTION
As requested in https://community.seqera.io/t/including-gif-images-in-multiqc-report/1640

It's very likely that `.tiff` files could be huge and will break reports / crash browsers. But as this is Custom Content it's a bit the wild-west already, so it's up to end users to handle this responsibly. At least MultiQC won't arbitrarily crash during report generation after this PR.