### PR TITLE
fix npe when generating ai table from violin plot

### DIFF
--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -527,8 +527,8 @@ class Dataset(BaseDataset):
             pseudonym = report.anonymize_sample_name(sample)
             row = []
             for _, _, col in headers:
-                value = self.violin_value_by_sample_by_metric[col.rid].get(
-                    sample, self.scatter_value_by_sample_by_metric[col.rid].get(sample, "")
+                value = self.violin_value_by_sample_by_metric.get(col.rid, {}).get(
+                    sample, self.scatter_value_by_sample_by_metric.get(col.rid, {}).get(sample, "")
                 )
                 if value:
                     fmt = getattr(col, "format", None)

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -519,8 +519,8 @@ class Dataset(BaseDataset):
         result += "|---|" + "|".join("---" for _ in headers) + "|\n"
         for sample in samples:
             if all(
-                sample not in self.violin_value_by_sample_by_metric[col.rid]
-                and sample not in self.scatter_value_by_sample_by_metric[col.rid]
+                sample not in self.violin_value_by_sample_by_metric.get(col.rid, {})
+                and sample not in self.scatter_value_by_sample_by_metric.get(col.rid, {})
                 for _, _, col in headers
             ):
                 continue


### PR DESCRIPTION
The AI summary logic seemingly backs onto violin plots.

When the metrics are accessed, the violin plot logic typically enumerates `self.metrics`, e.g.: https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L398 and https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L491

However, when generating the AI summary, the `headers` are enumerated: https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L529

There are cases where `col.rid` is not present in `violin_value_by_sample_by_metric`. I think, for example, this can happen if there are no non-empty values for a metric: https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L248

And therefore `scatter_value_by_sample_by_metric` and `violin_value_by_sample_by_metric` will not include those headers:
- https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L304
- https://github.com/MultiQC/MultiQC/blob/99fa93eaca4e4d1fa4c63d96fe649e4856d608f6/multiqc/plots/violin.py#L320

I'm not sure if this fix is the best way to fix the issue, but it did fix the NPE.