### PR TITLE
Anonymize sample names

### DIFF
--- a/docs/markdown/ai/index.md
+++ b/docs/markdown/ai/index.md
@@ -301,6 +301,31 @@ Seqera AI does not use inputs for subsequent fine-tuning or direct model improve
 You can find our more information about Seqera's pledge for privacy at
 [https://seqera.io/ai-trust/](https://seqera.io/ai-trust/)
 
+### Sample anonymization
+
+MultiQC provides an option to anonymize sample names when generating AI summaries, both during report generation and in the browser. This helps protect sensitive information when sharing summaries with AI providers.
+
+When enabled, sample names are replaced with generic pseudonyms (e.g., "SAMPLE_1", "SAMPLE_2") before being sent to the AI provider. The mapping between original names and pseudonyms is:
+
+- Stored only in your browser's local storage for in-browser summaries
+- Not saved in the report HTML
+- Used to convert pseudonyms back to real sample names in the AI response
+
+To enable sample anonymization:
+
+- For in-browser summaries: Toggle "Anonymize samples" in the AI toolbox
+- For report generation: Set `anonymize_samples: true` in your MultiQC config
+
+The anonymization is applied consistently across the entire report - each sample name gets the same pseudonym wherever it appears. When the AI response references samples, the pseudonyms are automatically converted back to the original sample names before displaying.
+
+:::tip
+Sample anonymization is particularly useful when:
+
+- Working with clinical samples
+- Sample names contain sensitive metadata
+- Institutional policies require data anonymization
+  :::
+
 [^seqera-ai-usage-limits]:
     Seqera Cloud Basic is free for small teams.
     It includes access to Seqera AI, with a usage cap of 100 messages per calendar month.

--- a/docs/markdown/ai/index.md
+++ b/docs/markdown/ai/index.md
@@ -305,26 +305,29 @@ You can find our more information about Seqera's pledge for privacy at
 
 MultiQC provides an option to anonymize sample names when generating AI summaries, both during report generation and in the browser. This helps protect sensitive information when sharing summaries with AI providers.
 
-When enabled, sample names are replaced with generic pseudonyms (e.g., "SAMPLE_1", "SAMPLE_2") before being sent to the AI provider. The mapping between original names and pseudonyms is:
-
-- Stored only in your browser's local storage for in-browser summaries
-- Not saved in the report HTML
-- Used to convert pseudonyms back to real sample names in the AI response
-
 To enable sample anonymization:
 
-- For in-browser summaries: Toggle "Anonymize samples" in the AI toolbox
+- For in-browser summaries: Toggle "Anonymize samples" in the AI toolbox section
 - For report generation: Set `anonymize_samples: true` in your MultiQC config
 
-The anonymization is applied consistently across the entire report - each sample name gets the same pseudonym wherever it appears. When the AI response references samples, the pseudonyms are automatically converted back to the original sample names before displaying.
+When enabled, sample names are replaced with generic pseudonyms (e.g., "SAMPLE_1", "SAMPLE_2") before being sent to the AI provider. The anonymization is applied consistently across the entire report - each sample name gets the same pseudonym wherever it appears. When the AI response references samples, the pseudonyms are automatically converted back to the original sample names before displaying.
 
-:::tip
-Sample anonymization is particularly useful when:
+MulitQC replaces sample names that appear as typical keys in plots and tables, specifically:
 
-- Working with clinical samples
-- Sample names contain sensitive metadata
-- Institutional policies require data anonymization
-  :::
+- First column of a table table (e.g. the General statistics table)
+- Labels of bars in bar plots
+- Line names in line plots
+- Data point labels in scatter plots
+- Heatmap axis labels
+- Violin plot data point names
+
+But note that if a module creates some custom plot configuration where sample names are used elsewhere, anonymization would not be guaranteed.
+
+:::info
+
+Note that with the "Continue chat" button you would see the anonymized samples, which makes it less useful.
+
+:::
 
 [^seqera-ai-usage-limits]:
     Seqera Cloud Basic is free for small teams.

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -698,13 +698,16 @@ class BaseMultiqcModule:
 
         search_pattern_key: the search pattern key that this file matched
         """
-        return self._clean_s_name(
+        cleaned_name = self._clean_s_name(
             s_name=s_name,
             f=f,
             root=root or f["root"],
             filename=filename or f["fn"],
             search_pattern_key=f["sp_key"],
         )
+        # Add to the list of all used sample names in the report, to support anonymization for AI requests
+        report.sample_names.append(SampleName(cleaned_name))
+        return cleaned_name
 
     def _clean_s_name(
         self,

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -119,6 +119,7 @@ ai_summary_full: bool
 ai_provider: str
 ai_model: str
 no_ai: bool
+ai_anonymize_samples: bool
 
 seqera_api_url: str
 seqera_website: str

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -68,6 +68,7 @@ ai_summary_full: false
 ai_provider: "seqera"
 ai_model: null
 no_ai: false
+ai_anonymize_samples: false
 
 # Development settings:
 seqera_api_url: "https://intern.seqera.io"

--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -562,14 +562,14 @@ def ai_section_metadata() -> AiReportMetadata:
     )
 
 
-def create_pseudonym_map(sample_names: List[SampleName]) -> Dict[SampleName, str]:
+def create_pseudonym_map(sample_names: List[SampleName]) -> Dict[str, str]:
     """
     Find all sample names in the report and replace them with anonymised names
     """
     # Create anonymised names map and reverse map
     ai_pseudonym_map = {}
     for i, name in enumerate(sample_names):
-        ai_pseudonym_map[name] = f"SAMPLE_{i + 1}"
+        ai_pseudonym_map[str(name)] = f"SAMPLE_{i + 1}"
     return ai_pseudonym_map
 
 

--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -679,9 +679,17 @@ MultiQC General Statistics (overview of key QC metrics for each sample, across a
             sec_context += f"Section help text: {_strip_html(section.helptext)}\n"
 
         if section.content_before_plot:
-            sec_context += section.content_before_plot + "\n\n"
+            content = section.content_before_plot
+            if config.ai_anonymize_samples:
+                for name, pseudonym in report.ai_pseudonym_map.items():
+                    content = content.replace(name, pseudonym)
+            sec_context += content + "\n\n"
         if section.content:
-            sec_context += section.content + "\n\n"
+            content = section.content
+            if config.ai_anonymize_samples:
+                for name, pseudonym in report.ai_pseudonym_map.items():
+                    content = content.replace(name, pseudonym)
+            sec_context += content + "\n\n"
 
         if section.plot_anchor and section.plot_anchor in report.plot_by_id:
             plot = report.plot_by_id[section.plot_anchor]
@@ -731,8 +739,7 @@ def add_ai_summary_to_report():
 
     prompt, exceeded_context_window = build_prompt(client, metadata)
 
-    if config.development or config.verbose:
-        _save_prompt_to_file(prompt)
+    _save_prompt_to_file(prompt)
 
     if exceeded_context_window:
         return

--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -134,20 +134,20 @@ class MultiqcModule(BaseMultiqcModule):
                     except ValueError:
                         log.warning(f"Could not find sample name in Peddy output: {f['fn']}")
                         return None
-            else:
-                s_name = "-".join([s[idx] for idx in s_name_idx])
-                s_name = self.clean_s_name(s_name, f)
-                parsed_data[s_name] = dict()
-                for i, v in enumerate(s):
-                    if i not in s_name_idx:
-                        if headers[i] == "error" and pattern == "sex_check":
-                            v = "True" if v == "False" else "False"
-                        try:
-                            # add the pattern as a suffix to key
-                            parsed_data[s_name][headers[i] + "_" + pattern] = float(v)
-                        except ValueError:
-                            # add the pattern as a suffix to key
-                            parsed_data[s_name][headers[i] + "_" + pattern] = v
+                continue
+            assert s_name_idx is not None
+            s_name = "-".join([self.clean_s_name(s[idx], f) for idx in s_name_idx])
+            parsed_data[s_name] = dict()
+            for i, v in enumerate(s):
+                if i not in s_name_idx:
+                    if headers[i] == "error" and pattern == "sex_check":
+                        v = "True" if v == "False" else "False"
+                    try:
+                        # add the pattern as a suffix to key
+                        parsed_data[s_name][headers[i] + "_" + pattern] = float(v)
+                    except ValueError:
+                        # add the pattern as a suffix to key
+                        parsed_data[s_name][headers[i] + "_" + pattern] = v
         if len(parsed_data) == 0:
             return None
         return parsed_data

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -58,10 +58,13 @@ def plot(
     else:
         pconf.data_labels = []
 
+    sample_names = []
+
     datasets: List[List[Series[KeyT, ValT]]] = []
     for ds_idx, raw_data_by_sample in enumerate(raw_dataset_list):
         list_of_series: List[Series[Any, Any]] = []
         for s in sorted(raw_data_by_sample.keys()):
+            sample_names.append(SampleName(s))
             x_to_y = raw_data_by_sample[s]
             if not isinstance(x_to_y, dict) and isinstance(x_to_y, Sequence):
                 if isinstance(x_to_y[0], tuple):
@@ -129,7 +132,7 @@ def plot(
                 # debugging of modules
                 raise
 
-    return line.plot(datasets, pconf)
+    return line.plot(datasets, pconf, sample_names)
 
 
 def _make_series_dict(

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -203,7 +203,7 @@ class BarPlot(Plot[Dataset, BarPlotConfig]):
     datasets: List[Dataset]
 
     def samples_names(self) -> List[SampleName]:
-        names = []
+        names: List[SampleName] = []
         for ds in self.datasets:
             names.extend(SampleName(sample) for sample in ds.samples)
         return names

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -183,8 +183,7 @@ class Dataset(BaseDataset):
                 suffix += " " + self.layout["xaxis"]["ticksuffix"]
 
         for sidx, sample in enumerate(self.samples):
-            # Use pseudonym if available, otherwise use original sample name
-            presudonym = report.ai_pseudonym_map.get(SampleName(sample), sample)
+            presudonym = report.anonymize_sample_name(sample)
             prompt += (
                 f"| {presudonym} | "
                 + " | ".join(

--- a/multiqc/plots/plotly/bar.py
+++ b/multiqc/plots/plotly/bar.py
@@ -20,7 +20,6 @@ from multiqc.plots.plotly.plot import (
     split_long_string,
 )
 from multiqc.types import SampleName
-from multiqc.validation import ValidatedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -184,8 +183,10 @@ class Dataset(BaseDataset):
                 suffix += " " + self.layout["xaxis"]["ticksuffix"]
 
         for sidx, sample in enumerate(self.samples):
+            # Use pseudonym if available, otherwise use original sample name
+            presudonym = report.ai_pseudonym_map.get(SampleName(sample), sample)
             prompt += (
-                f"| {sample} | "
+                f"| {presudonym} | "
                 + " | ".join(
                     self.fmt_value_for_llm(
                         (cat.data if not pconfig.cpswitch or pconfig.cpswitch_c_active else cat.data_pct)[sidx]
@@ -200,6 +201,12 @@ class Dataset(BaseDataset):
 
 class BarPlot(Plot[Dataset, BarPlotConfig]):
     datasets: List[Dataset]
+
+    def samples_names(self) -> List[SampleName]:
+        names = []
+        for ds in self.datasets:
+            names.extend(SampleName(sample) for sample in ds.samples)
+        return names
 
     @staticmethod
     def create(

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -7,6 +7,7 @@ import plotly.graph_objects as go  # type: ignore
 from multiqc.plots.plotly import determine_barplot_height
 from multiqc.plots.plotly.plot import PlotType, BaseDataset, Plot, PConfig
 from multiqc import report
+from multiqc.types import SampleName
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,12 @@ class Dataset(BaseDataset):
 
 class BoxPlot(Plot[Dataset, BoxPlotConfig]):
     datasets: List[Dataset]
+
+    def samples_names(self) -> List[SampleName]:
+        names = []
+        for ds in self.datasets:
+            names.extend(SampleName(sample) for sample in ds.samples)
+        return names
 
     @staticmethod
     def create(

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -116,7 +116,7 @@ class Dataset(BaseDataset):
                 continue
 
             # Use pseudonym if available, otherwise use original sample name
-            pseudonym = report.ai_pseudonym_map.get(SampleName(sample), sample)
+            pseudonym = report.anonymize_sample_name(sample)
 
             # Calculate statistics
             sorted_vals = sorted(values)

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -4,9 +4,9 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import plotly.graph_objects as go  # type: ignore
 
-from multiqc.plots.plotly import determine_barplot_height
-from multiqc.plots.plotly.plot import PlotType, BaseDataset, Plot, PConfig
 from multiqc import report
+from multiqc.plots.plotly import determine_barplot_height
+from multiqc.plots.plotly.plot import BaseDataset, PConfig, Plot, PlotType
 from multiqc.types import SampleName
 
 logger = logging.getLogger(__name__)
@@ -100,6 +100,45 @@ class Dataset(BaseDataset):
         for sample, values in zip(self.samples, self.data):
             vals_by_sample[sample] = values
         report.write_data_file(vals_by_sample, self.uid)
+
+    def format_dataset_for_ai_prompt(self, pconfig: PConfig, keep_hidden: bool = True) -> str:
+        """Format dataset as a markdown table with basic statistics"""
+        prompt = "| Sample | Min | Q1 | Median | Q3 | Max | Mean |\n"
+        prompt += "| --- | --- | --- | --- | --- | --- | --- |\n"
+
+        suffix = ""
+        if self.layout["xaxis"]["ticksuffix"]:
+            suffix = " " + self.layout["xaxis"]["ticksuffix"]
+
+        for sample, values in zip(self.samples, self.data):
+            # Skip samples with no data
+            if len(values) == 0:
+                continue
+
+            # Use pseudonym if available, otherwise use original sample name
+            pseudonym = report.ai_pseudonym_map.get(SampleName(sample), sample)
+
+            # Calculate statistics
+            sorted_vals = sorted(values)
+            n = len(sorted_vals)
+
+            min_val = sorted_vals[0]
+            max_val = sorted_vals[-1]
+            median = sorted_vals[n // 2] if n % 2 == 1 else (sorted_vals[n // 2 - 1] + sorted_vals[n // 2]) / 2
+            q1 = sorted_vals[n // 4] if n >= 4 else sorted_vals[0]
+            q3 = sorted_vals[3 * n // 4] if n >= 4 else sorted_vals[-1]
+            mean = sum(values) / len(values)
+
+            prompt += (
+                f"| {pseudonym} | "
+                f"{self.fmt_value_for_llm(min_val)}{suffix} | "
+                f"{self.fmt_value_for_llm(q1)}{suffix} | "
+                f"{self.fmt_value_for_llm(median)}{suffix} | "
+                f"{self.fmt_value_for_llm(q3)}{suffix} | "
+                f"{self.fmt_value_for_llm(max_val)}{suffix} | "
+                f"{self.fmt_value_for_llm(mean)}{suffix} |\n"
+            )
+        return prompt
 
 
 class BoxPlot(Plot[Dataset, BoxPlotConfig]):

--- a/multiqc/plots/plotly/box.py
+++ b/multiqc/plots/plotly/box.py
@@ -145,7 +145,7 @@ class BoxPlot(Plot[Dataset, BoxPlotConfig]):
     datasets: List[Dataset]
 
     def samples_names(self) -> List[SampleName]:
-        names = []
+        names: List[SampleName] = []
         for ds in self.datasets:
             names.extend(SampleName(sample) for sample in ds.samples)
         return names

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -14,7 +14,7 @@ from multiqc.plots.plotly.plot import (
     PlotType,
     split_long_string,
 )
-from multiqc.types import Anchor
+from multiqc.types import Anchor, SampleName
 from multiqc.utils.util_functions import scipy_pdist, scipy_hierarchy_linkage, scipy_hierarchy_leaves_list
 
 logger = logging.getLogger(__name__)
@@ -227,6 +227,18 @@ class HeatmapPlot(Plot[Dataset, HeatmapConfig]):
     min: Optional[float] = None
     max: Optional[float] = None
     cluster_switch_clustered_active: bool = False
+
+    def samples_names(self) -> List[SampleName]:
+        names = []
+        if self.xcats_samples:
+            for ds in self.datasets:
+                if ds.xcats:
+                    names.extend(SampleName(cat) for cat in ds.xcats)
+        if self.ycats_samples:
+            for ds in self.datasets:
+                if ds.ycats:
+                    names.extend(SampleName(cat) for cat in ds.ycats)
+        return names
 
     @staticmethod
     def create(

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -242,7 +242,7 @@ class HeatmapPlot(Plot[Dataset, HeatmapConfig]):
     cluster_switch_clustered_active: bool = False
 
     def samples_names(self) -> List[SampleName]:
-        names = []
+        names: List[SampleName] = []
         if self.xcats_samples:
             for ds in self.datasets:
                 if ds.xcats:

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -217,17 +217,16 @@ class Dataset(BaseDataset):
                     prompt += " Sample "
             xcats = self.xcats
             if pconfig.xcats_samples:
-                xcats = [report.ai_pseudonym_map.get(SampleName(cat), cat) for cat in xcats]
+                xcats = [report.anonymize_sample_name(cat) for cat in xcats]
             prompt += "| " + " | ".join(xcats) + " |\n"
             if self.ycats:
                 prompt += "| --- "
             prompt += "| " + " | ".join("---" for _ in self.xcats) + " |\n"
         for i, row in enumerate(self.rows):
             if self.ycats:
-                # Use pseudonym if available, otherwise use original sample name
                 ycat = self.ycats[i]
                 if pconfig.ycats_samples:
-                    ycat = report.ai_pseudonym_map.get(SampleName(ycat), ycat)
+                    ycat = report.anonymize_sample_name(ycat)
                     prompt += "| " + ycat + " "
             prompt += "| " + " | ".join(str(x) for x in row) + " |\n"
         return prompt

--- a/multiqc/plots/plotly/heatmap.py
+++ b/multiqc/plots/plotly/heatmap.py
@@ -1,10 +1,10 @@
 import json
 import logging
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union, Any, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
 
+import numpy as np
 import plotly.graph_objects as go  # type: ignore
 from pydantic import Field
-import numpy as np
 
 from multiqc import report
 from multiqc.plots.plotly.plot import (
@@ -15,7 +15,7 @@ from multiqc.plots.plotly.plot import (
     split_long_string,
 )
 from multiqc.types import Anchor, SampleName
-from multiqc.utils.util_functions import scipy_pdist, scipy_hierarchy_linkage, scipy_hierarchy_leaves_list
+from multiqc.utils.util_functions import scipy_hierarchy_leaves_list, scipy_hierarchy_linkage, scipy_pdist
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,8 @@ class Dataset(BaseDataset):
     ycats: Optional[Sequence[str]]
     xcats_clustered: Optional[Sequence[str]] = None
     ycats_clustered: Optional[Sequence[str]] = None
+    xcats_samples: bool = True
+    ycats_samples: bool = True
 
     @staticmethod
     def create(
@@ -116,6 +118,8 @@ class Dataset(BaseDataset):
         cluster_rows: bool = True,
         cluster_cols: bool = True,
         cluster_method: str = "complete",
+        xcats_samples: bool = True,
+        ycats_samples: bool = True,
     ) -> "Dataset":
         data: List[List[ElemT]]
         if isinstance(rows, dict):
@@ -160,6 +164,8 @@ class Dataset(BaseDataset):
             ycats=[str(y) for y in ycats] if ycats else None,
             xcats_clustered=[str(x) for x in xcats_clustered] if xcats_clustered else None,
             ycats_clustered=[str(y) for y in ycats_clustered] if ycats_clustered else None,
+            xcats_samples=xcats_samples,
+            ycats_samples=ycats_samples,
         )
         return dataset
 
@@ -209,13 +215,20 @@ class Dataset(BaseDataset):
                 prompt = "|"
                 if pconfig.ycats_samples:
                     prompt += " Sample "
-            prompt += "| " + " | ".join(self.xcats) + " |\n"
+            xcats = self.xcats
+            if pconfig.xcats_samples:
+                xcats = [report.ai_pseudonym_map.get(SampleName(cat), cat) for cat in xcats]
+            prompt += "| " + " | ".join(xcats) + " |\n"
             if self.ycats:
                 prompt += "| --- "
             prompt += "| " + " | ".join("---" for _ in self.xcats) + " |\n"
         for i, row in enumerate(self.rows):
             if self.ycats:
-                prompt += "| " + self.ycats[i] + " "
+                # Use pseudonym if available, otherwise use original sample name
+                ycat = self.ycats[i]
+                if pconfig.ycats_samples:
+                    ycat = report.ai_pseudonym_map.get(SampleName(ycat), ycat)
+                    prompt += "| " + ycat + " "
             prompt += "| " + " | ".join(str(x) for x in row) + " |\n"
         return prompt
 
@@ -301,6 +314,8 @@ class HeatmapPlot(Plot[Dataset, HeatmapConfig]):
                 cluster_rows=pconfig.cluster_rows,
                 cluster_cols=pconfig.cluster_cols,
                 cluster_method=pconfig.cluster_method,
+                xcats_samples=xcats_samples,
+                ycats_samples=ycats_samples,
             )
         ]
 

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -335,7 +335,7 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
         # Make a tooltip always show on hover over any point on plot
         model.layout.hoverdistance = -1
 
-        return LinePlot(**model.__dict__, samples_names=sample_names)
+        return LinePlot(**model.__dict__, sample_names=sample_names)
 
 
 def remove_nones_and_empty_dicts(d: Mapping[Any, Any]) -> Dict[Any, Any]:

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -280,12 +280,10 @@ class Dataset(BaseDataset, Generic[KeyT, ValT]):
         ysuffix = self.layout.get("yaxis", {}).get("ticksuffix")
 
         # Use pseudonyms for sample names if available
-        pseudonyms = [report.ai_pseudonym_map.get(SampleName(series.name), series.name) for series in self.lines]
+        pseudonyms = [report.anonymize_sample_name(series.name) for series in self.lines]
         result = "Samples: " + ", ".join(pseudonyms) + "\n\n"
 
-        for series in self.lines:
-            # Use pseudonym if available, otherwise use original sample name
-            pseudonym = report.ai_pseudonym_map.get(SampleName(series.name), series.name)
+        for pseudonym, series in zip(pseudonyms, self.lines):
             pairs = [
                 f"({self.fmt_value_for_llm(x[0])}{xsuffix}: {self.fmt_value_for_llm(x[1])}{ysuffix})"
                 for x in series.pairs

--- a/multiqc/plots/plotly/line.py
+++ b/multiqc/plots/plotly/line.py
@@ -108,7 +108,9 @@ class LinePlotConfig(PConfig):
         super().__init__(path_in_cfg=path_in_cfg or ("lineplot",), **data)
 
 
-def plot(lists_of_lines: List[List[Series[KeyT, ValT]]], pconfig: LinePlotConfig) -> "LinePlot[KeyT, ValT]":
+def plot(
+    lists_of_lines: List[List[Series[KeyT, ValT]]], pconfig: LinePlotConfig, sample_names: List[SampleName]
+) -> "LinePlot[KeyT, ValT]":
     """
     Build and add the plot data to the report, return an HTML wrapper.
     :param lists_of_lines: each dataset is a 2D dict, first keys as sample names, then x:y data pairs
@@ -122,7 +124,7 @@ def plot(lists_of_lines: List[List[Series[KeyT, ValT]]], pconfig: LinePlotConfig
     # Create a violin of median values in each sample, showing dots for outliers
     # Clicking on a dot of a violin will show the line plot for that sample
 
-    return LinePlot.create(pconfig, lists_of_lines)
+    return LinePlot.create(pconfig, lists_of_lines, sample_names)
 
 
 class Dataset(BaseDataset, Generic[KeyT, ValT]):
@@ -277,18 +279,27 @@ class Dataset(BaseDataset, Generic[KeyT, ValT]):
         xsuffix = self.layout.get("xaxis", {}).get("ticksuffix")
         ysuffix = self.layout.get("yaxis", {}).get("ticksuffix")
 
-        result = "Samples: " + ", ".join(series.name for series in self.lines) + "\n\n"
+        # Use pseudonyms for sample names if available
+        pseudonyms = [report.ai_pseudonym_map.get(SampleName(series.name), series.name) for series in self.lines]
+        result = "Samples: " + ", ".join(pseudonyms) + "\n\n"
+
         for series in self.lines:
+            # Use pseudonym if available, otherwise use original sample name
+            pseudonym = report.ai_pseudonym_map.get(SampleName(series.name), series.name)
             pairs = [
                 f"({self.fmt_value_for_llm(x[0])}{xsuffix}: {self.fmt_value_for_llm(x[1])}{ysuffix})"
                 for x in series.pairs
             ]
-            result += f"{series.name} {', '.join(pairs)}\n\n"
+            result += f"{pseudonym} {', '.join(pairs)}\n\n"
         return result
 
 
 class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
     datasets: List[Dataset[KeyT, ValT]]
+    sample_names: List[SampleName]
+
+    def samples_names(self) -> List[SampleName]:
+        return self.sample_names
 
     def _plot_ai_header(self) -> str:
         result = super()._plot_ai_header()
@@ -302,6 +313,7 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
     def create(
         pconfig: LinePlotConfig,
         lists_of_lines: List[List[Series[KeyT, ValT]]],
+        sample_names: List[SampleName],
     ) -> "LinePlot[KeyT, ValT]":
         n_samples_per_dataset = [len(x) for x in lists_of_lines]
 
@@ -323,7 +335,7 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
         # Make a tooltip always show on hover over any point on plot
         model.layout.hoverdistance = -1
 
-        return LinePlot(**model.__dict__)
+        return LinePlot(**model.__dict__, samples_names=sample_names)
 
 
 def remove_nones_and_empty_dicts(d: Mapping[Any, Any]) -> Dict[Any, Any]:

--- a/multiqc/plots/plotly/plot.py
+++ b/multiqc/plots/plotly/plot.py
@@ -28,7 +28,7 @@ from multiqc import config, report
 from multiqc.core import tmp_dir
 from multiqc.core.strict_helpers import lint_error
 from multiqc.plots.plotly import check_plotly_version
-from multiqc.types import Anchor, PlotType
+from multiqc.types import Anchor, PlotType, SampleName
 from multiqc.utils import mqc_colour
 from multiqc.validation import ValidatedConfig, add_validation_warning
 
@@ -215,6 +215,9 @@ class BaseDataset(BaseModel):
     trace_params: Dict[str, Any]
     pct_range: Dict[str, Any]
     n_samples: int
+
+    def samples_names(self) -> List[SampleName]:
+        raise NotImplementedError
 
     def create_figure(
         self,

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -239,9 +239,7 @@ class Dataset(BaseDataset):
         prompt += "| --- | --- | --- |\n"
 
         for point in self.points:
-            # Use pseudonym if available, otherwise use original sample name
-            sname = SampleName(cast(str, point["name"]))
-            pseudonym = report.ai_pseudonym_map.get(sname, sname)
+            pseudonym = report.anonymize_sample_name(cast(str, point["name"]))
             prompt += f"| {pseudonym} | {point['x']}{xsuffix} | {point['y']}{ysuffix} |\n"
 
         return prompt

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -234,7 +234,17 @@ class Dataset(BaseDataset):
         xsuffix = self.layout.get("xaxis", {}).get("ticksuffix", "")
         ysuffix = self.layout.get("yaxis", {}).get("ticksuffix", "")
 
-        return "\n".join(f"{point['name']} ({point['x']}{xsuffix}, {point['y']}{ysuffix})" for point in self.points)
+        prompt = ""
+        prompt += "| Sample | X | Y |\n"
+        prompt += "| --- | --- | --- |\n"
+
+        for point in self.points:
+            # Use pseudonym if available, otherwise use original sample name
+            sname = SampleName(point["name"])
+            pseudonym = report.ai_pseudonym_map.get(sname, sname)
+            prompt += f"| {pseudonym} | {point['x']}{xsuffix} | {point['y']}{ysuffix} |\n"
+
+        return prompt
 
 
 class ScatterPlot(Plot[Dataset, ScatterConfig]):

--- a/multiqc/plots/plotly/scatter.py
+++ b/multiqc/plots/plotly/scatter.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
 from plotly import graph_objects as go  # type: ignore
@@ -240,7 +240,7 @@ class Dataset(BaseDataset):
 
         for point in self.points:
             # Use pseudonym if available, otherwise use original sample name
-            sname = SampleName(point["name"])
+            sname = SampleName(cast(str, point["name"]))
             pseudonym = report.ai_pseudonym_map.get(sname, sname)
             prompt += f"| {pseudonym} | {point['x']}{xsuffix} | {point['y']}{ysuffix} |\n"
 

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -439,7 +439,7 @@ class ViolinPlot(Plot[Dataset, TableConfig]):
     table_anchor: Anchor
 
     def samples_names(self) -> List[SampleName]:
-        names = []
+        names: List[SampleName] = []
         for ds in self.datasets:
             names.extend(SampleName(s) for s in ds.all_samples)
         return names

--- a/multiqc/plots/plotly/violin.py
+++ b/multiqc/plots/plotly/violin.py
@@ -412,8 +412,7 @@ class Dataset(BaseDataset):
                 for _, _, col in headers
             ):
                 continue
-            # Use pseudonym if available, otherwise use original sample name
-            pseudonym = report.ai_pseudonym_map.get(SampleName(sample), sample)
+            pseudonym = report.anonymize_sample_name(sample)
             row = []
             for _, _, col in headers:
                 value = self.violin_value_by_sample_by_metric[col.rid].get(

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -37,7 +37,7 @@ def plot(
 
     # Given one dataset - turn it into a list
     if not isinstance(data, list):
-        data = [data]  # typSampleName
+        data = [data]  # type: ignore
 
     sample_names = []
 
@@ -118,7 +118,7 @@ def plot(
     if "scatter" in mod.__dict__ and callable(mod.__dict__["scatter"]):
         # noinspection PyBroadException
         try:
-            return mod.__dict__["scatter"](plotdata, pconf)
+            return mod.__dict__["scatter"](plotdata, sample_names, pconf)
         except:  # noqa: E722
             if config.strict:
                 # Crash quickly in the strict mode. This can be helpful for interactive

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -8,6 +8,7 @@ from importlib_metadata import EntryPoint
 from multiqc import config
 from multiqc.plots.plotly import scatter
 from multiqc.plots.plotly.scatter import ScatterConfig
+from multiqc.types import SampleName
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +37,15 @@ def plot(
 
     # Given one dataset - turn it into a list
     if not isinstance(data, list):
-        data = [data]  # type: ignore
+        data = [data]  # typSampleName
+
+    sample_names = []
 
     plotdata: List[List[Dict[str, Any]]] = list()
     for data_index, ds in enumerate(data):
         d: List[Dict[str, Any]] = list()
         for s_name in ds:
+            sample_names.append(SampleName(s_name))
             # Ensure any overwriting conditionals from data_labels (e.g. ymax) are taken in consideration
             series_config: ScatterConfig = pconf.model_copy()
             if pconf.data_labels:
@@ -121,4 +125,4 @@ def plot(
                 # debugging of modules
                 raise
 
-    return scatter.plot(plotdata, pconf)
+    return scatter.plot(plotdata, sample_names, pconf)

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -1189,8 +1189,7 @@ def anonymize_sample_name(sample: str) -> str:
     Method will attempt to replace SAMPLE1 exactly, and more complex cases with text-replace
     which can be inacurate.
     """
-    # Use pseudonym if available, otherwise use original sample name
-    if not ai_pseudonym_map:
+    if not config.ai_anonymize_samples or not ai_pseudonym_map:
         return sample
 
     # Exact match

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -107,6 +107,7 @@ ai_provider_title: str = ""
 ai_model: str = ""
 ai_model_resolved: str = ""
 ai_report_metadata_base64: str = ""  # to copy/generate AI summaries from the report JS runtime
+ai_pseudonym_map: Dict[str, str] = {}
 
 # Following fields are preserved between interactive runs
 data_sources: Dict[str, Dict[str, Dict[str, Any]]]
@@ -164,6 +165,7 @@ def reset():
     global ai_model
     global ai_model_resolved
     global ai_report_metadata_base64
+    global ai_pseudonym_map
 
     # Create new temporary directory for module data exports
     initialized = True
@@ -194,7 +196,7 @@ def reset():
     ai_model = ""
     ai_model_resolved = ""
     ai_report_metadata_base64 = ""
-
+    ai_pseudonym_map = {}
     data_sources = defaultdict(lambda: defaultdict(lambda: defaultdict()))
     html_ids_by_scope = defaultdict(set)
     plot_data = dict()

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -5,7 +5,6 @@ modules. Contains helper functions to generate markup for report.
 
 import base64
 import dataclasses
-from datetime import datetime
 import fnmatch
 import gzip
 import inspect
@@ -18,6 +17,7 @@ import re
 import sys
 import time
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path, PosixPath
 from typing import (
     Any,
@@ -33,8 +33,8 @@ from typing import (
     Union,
 )
 
-from dotenv import load_dotenv
 import yaml
+from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 
 from multiqc import config
@@ -42,7 +42,7 @@ from multiqc import config
 # This does not cause circular imports because BaseMultiqcModule is used only in
 # quoted type hints, and quoted type hints are lazily evaluated:
 from multiqc.base_module import BaseMultiqcModule
-from multiqc.core import log_and_rich, tmp_dir
+from multiqc.core import ai, log_and_rich, tmp_dir
 from multiqc.core.exceptions import NoAnalysisFound
 from multiqc.core.log_and_rich import iterate_using_progress_bar
 from multiqc.core.tmp_dir import data_tmp_dir
@@ -56,7 +56,6 @@ from multiqc.utils.util_functions import (
     replace_defaultdicts,
     rmtree_with_retries,
 )
-from multiqc.core import ai
 
 load_dotenv()
 
@@ -107,7 +106,9 @@ ai_provider_title: str = ""
 ai_model: str = ""
 ai_model_resolved: str = ""
 ai_report_metadata_base64: str = ""  # to copy/generate AI summaries from the report JS runtime
+sample_names: List[SampleName] = []  # all sample names in the report to construct ai_pseudonym_map
 ai_pseudonym_map: Dict[str, str] = {}
+ai_pseudonym_map_base64: str = ""
 
 # Following fields are preserved between interactive runs
 data_sources: Dict[str, Dict[str, Dict[str, Any]]]
@@ -165,6 +166,7 @@ def reset():
     global ai_model
     global ai_model_resolved
     global ai_report_metadata_base64
+    global sample_names
     global ai_pseudonym_map
 
     # Create new temporary directory for module data exports
@@ -196,6 +198,7 @@ def reset():
     ai_model = ""
     ai_model_resolved = ""
     ai_report_metadata_base64 = ""
+    sample_names = []
     ai_pseudonym_map = {}
     data_sources = defaultdict(lambda: defaultdict(lambda: defaultdict()))
     html_ids_by_scope = defaultdict(set)
@@ -1178,3 +1181,25 @@ def reset_tmp_dir():
 
 def add_ai_summary():
     ai.add_ai_summary_to_report()
+
+
+def anonymize_sample_name(sample: str) -> str:
+    """
+    Anonymise sample name - sample can be any key in a plot, like SAMPLE1, SAMPLE1-SAMPLE2, etc.
+    Method will attempt to replace SAMPLE1 exactly, and more complex cases with text-replace
+    which can be inacurate.
+    """
+    # Use pseudonym if available, otherwise use original sample name
+    if not ai_pseudonym_map:
+        return sample
+
+    # Exact match
+    if SampleName(sample) in ai_pseudonym_map:
+        return ai_pseudonym_map[SampleName(sample)]
+
+    # Try replacing partial matches for cases like sample="SAMPLE1-SAMPLE2"
+    # Start with the longest original name ro avoid situations when one sample is a prefix of another
+    for original, pseudonym in sorted(ai_pseudonym_map.items(), key=lambda x: len(x[1]), reverse=True):
+        if original in sample:
+            sample = sample.replace(original, pseudonym)
+    return sample

--- a/multiqc/templates/default/assets/js/plots/bar.js
+++ b/multiqc/templates/default/assets/js/plots/bar.js
@@ -20,7 +20,6 @@ class BarPlot extends Plot {
 
     // Rename and filter samples:
     this.filteredSettings = samplesSettings.filter((s) => !s.hidden);
-    samples = this.filteredSettings.map((s) => s.name);
 
     cats = cats.map((cat) => {
       let data = this.pActive ? cat["data_pct"] : cat.data;
@@ -31,7 +30,7 @@ class BarPlot extends Plot {
       };
     });
 
-    return [cats, samples];
+    return [cats];
   }
 
   plotAiHeader() {
@@ -68,10 +67,11 @@ class BarPlot extends Plot {
     }
 
     // Create data rows
-    samples.forEach((sample, idx) => {
-      if (samplesSettings[idx].hidden) return;
+
+    samplesSettings.forEach((sample, idx) => {
+      if (sample.hidden) return;
       prompt +=
-        `| ${sample} | ` +
+        `| ${sample.pseudonym ?? sample.name} | ` +
         cats
           .map((cat) => {
             let val = this.pActive ? cat.data_pct[idx] : cat.data[idx];
@@ -97,8 +97,8 @@ class BarPlot extends Plot {
 
   // Constructs and returns traces for the Plotly plot
   buildTraces() {
-    let [cats, samples] = this.prepData();
-    if (cats.length === 0 || samples.length === 0) return [];
+    let [cats] = this.prepData();
+    if (cats.length === 0 || this.filteredSettings.length === 0) return [];
 
     const maxTicks = (this.layout.height - 140) / 12;
     this.recalculateTicks(this.filteredSettings, this.layout.yaxis, maxTicks);
@@ -134,7 +134,7 @@ class BarPlot extends Plot {
         // Plotly adds giant gaps between bars in the group mode when adding each sample as a
         // separate trace. Sacrificing dimming the de-highlighted bars to get rid of this gap.
         let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
-        samples = this.filteredSettings.map((s) => s.name);
+        let samples = this.filteredSettings.map((s) => s.name);
         params.marker.color = "rgb(" + cat.color + ")";
 
         return {
@@ -150,13 +150,13 @@ class BarPlot extends Plot {
   }
 
   exportData(format) {
-    let [cats, filteredSettings] = this.prepData();
+    let [cats] = this.prepData();
 
     let delim = format === "tsv" ? "\t" : ",";
 
     let csv = "Sample" + delim + cats.map((cat) => cat.name).join(delim) + "\n";
-    for (let i = 0; i < filteredSettings.length; i++) {
-      csv += filteredSettings[i] + delim + cats.map((cat) => cat.data[i]).join(delim) + "\n";
+    for (let i = 0; i < this.filteredSettings.length; i++) {
+      csv += this.filteredSettings[i] + delim + cats.map((cat) => cat.data[i]).join(delim) + "\n";
     }
     return csv;
   }

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -61,7 +61,9 @@ class BoxPlot extends Plot {
         return (isInt ? val : parseFloat(val.toFixed(2))) + suffix;
       };
 
-      prompt += `| ${sample} | ${fmt(min)} | ${fmt(q1)} | ${fmt(median)} | ${fmt(q3)} | ${fmt(max)} | ${fmt(mean)} |\n`;
+      prompt += `| ${anonymizeSampleName(sample)} | ${fmt(min)} | ${fmt(q1)} | ${fmt(median)} | ${fmt(q3)} | ${fmt(
+        max,
+      )} | ${fmt(mean)} |\n`;
     });
 
     return prompt;

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -25,9 +25,10 @@ class BoxPlot extends Plot {
   }
 
   formatDatasetForAiPrompt(dataset) {
-    // Prepare data to be sent to the LLM. LLM doesn't need things like colors, etc.
-    const suffix = this.layout.yaxis.ticksuffix;
+    let prompt = "";
 
+    // Prepare data to be sent to the LLM. LLM doesn't need things like colors, etc.
+    dataset = dataset ?? this.datasets[this.activeDatasetIdx];
     let [data, samples] = this.prepData(dataset);
 
     // Check if all samples are hidden
@@ -35,25 +36,36 @@ class BoxPlot extends Plot {
       return "All samples are hidden by user, so no data to analyse. Please inform user to use the toolbox to unhide samples.\n";
     }
 
-    data = data.map((d) =>
-      d.map((x) => {
-        let val = !Number.isFinite(x) ? "" : Number.isInteger(x) ? x : parseFloat(x.toFixed(2));
-        if (val !== "" && suffix) val += suffix;
-        return val;
-      }),
-    );
+    prompt += "| Sample | Min | Q1 | Median | Q3 | Max | Mean |\n";
+    prompt += "| --- | --- | --- | --- | --- | --- | --- |\n";
 
-    return (
-      "Plot type: boxplot\n\n" +
-      "Samples: " +
-      samples.join(", ") +
-      "\n\n" +
-      data
-        .map((values, idx) => {
-          return samples[idx] + " " + values.join(", ");
-        })
-        .join("\n\n")
-    );
+    const suffix = this.layout.xaxis.ticksuffix ? " " + this.layout.xaxis.ticksuffix : "";
+
+    // Calculate statistics for each sample
+    samples.forEach((sample, idx) => {
+      const values = data[idx].filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+      if (values.length === 0) return;
+
+      let n = values.length;
+
+      let min = values[0];
+      let max = values[n - 1];
+      let median = n % 2 === 1 ? values[Math.floor(n / 2)] : (values[n / 2 - 1] + values[n / 2]) / 2;
+      let q1 = n >= 4 ? values[Math.floor(n / 4)] : values[0];
+      let q3 = n >= 4 ? values[Math.floor((3 * n) / 4)] : values[n - 1];
+      let mean = values.reduce((a, b) => a + b, 0) / n;
+
+      // Format each value and add suffix
+      let fmt = (val) => {
+        if (!Number.isFinite(val)) return "";
+        const isInt = Number.isInteger(val);
+        return (isInt ? val : parseFloat(val.toFixed(2))) + suffix;
+      };
+
+      prompt += `| ${sample} | ${fmt(min)} | ${fmt(q1)} | ${fmt(median)} | ${fmt(q3)} | ${fmt(max)} | ${fmt(mean)} |\n`;
+    });
+
+    return prompt;
   }
 
   resize(newHeight) {

--- a/multiqc/templates/default/assets/js/plots/heatmap.js
+++ b/multiqc/templates/default/assets/js/plots/heatmap.js
@@ -70,15 +70,23 @@ class HeatmapPlot extends Plot {
         prompt = "|";
         if (this.yCatsAreSamples) prompt += " Sample ";
       }
-      prompt += "| " + xcats.join(" | ") + " |\n";
-      if (ycats) {
-        prompt += "| --- ";
+      if (this.xCatsAreSamples) {
+        const xPseudonyms = this.filtXCatsSettings.map((s) => s.pseudonym ?? s.name);
+        prompt += "| " + xPseudonyms.join(" | ") + " |\n";
+      } else {
+        prompt += "| " + xcats.join(" | ") + " |\n";
       }
+      if (ycats) prompt += "| --- ";
       prompt += "| " + xcats.map(() => "---").join(" | ") + " |\n";
     }
     for (let i = 0; i < rows.length; i++) {
       if (ycats) {
-        prompt += "| " + ycats[i] + " ";
+        if (this.yCatsAreSamples) {
+          const yPseudonyms = this.filtYCatsSettings.map((s) => s.pseudonym ?? s.name);
+          prompt += "| " + yPseudonyms[i] + " ";
+        } else {
+          prompt += "| " + ycats[i] + " ";
+        }
       }
       prompt +=
         "| " +

--- a/multiqc/templates/default/assets/js/plots/line.js
+++ b/multiqc/templates/default/assets/js/plots/line.js
@@ -4,7 +4,7 @@ class LinePlot extends Plot {
     return this.datasets[this.activeDatasetIdx].lines.length; // no samples in a dataset
   }
 
-  prepData(dataset) {
+  prepData(dataset, anonymize = false) {
     // Prepare data to either build Plotly traces or export as a file
     dataset = dataset ?? this.datasets[this.activeDatasetIdx];
 
@@ -12,9 +12,12 @@ class LinePlot extends Plot {
 
     let samples = lines.map((line) => line.name);
     let sampleSettings = applyToolboxSettings(samples);
+    this.filtSampleSettings = sampleSettings.filter((s) => !s.hidden);
 
     lines = lines.filter((line, idx) => {
-      line.name = sampleSettings[idx].name ?? line.name;
+      if (sampleSettings[idx].name !== undefined) {
+        line.name = anonymize ? sampleSettings[idx].pseudonym : sampleSettings[idx].name;
+      }
       line.highlight = sampleSettings[idx].highlight;
       return !sampleSettings[idx].hidden;
     });
@@ -30,7 +33,7 @@ class LinePlot extends Plot {
   }
 
   formatDatasetForAiPrompt(dataset) {
-    let [samples, lines] = this.prepData(dataset);
+    let [samples, lines] = this.prepData(dataset, true);
 
     // Check if all samples are hidden
     if (samples.length === 0) {

--- a/multiqc/templates/default/assets/js/plots/scatter.js
+++ b/multiqc/templates/default/assets/js/plots/scatter.js
@@ -4,7 +4,7 @@ class ScatterPlot extends Plot {
     return this.datasets[this.activeDatasetIdx].points; // no data points in a dataset
   }
 
-  prepData(dataset) {
+  prepData(dataset, anonymize = false) {
     // Prepare data to either build Plotly traces or export as a file
     dataset = dataset ?? this.datasets[this.activeDatasetIdx];
 
@@ -14,7 +14,11 @@ class ScatterPlot extends Plot {
     let sampleSettings = applyToolboxSettings(samples);
 
     points = points.map((point, idx) => {
-      point.name = sampleSettings[idx].name ?? point.name;
+      if (anonymize) {
+        point.name = sampleSettings[idx].pseudonym ?? sampleSettings[idx].name ?? point.name;
+      } else {
+        point.name = sampleSettings[idx].name ?? point.name;
+      }
       point.highlight = sampleSettings[idx].highlight;
       if (!sampleSettings[idx].hidden) return point;
     });
@@ -31,7 +35,7 @@ class ScatterPlot extends Plot {
   }
 
   formatDatasetForAiPrompt(dataset) {
-    let [samples, points] = this.prepData(dataset);
+    let [samples, points] = this.prepData(dataset, true);
 
     // Check if all samples are hidden
     if (samples.length === 0) {

--- a/multiqc/templates/default/assets/js/plots/violin.js
+++ b/multiqc/templates/default/assets/js/plots/violin.js
@@ -129,24 +129,25 @@ class ViolinPlot extends Plot {
     results +=
       `| ${this.pconfig.col1_header} | ` + metrics.map((metric) => headerByMetric[metric].title).join(" | ") + " |\n";
     results += "| --- | " + metrics.map(() => "---").join(" | ") + " |\n";
-    results += allSamples
+    results += sampleSettings
       .map((sample) => {
-        if (sampleSettings[allSamples.indexOf(sample)].hidden) return "";
+        if (sample.hidden) return "";
         if (
           metrics.every(
             (metric) =>
-              violinValuesBySampleByMetric[metric][sample] === undefined &&
-              scatterValuesBySampleByMetric[metric][sample] === undefined,
+              violinValuesBySampleByMetric[metric][sample.originalName] === undefined &&
+              scatterValuesBySampleByMetric[metric][sample.originalName] === undefined,
           )
         )
           return "";
 
         return (
-          `| ${sample} | ` +
+          `| ${sample.pseudonym ?? sample.name} | ` +
           metrics
             .map((metric) => {
               const value =
-                violinValuesBySampleByMetric[metric][sample] ?? scatterValuesBySampleByMetric[metric][sample];
+                violinValuesBySampleByMetric[metric][sample.originalName] ??
+                scatterValuesBySampleByMetric[metric][sample.originalName];
               const suffix = headerByMetric[metric].suffix;
               return !Number.isFinite(value)
                 ? ""

--- a/multiqc/templates/default/assets/js/toolbox.js
+++ b/multiqc/templates/default/assets/js/toolbox.js
@@ -1550,6 +1550,26 @@ $(function () {
     const modelName = $(this).data("model");
     $("#ai-model").val(modelName).trigger("change");
   });
+
+  // Initialize anonymize samples switch
+  const anonymizeSamplesEnabled = getStoredSampleAnonymizationEnabled() ?? aiAnonymizeSamples === "true";
+  if (anonymizeSamplesEnabled) {
+    $(".mqc_switch.anonymize_samples").removeClass("off").addClass("on").text("on");
+  }
+
+  // Handle anonymize samples switch clicks
+  $(".mqc_switch_wrapper.mqc_anonymize_samples").click(function (e) {
+    e.preventDefault();
+    const switchElem = $(this).find(".mqc_switch");
+    const isEnabled = switchElem.hasClass("on");
+    if (isEnabled) {
+      switchElem.removeClass("on").addClass("off").text("off");
+      storeSampleAnonymizationEnabled(false);
+    } else {
+      switchElem.removeClass("off").addClass("on").text("on");
+      storeSampleAnonymizationEnabled(true);
+    }
+  });
 });
 
 // Read the JWT local cookie in in the seqera.io domain - that's our API key:
@@ -1581,6 +1601,13 @@ function getStoredModelName(providerId) {
 }
 function storeModelName(providerId, modelName) {
   saveToLocalStorage(`mqc_ai_model_${providerId}`, modelName);
+}
+function getStoredSampleAnonymizationEnabled() {
+  const stored = getFromLocalStorage("mqc_ai_anonymize_samples");
+  return stored === null ? null : stored === "true";
+}
+function storeSampleAnonymizationEnabled(value) {
+  saveToLocalStorage("mqc_ai_anonymize_samples", value.toString());
 }
 
 function addLogo(imageDataUrl, callback) {

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -42,6 +42,9 @@ aiConfigModel = "{{ report.ai_model or config.ai_model }}";
 aiReportMetadataBase64 = "{{ report.ai_report_metadata_base64 }}";
 aiReportMetadata = JSON.parse(atob(aiReportMetadataBase64));
 
+aiAnonymizeSamples = "{{ config.ai_anonymize_samples }}";
+aiPseudonymMap = JSON.parse(atob("{{ report.ai_pseudonym_map_base64 }}"));
+
 configTitle = "{{ config.title }}";
 configCreationDate = "{{ report.creation_date.strftime('%d %b %Y, %H:%M %Z') }}";
 </script>

--- a/multiqc/templates/default/toolbox.html
+++ b/multiqc/templates/default/toolbox.html
@@ -166,6 +166,9 @@ of the report.
           </p>
         </div>  
       </form>
+
+      <hr>
+
       <p class="mqc_anonymize_samples_p">
         <span class="mqc_switch_wrapper mqc_anonymize_samples" data-target="mqc_cols">Anonymize samples <span class="mqc_switch anonymize_samples off">off</span></span>
       </p>

--- a/multiqc/templates/default/toolbox.html
+++ b/multiqc/templates/default/toolbox.html
@@ -164,8 +164,12 @@ of the report.
             Keys entered here will be stored in your browser's local storage.
             See <a href="https://docs.seqera.io/multiqc/ai#configuring-the-ai-provider" style='text-decoration: underline;' target="_blank">the docs</a>.
           </p>
-        </div>
+        </div>  
       </form>
+      <p class="mqc_anonymize_samples_p">
+        <span class="mqc_switch_wrapper mqc_anonymize_samples" data-target="mqc_cols">Anonymize samples <span class="mqc_switch anonymize_samples off">off</span></span>
+      </p>
+
     </div>
 
     <!-- Export Plots -->


### PR DESCRIPTION
Anonymize sample names if `ai_anonymize_samples: true` is set.

- [x] Handle all plot types - scatter plot, heatmap, boxplot
- [x] Handle dynamically generated summaries
- [x] Add toolbox switch to enable anonimization, read default from config, save state in local storage 
- [x] Handle toolbox-renamed samples
- [x] Handle section `content` and `content_before_plot` that can contain sample names (e.g. FastQC special heatmap, etc.)
- [x] Handle non-standard combined sample names 
    - [x] peddy pairs: FATHER-PROBAND
    - [x] check other modules
- [x] Add docs

Fix https://github.com/MultiQC/MultiQC/issues/3060