### PR TITLE
Tix pre-configured table sort `defaultsort`

### DIFF
--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -641,7 +641,8 @@ def _get_sortlist(dt: DataTable) -> str:
         direction = 0 if d.get("direction", "").startswith("asc") else 1
         sortlist.append((idx, direction))
 
-    return str(sortlist)
+    sortlist_formatted = [list(t) for t in sortlist]
+    return str(sortlist_formatted)
 
 
 def _is_configure_columns_disabled(num_columns: int) -> bool:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -8,6 +8,8 @@ from multiqc.core.exceptions import RunError
 from multiqc.plots import bargraph, box, heatmap, linegraph, scatter, table, violin
 from multiqc.plots.linegraph import LinePlotConfig, Series
 from multiqc.plots.plot import Plot
+from multiqc.plots.table import _get_sortlist
+from multiqc.plots.table_object import DataTable
 from multiqc.types import Anchor
 from multiqc.validation import ModuleConfigValidationError
 
@@ -489,3 +491,22 @@ def test_dash_styles():
     assert len(report.plot_data[anchor]["datasets"][0]["lines"]) == 5
     for line in report.plot_data[anchor]["datasets"][0]["lines"][1:]:
         assert line["dash"] == "dash"
+
+
+def test_table_default_sort():
+    dt = DataTable.create(
+        table_id="foo",
+        table_anchor="foo",
+        data={
+            "sample1": {"x": 1, "y": 2},
+            "sample2": {"x": 3, "y": 4},
+        },
+        headers={"x": {"title": "Metric X"}, "y": {"title": "Metric Y"}},
+        pconfig=table.TableConfig(
+            id="table",
+            title="Table",
+            defaultsort=[{"column": "y", "direction": "desc"}, {"column": "x", "direction": "asc"}],
+        ),
+    )
+    sortlist = _get_sortlist(dt)
+    assert sortlist == "[[2, 1], [1, 0]]"

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,4 +1,5 @@
 import tempfile
+from typing import Dict
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +10,7 @@ from multiqc.plots import bargraph, box, heatmap, linegraph, scatter, table, vio
 from multiqc.plots.linegraph import LinePlotConfig, Series
 from multiqc.plots.plot import Plot
 from multiqc.plots.table import _get_sortlist
-from multiqc.plots.table_object import DataTable
+from multiqc.plots.table_object import ColumnDict, DataTable
 from multiqc.types import Anchor
 from multiqc.validation import ModuleConfigValidationError
 
@@ -494,14 +495,15 @@ def test_dash_styles():
 
 
 def test_table_default_sort():
+    headers: Dict[str, ColumnDict] = {"x": {"title": "Metric X"}, "y": {"title": "Metric Y"}}
     dt = DataTable.create(
         table_id="foo",
-        table_anchor="foo",
+        table_anchor=Anchor("foo"),
         data={
             "sample1": {"x": 1, "y": 2},
             "sample2": {"x": 3, "y": 4},
         },
-        headers={"x": {"title": "Metric X"}, "y": {"title": "Metric Y"}},
+        headers=headers,
         pconfig=table.TableConfig(
             id="table",
             title="Table",


### PR DESCRIPTION
I noticed table-sort on load was broken. Chased it down to this PR: https://github.com/MultiQC/MultiQC/commit/5c347bf1ab89c955f61b91a16e47cdf88fc03e23#diff-9c52baa1b48d5a07609a29efec35c56dfceb2fa317d53de6f8c1491f36a1a417R558

The list was converted to a tuple. Which caused the str serialization to change from `[[1, 1]]` to `[(1, 1)]`. The charting library doesn't know how to read the tuple format. This fixes.

Note the sort direction on the bar column here:

See before:
![2025-03-29_18-27](https://github.com/user-attachments/assets/0ec04ae1-646e-422e-a62c-fdd0035e512e)

After:
![2025-03-29_18-29](https://github.com/user-attachments/assets/5876d001-0e65-49b6-a372-b7916ce7e432)

mqc config:
```
custom_plot_config:
  general_stats_table:
    defaultsort:
      - column: bar
        direction: desc
```

input:
```
{
    "plot_type": "generalstats",
    "id": "Foo",
    "data": {
        "org": {
            "foo": 100.0,
            "bar": 34,
            "baz": 1637
        }
    }
}
```