### PR TITLE
QUAST: add ANI column

### DIFF
--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -165,6 +165,15 @@ class MultiqcModule(BaseMultiqcModule):
                     except ValueError:
                         self.quast_data[s_name][k] = v
 
+        # Calculate ANI
+        for s_name, data in self.quast_data.items():
+            # These fields are only present if a reference genome was provided to QUAST
+            if "# mismatches per 100 kbp" in data and "# indels per 100 kbp" in data:
+                self.quast_data[s_name]["ANI (%)"] = 100 - (
+                    data["# mismatches per 100 kbp"] / 1000
+                    + data["# indels per 100 kbp"] / 1000
+                )
+
     def quast_general_stats_table(self):
         """Take the parsed stats from the QUAST report and add some to the
         General Statistics table at the top of the report"""
@@ -257,6 +266,14 @@ class MultiqcModule(BaseMultiqcModule):
                 "description": "The number of indels per 100 kbp",
                 "scale": "YlOrRd",
                 "format": "{:,.2f}",
+            },
+            "ANI (%)": {
+                "title": "ANI",
+                "description": "The average nucleotide identity",
+                "scale": "YlGn",
+                "format": "{:,.2f}",
+                "max": 100,
+                "suffix": "%",
             },
             "# genes": {
                 "title": "Genes",

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -165,8 +165,10 @@ class MultiqcModule(BaseMultiqcModule):
                     except ValueError:
                         self.quast_data[s_name][k] = v
 
-        # Calculate ANI
+        # Calculate ANI if not present
         for s_name, data in self.quast_data.items():
+            if "ANI (%)" in data:
+                continue
             # These fields are only present if a reference genome was provided to QUAST
             if "# mismatches per 100 kbp" in data and "# indels per 100 kbp" in data:
                 self.quast_data[s_name]["ANI (%)"] = 100 - (

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -269,7 +269,7 @@ class MultiqcModule(BaseMultiqcModule):
             },
             "ANI (%)": {
                 "title": "ANI",
-                "description": "The average nucleotide identity",
+                "description": "The average gap-compressed nucleotide identity",
                 "scale": "YlGn",
                 "format": "{:,.2f}",
                 "max": 100,

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -170,8 +170,7 @@ class MultiqcModule(BaseMultiqcModule):
             # These fields are only present if a reference genome was provided to QUAST
             if "# mismatches per 100 kbp" in data and "# indels per 100 kbp" in data:
                 self.quast_data[s_name]["ANI (%)"] = 100 - (
-                    data["# mismatches per 100 kbp"] / 1000
-                    + data["# indels per 100 kbp"] / 1000
+                    data["# mismatches per 100 kbp"] / 1000 + data["# indels per 100 kbp"] / 1000
                 )
 
     def quast_general_stats_table(self):


### PR DESCRIPTION
When comparing a genome against a reference with QUAST, it is helpful to know how similar that genome is. QUAST outputs this in a "# mismatches per 100 kbp" and "# indels per 100 kbp" field. Here we combine these two fields to calculate an average nucleotide identity for a new column, which is simpler and more interpretable.

I acknowledge that sequence identity is complicated and has different meanings (https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity). However, the choice is made easier given the outputs available from QUAST. Here I implement the gap-compressed identity, which the author of the above blog finds most compelling. Although it slightly differs from the definition of BLAST ANI used in the literature for prokaryotic species definition (non-gap-compressed), I think it is sufficient for most applications. The description also explicitly states it is gap-uncompressed.

Thanks for your consideration!

![image](https://github.com/user-attachments/assets/94f79de9-b985-4cb2-8b2b-c07479ed013e)


- [X] This comment contains a description of changes (with reason)