### PR TITLE
kraken: hide read-count decimals for taxa plot

### DIFF
--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -292,6 +292,7 @@ class MultiqcModule(BaseMultiqcModule):
             "title": f"{self.name}: Top taxa",
             "ylab": "Number of fragments",
             "data_labels": [v for k, v in MultiqcModule.T_RANKS.items() if k in found_rank_codes],
+            "tt_decimals": 0,
         }
 
         self.add_section(


### PR DESCRIPTION
I hypothesize that the default decimal count probably changed from 0 to 2 at some point. That means all the charts that used to work well with the default now show 2 decimals.

This includes the kraken top-taxa plots, which display a read-count. It doesn't make sense for this chart to show decimals (I don't think).