### PR TITLE
Use `tiktoken` to estimate token counts for all providers

### DIFF
--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -14,8 +14,6 @@ from multiqc import config, report
 from multiqc.core.log_and_rich import run_with_spinner
 from multiqc.types import Anchor
 
-import tiktoken
-
 if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import BaseChatModel  # type: ignore
     from langchain_core.messages import BaseMessage  # type: ignore
@@ -197,6 +195,8 @@ class Client:
         but better than nothing. Anthropic's tokenizer is only available through API and counts towards the API quota :'(
         """
         try:
+            import tiktoken
+
             model = self.model if self.name == "openai" else "gpt-4o"
             encoding = tiktoken.encoding_for_model(model)
             return len(encoding.encode(text))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "tqdm",               # progress bar in notebooks
     "python-dotenv",
     "natsort",
+    "tiktoken",
 ]
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
* Use `tiktoken` to estimate token counts for all providers (with a fallback)
* Add `tiktoken` as a dependency
* Print error only once