### PR TITLE
Small VEP fix when data in category is missing

### DIFF
--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -168,7 +168,12 @@ class MultiqcModule(BaseMultiqcModule):
                 title = line.replace("[", "").replace("]", "")
                 txt_data[title] = {}
                 continue
-            key, value = line.split("\t")
+            try:
+                key, value = line.split("\t")
+            except ValueError:
+                # Splitting has failed, line contains something about
+                # information not available
+                continue
             if value == "-":
                 continue
             if key == "Novel / existing variants":


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

A small error I ran into when testing a pipeline with VEP.

I have attached the file that caused the failure.

[GM24385_ubam.clair3.vep.vcf.gz_summary.txt](https://github.com/user-attachments/files/19090029/GM24385_ubam.clair3.vep.vcf.gz_summary.txt)
