### PR TITLE
Dont display decimal points on fastp filtering result bar chart

### DIFF
--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -247,7 +247,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse filtering_result
         try:
             for k in parsed_json["filtering_result"]:
-                self.fastp_data[s_name][f"filtering_result_{k}"] = parsed_json["filtering_result"][k]
+                self.fastp_data[s_name][f"filtering_result_{k}"] = float(parsed_json["filtering_result"][k])
         except KeyError:
             log.debug(f"fastp JSON did not have 'filtering_result' key: '{s_name}'")
 
@@ -260,13 +260,13 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse after_filtering
         try:
             for k in parsed_json["summary"]["after_filtering"]:
-                self.fastp_data[s_name][f"after_filtering_{k}"] = parsed_json["summary"]["after_filtering"][k]
+                self.fastp_data[s_name][f"after_filtering_{k}"] = float(parsed_json["summary"]["after_filtering"][k])
         except KeyError:
             log.debug(f"fastp JSON did not have a 'summary'-'after_filtering' keys: '{s_name}'")
 
         # Parse data required to calculate Pct reads surviving
         try:
-            self.fastp_data[s_name]["before_filtering_total_reads"] = (
+            self.fastp_data[s_name]["before_filtering_total_reads"] = float(
                 parsed_json["summary"]["before_filtering"]["total_reads"]
             )
         except KeyError:

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -247,7 +247,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse filtering_result
         try:
             for k in parsed_json["filtering_result"]:
-                self.fastp_data[s_name][f"filtering_result_{k}"] = float(parsed_json["filtering_result"][k])
+                self.fastp_data[s_name][f"filtering_result_{k}"] = parsed_json["filtering_result"][k]
         except KeyError:
             log.debug(f"fastp JSON did not have 'filtering_result' key: '{s_name}'")
 
@@ -260,13 +260,13 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse after_filtering
         try:
             for k in parsed_json["summary"]["after_filtering"]:
-                self.fastp_data[s_name][f"after_filtering_{k}"] = float(parsed_json["summary"]["after_filtering"][k])
+                self.fastp_data[s_name][f"after_filtering_{k}"] = parsed_json["summary"]["after_filtering"][k]
         except KeyError:
             log.debug(f"fastp JSON did not have a 'summary'-'after_filtering' keys: '{s_name}'")
 
         # Parse data required to calculate Pct reads surviving
         try:
-            self.fastp_data[s_name]["before_filtering_total_reads"] = float(
+            self.fastp_data[s_name]["before_filtering_total_reads"] = (
                 parsed_json["summary"]["before_filtering"]["total_reads"]
             )
         except KeyError:
@@ -450,6 +450,7 @@ class MultiqcModule(BaseMultiqcModule):
             "ylab": "# Reads",
             "cpswitch_counts_label": "Number of Reads",
             "hide_zero_cats": False,
+            "tt_decimals": 0,
         }
         return bargraph.plot(self.fastp_data, keys, pconfig)
 


### PR DESCRIPTION
The fastp bar chart did not used to display decimals. I also don't think it should - it handles read counts. I chased the change in behaviour down to 0dcd3f3de0fd53556b5ff29e02142d881e96c32d

Prior to that commit it did not display decimals. I'm not sure how it broke things, it's a rather large commit.

Anyway, at first I tried removing the `float(...)` casts when parsing fastp data, as most of it is ints:

```json
    "filtering_result": {
        "passed_filter_reads": 1488254,
        "corrected_reads": 299344,
        "corrected_bases": 571668,
        "low_quality_reads": 0,
        "too_many_N_reads": 0,
        "too_short_reads": 1396,
        "too_long_reads": 0
    },
```

Even parsing as int, the chart still displayed two decimal places. Maybe barchart defaults to two decimals even when passed ints? You can check the commit history of this PR to see this approach.

So I just configured `tt_decimals` and that fixed things. I reverted back to parsing the values as floats, in case there's good reason for that.

Before:
![2025-03-23_22-15](https://github.com/user-attachments/assets/aaa02139-9586-4994-8769-8c7cf4f2081c)

After:
![2025-03-23_22-14](https://github.com/user-attachments/assets/ec6714be-7ea8-4bfc-b55a-8e5b13fc6acc)
