### PR TITLE
Config from env: resolve empty to Null

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -423,6 +423,8 @@ def _env_vars_config() -> Dict:
     PREFIX = "MULTIQC_"  # Prefix for environment variables
     env_config: Dict[str, Union[str, int, float, bool]] = {}
     for k, v in os.environ.items():
+        if v.strip() == "":
+            continue
         if k.startswith(PREFIX) and k not in RESERVED_NAMES:
             conf_key = k[len(PREFIX) :].lower()
             if conf_key not in globals():


### PR DESCRIPTION
Empty env vars will be ignored instead of showing a warning (e.g. `export MULTIQC_AI_SUMMARY=` would keep `config.ai_summary` default).