### PR TITLE
BCLConvert - Fix index parsing

### DIFF
--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -690,7 +690,7 @@ class MultiqcModule(BaseMultiqcModule):
                         f"{chunk.sample_project} != {sample.sample_project}, overriding"
                     )
                     sample.sample_project = chunk.sample_project
-                if sample.index is not None and chunk.index != sample.index:
+                if chunk.index != sample.index:
                     log.warning(
                         f"Sample {sname} has different indices on different lanes: "
                         f"{chunk.index} != {sample.index}, overriding"


### PR DESCRIPTION
This PR fixes index parsing. In the current version `sample.index` is always None and there will never 'pass' `sample.index is not None`. In this PR I adjusted index parsing to behave similar to project parsing. 

- [x] This comment contains a description of changes (with reason)

