### PR TITLE
coerce x values to float when setting x range on linegraph

### DIFF
--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -539,10 +539,16 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
                 minval = dataset.layout["xaxis"]["autorangeoptions"]["minallowed"]
                 maxval = dataset.layout["xaxis"]["autorangeoptions"]["maxallowed"]
                 dminval, dmaxval = dataset.get_x_range()
+
                 if dminval is not None:
+                    if isinstance(minval, int) or isinstance(minval, float):
+                        dminval = float(dminval)
                     minval = min(minval, dminval) if minval is not None else dminval
                 if dmaxval is not None:
+                    if isinstance(maxval, int) or isinstance(maxval, float):
+                        dmaxval = float(dmaxval)
                     maxval = max(maxval, dmaxval) if maxval is not None else dmaxval
+
                 clipmin = dataset.layout["xaxis"]["autorangeoptions"]["clipmin"]
                 clipmax = dataset.layout["xaxis"]["autorangeoptions"]["clipmax"]
                 if clipmin is not None and minval is not None and clipmin > minval:


### PR DESCRIPTION
There's a tricky situation setting x-bands with json input.

Consider the example input below[0]. Object keys in JSON must be strings https://stackoverflow.com/a/8758771. Multiqc correctly parses them as strings. But this makes x-bands difficult to make use of. Because you really want numeric ranges for numeric values.

If a user specifies their x-bands numerically, I assume they want their x-labels to also be coerced to numeric values and compared. So I did that.

Perhaps a better approach would be at parse-time to infer if the user is passing numeric values. This could also be surprising if a user genuinely wants to treat values as strings, and they all just happen to be numeric. Maybe you have better ideas on how to handle this case.

0: Here is an example JSON input that triggers this:

```json
{
    "plot_type": "linegraph",
    "id": "myline_cc",
    "anchor": "myline_cc",
    "pconfig": {
        "id": "myline_cc",
        "title": "MyLine CC",
        "ylab": "Count",
        "xlab": "MyX",
        "xmin": 0,
        "ymin": 0,
        "x_bands": [
            {
                "from": 20,
                "to": 126,
                "color": "green"
            },
            {
                "from": 8,
                "to": 20,
                "color": "blue"
            },
            {
                "from": 0,
                "to": 8,
                "color": "red"
            }
        ]
    },
    "data": {
        "test": {
            "9": 4,
            "10": 2,
            "11": 17,
            "12": 9,
            "13": 2
        }
    }
}
```

Without fix:
```
/// MultiQC 🔍 v1.28

       file_search | Search path: /work
         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1/1  
╭─────────────────────────────────────────── Oops! The 'custom_content' MultiQC module broke... ───────────────────────────────────────────╮
│ Please copy this log and report it at https://github.com/MultiQC/MultiQC/issues                                                          │
│ Please attach a file that triggers the error. The last file found was: ./myline_cc_mqc.json                                              │
│                                                                                                                                          │
│ Traceback (most recent call last):                                                                                                       │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/core/exec_modules.py", line 79, in exec_modules                                  │
│     these_modules: Union[BaseMultiqcModule, List[BaseMultiqcModule]] = module_initializer()                                              │
│                                                                        ^^^^^^^^^^^^^^^^^^^^                                              │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/core/special_case_modules/custom_content.py", line 342, in custom_module_classes │
│     parsed_modules[mod_id].add_cc_section(section_id, section_anchor=section_anchor, ccdict=ccdict)                                      │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/core/special_case_modules/custom_content.py", line 517, in add_cc_section        │
│     plot = linegraph.plot(plot_datasets, pconfig=linegraph.LinePlotConfig(**pconfig))                                                    │
│            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                    │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/plots/linegraph.py", line 513, in plot                                           │
│     return LinePlot.create(                                                                                                              │
│            ^^^^^^^^^^^^^^^^                                                                                                              │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/plots/linegraph.py", line 332, in create                                         │
│     return LinePlot(**model.__dict__, sample_names=sample_names)                                                                         │
│            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                         │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/plots/plot.py", line 318, in __init__                                            │
│     self._set_x_bands_and_range(self.pconfig)                                                                                            │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/plots/plot.py", line 543, in _set_x_bands_and_range                              │
│     minval = min(minval, dminval) if minval is not None else dminval                                                                     │
│              ^^^^^^^^^^^^^^^^^^^^                                                                                                        │
│ TypeError: '<' not supported between instances of 'str' and 'int'                                                                        │
│                                                                                                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           multiqc | No analysis results found. Cleaning up…
```

With fix (ignore the poor screenshot, but suffice to say it generated and didn't error):
![_home_j_third-party_MultiQC_debugxband_multiqc_report html](https://github.com/user-attachments/assets/15efec59-5029-46aa-a624-81130ff32097)
