### PR TITLE
allow customizing prompt sent to llm

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -119,6 +119,8 @@ ai_model: str
 ai_custom_endpoint: Optional[str]
 ai_extra_query_options: Optional[Dict[str, Any]]
 ai_custom_context_window: Optional[int]
+ai_prompt_short: Optional[str]
+ai_prompt_full: Optional[str]
 no_ai: bool
 ai_anonymize_samples: bool
 

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -70,6 +70,8 @@ ai_model: null
 ai_custom_endpoint: null
 ai_extra_query_options: null
 ai_custom_context_window: null
+ai_prompt_short: null
+ai_prompt_full: null
 no_ai: false
 ai_anonymize_samples: false
 

--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -180,11 +180,18 @@ class Client:
         self.model: str
         self.api_key: str = api_key
 
+        self.prompt_short = PROMPT_SHORT
+        if config.ai_prompt_short is not None:
+            self.prompt_short = config.ai_prompt_short
+        self.prompt_full = PROMPT_FULL
+        if config.ai_prompt_full is not None:
+            self.prompt_full = config.ai_prompt_full
+
     def _query(self, prompt: str):
         raise NotImplementedError
 
     def interpret_report_short(self, report_content: str) -> InterpretationResponse:
-        response = self._query(PROMPT_SHORT + "\n\n" + report_content)
+        response = self._query(self.prompt_short + "\n\n" + report_content)
 
         return InterpretationResponse(
             interpretation=InterpretationOutput(summary=response.content),
@@ -192,7 +199,7 @@ class Client:
         )
 
     def interpret_report_full(self, report_content: str) -> InterpretationResponse:
-        response = self._query(PROMPT_FULL + "\n\n" + report_content)
+        response = self._query(self.prompt_full + "\n\n" + report_content)
 
         try:
             output = yaml.safe_load(response.content)
@@ -411,7 +418,7 @@ class SeqeraClient(Client):
         )
 
     def interpret_report_short(self, report_content: str) -> InterpretationResponse:
-        response = self._send_request(PROMPT_SHORT, report_content, extra_options=None)
+        response = self._send_request(self.prompt_short, report_content, extra_options=None)
 
         return InterpretationResponse(
             interpretation=InterpretationOutput(summary=str(response.content)),
@@ -421,7 +428,7 @@ class SeqeraClient(Client):
 
     def interpret_report_full(self, report_content: str) -> InterpretationResponse:
         response = self._send_request(
-            PROMPT_FULL,
+            self.prompt_full,
             report_content,
             extra_options={
                 "response_schema": {
@@ -627,7 +634,7 @@ def deanonymize_sample_names(text: str) -> str:
 
 
 def build_prompt(client: Client, metadata: AiReportMetadata) -> Tuple[str, bool]:
-    system_prompt = PROMPT_FULL if config.ai_summary_full else PROMPT_SHORT
+    system_prompt = client.prompt_full if config.ai_summary_full else client.prompt_short
 
     # Account for system message, plus leave 10% buffer
     max_tokens = client.max_tokens()
@@ -720,10 +727,10 @@ MultiQC General Statistics (overview of key QC metrics for each sample, across a
     return user_prompt, False
 
 
-def _save_prompt_to_file(prompt: str):
+def _save_prompt_to_file(client: Client, prompt: str):
     """Save content to file for debugging"""
     path = report.data_tmp_dir() / "multiqc_ai_prompt.txt"
-    system_prompt = PROMPT_FULL if config.ai_summary_full else PROMPT_SHORT
+    system_prompt = client.prompt_full if config.ai_summary_full else client.prompt_short
     path.write_text(f"{system_prompt}\n\n----------------------\n\n{prompt}")
     logger.debug(f"Saved AI prompt to {path.parent.name}/{path.name}")
 
@@ -755,7 +762,7 @@ def add_ai_summary_to_report():
 
     prompt, exceeded_context_window = build_prompt(client, metadata)
 
-    _save_prompt_to_file(prompt)
+    _save_prompt_to_file(client, prompt)
 
     if exceeded_context_window:
         return

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -69,6 +69,8 @@ class ClConfig(BaseModel):
     ai_model: Optional[str] = None
     ai_custom_endpoint: Optional[str] = None
     ai_custom_context_window: Optional[int] = None
+    ai_prompt_short: Optional[str] = None
+    ai_prompt_full: Optional[str] = None
     no_ai: Optional[bool] = None
     unknown_options: Optional[Dict] = None
 
@@ -221,6 +223,10 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None, log_to_file=Fal
         config.ai_custom_endpoint = cfg.ai_custom_endpoint
     if cfg.ai_custom_context_window is not None:
         config.ai_custom_context_window = cfg.ai_custom_context_window
+    if cfg.ai_prompt_short is not None:
+        config.ai_prompt_short = cfg.ai_prompt_short
+    if cfg.ai_prompt_full is not None:
+        config.ai_prompt_full = cfg.ai_prompt_full
     if cfg.no_ai is not None:
         config.no_ai = cfg.no_ai
 

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -102,6 +102,8 @@ class MultiQCConfig(BaseModel):
     ai_custom_endpoint: Optional[str] = Field(None, description="AI custom endpoint")
     ai_extra_query_options: Optional[str] = Field(None, description="AI extra query options")
     ai_custom_context_window: Optional[str] = Field(None, description="AI custom context window")
+    ai_prompt_short: Optional[str] = Field(None, description="Prompt for short AI summary, put before the report details when sent to the provider")
+    ai_prompt_full: Optional[str] = Field(None, description="Prompt for full AI summary, put before the report details when sent to the provider")
     no_ai: Optional[bool] = Field(None, description="Disable AI")
     ai_anonymize_samples: Optional[bool] = Field(None, description="Anonymize samples")
 

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -102,8 +102,12 @@ class MultiQCConfig(BaseModel):
     ai_custom_endpoint: Optional[str] = Field(None, description="AI custom endpoint")
     ai_extra_query_options: Optional[str] = Field(None, description="AI extra query options")
     ai_custom_context_window: Optional[str] = Field(None, description="AI custom context window")
-    ai_prompt_short: Optional[str] = Field(None, description="Prompt for short AI summary, put before the report details when sent to the provider")
-    ai_prompt_full: Optional[str] = Field(None, description="Prompt for full AI summary, put before the report details when sent to the provider")
+    ai_prompt_short: Optional[str] = Field(
+        None, description="Prompt for short AI summary, put before the report details when sent to the provider"
+    )
+    ai_prompt_full: Optional[str] = Field(
+        None, description="Prompt for full AI summary, put before the report details when sent to the provider"
+    )
     no_ai: Optional[bool] = Field(None, description="Disable AI")
     ai_anonymize_samples: Optional[bool] = Field(None, description="Anonymize samples")
 


### PR DESCRIPTION
I was playing around in-depth with the new LLM functionality. It's awesome.

I started fiddling with the prompts to see if I could get better outputs. Depending on the domain/use-case, I was able to get better content and formatting. I came to the conclusion that there will not be a one-size-fits-all prompt that works for everyone. So I made it configurable via multiqc config.

Let me know what you think.