### PR TITLE
ignore formatting errors when generating ai summary from violin plot

### DIFF
--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -539,7 +539,10 @@ class Dataset(BaseDataset):
                         elif isinstance(value, int):
                             value = f"{value:d}"
                     elif isinstance(fmt, str):
-                        value = fmt.format(value)
+                        try:
+                            value = fmt.format(value)
+                        except ValueError:
+                            logger.info(f"Value {value} failed to format with {fmt=}")
                 row.append(str(value))
             result += f"|{pseudonym}|" + "|".join(row) + "|\n"
 


### PR DESCRIPTION
Formatting values for ai summaries is generally a good idea. In testing, I noticed a couple edge-cases:
1. Multiqc can generally handle string values in numeric columns. Arguably the caller shouldn't do this, but it does work. I believe there are valid cases, e.g. filling a column with values `1`, `2`, `NA`, `3`. However, calling `fmt.format(...)` fails when the input doesn't conform to the format string expectation.
2. There's rare cases where formatting is probably suboptimal for prompts. For example, I noticed formatting `3123` as `3,123`. I'd think the comma could throw off tokenization. I'm really not sure what the best answer is here (how could multiqc know whether to strip commas or not!). I think the current approach is good enough. LLMs should also understand comma-separated numbers.

Anyway, I wrapped the fmt in try/catch to fall-back to the original value if formatting fails. That seems sensible to me.