### PR TITLE
NanoStat: allow customizing general stats columns

### DIFF
--- a/docs/markdown/reports/customisation.md
+++ b/docs/markdown/reports/customisation.md
@@ -461,6 +461,46 @@ sp:
 
 The search pattern identifiers can be found in the documentation below for each module.
 
+## Customize General Statistics Table
+
+The General Statistics table is one of the most important features in MultiQC reports. It shows an overview of key metrics from all modules in a single table.
+
+By default, each module decides which columns to show in this table. However, some modules support customizing this using the `general_stats_columns` configuration option.
+
+For example, to customize which columns from the NanoStat module appear in the General Statistics table:
+
+```yaml
+general_stats_columns:
+  nanostat:
+    columns:
+      Number of reads_fastq:
+        title: "# Reads"
+        description: "Number of reads"
+        hidden: false
+      Mean read length_fastq:
+        title: "Mean Length"
+        description: "Mean read length"
+        hidden: false
+      Median read quality_fastq:
+        title: "Median Quality"
+        description: "Median read quality"
+        hidden: false
+```
+
+Each module has its own set of available metrics that can be added to the General Statistics table. You can find these in the module's documentation.
+
+For each column, you can customize:
+
+- `title` - Column title
+- `description` - Column description
+- `hidden` - Whether to hide the column by default
+- `scale` - Color scale for the column
+- `format` - Number format
+- `min` - Minimum value for the color scale
+- `max` - Maximum value for the color scale
+- `suffix` - Suffix to add to values
+- `shared_key` - Share color scale with other columns
+
 #### Removing General Statistics
 
 The General Statistics is a bit of a special case in MultiQC, but there is added code to make it

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -142,6 +142,7 @@ violin_min_threshold_no_points: int
 collapse_tables: bool
 max_table_rows: int
 max_configurable_table_columns: int
+general_stats_columns: Dict[str, List[str]]
 table_columns_visible: Dict[str, Union[bool, Dict[str, bool]]]
 table_columns_placement: Dict[str, Dict[str, float]]
 table_columns_name: Dict[str, Union[str, Dict[str, str]]]

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -95,6 +95,7 @@ violin_min_threshold_no_points: 1000 # for more than this number of samples, sho
 collapse_tables: true
 max_table_rows: 500
 max_configurable_table_columns: 200
+general_stats_columns: {}
 table_columns_visible: {}
 table_columns_placement: {}
 table_columns_name: {}

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -11,6 +11,61 @@ log = logging.getLogger(__name__)
 
 
 class MultiqcModule(BaseMultiqcModule):
+    """
+    NanoStat module for parsing statistics from Oxford Nanopore sequencing data.
+
+    By default, only the Read N50 metric is shown in the General Statistics table, with all other metrics hidden.
+    You can customize which metrics appear in the General Statistics table using the `general_stats_columns`
+    configuration option in your MultiQC config file.
+
+    For example, to show number of reads, mean read length and median quality for FASTQ data:
+
+    ```yaml
+    general_stats_columns:
+        nanostat:
+            columns:
+                Number of reads_fastq:
+                    title: "# Reads"
+                    description: "Number of reads"
+                    hidden: false
+                Mean read length_fastq:
+                    title: "Mean Length"
+                    description: "Mean read length"
+                    hidden: false
+                Median read quality_fastq:
+                    title: "Median Quality"
+                    description: "Median read quality"
+                    hidden: false
+    ```
+
+    Available metrics that can be added to General Statistics (append `_fastq`, `_aligned`, `_fasta` or `_seq summary`
+    depending on the data type):
+
+    * `Active channels` - Number of active channels
+    * `Median read length` - Median read length (bp)
+    * `Mean read length` - Mean read length (bp)
+    * `Read length N50` - Read length N50
+    * `Median read quality` - Median read quality (Phred scale)
+    * `Mean read quality` - Mean read quality (Phred scale)
+    * `Median percent identity` - Median percent identity
+    * `Average percent identity` - Average percent identity
+    * `Number of reads` - Number of reads
+    * `Total bases` - Total number of bases
+    * `Total bases aligned` - Total number of aligned bases
+
+    Each metric can be customized with the following options:
+
+    * `title` - Column title
+    * `description` - Column description
+    * `hidden` - Whether to hide the column by default
+    * `scale` - Color scale for the column
+    * `format` - Number format
+    * `min` - Minimum value for the color scale
+    * `max` - Maximum value for the color scale
+    * `suffix` - Suffix to add to values
+    * `shared_key` - Share color scale with other columns
+    """
+
     _KEYS_MAPPING = {
         "number_of_reads": "Number of reads",
         "number_of_bases": "Total bases",
@@ -308,18 +363,34 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
         if not self.general_stats_added:
-            # Remove the hidden metrics, hide the rest apart from Read N50
-            general_stats_headers = {}
-            for k in headers:
-                if headers[k].get("hidden"):
-                    continue
-                general_stats_headers[k] = headers[k]
-                general_stats_headers[k]["description"] = headers[k]["description"] + f" ({stat_title})"
-                if k != f"Read length N50_{stat_type}":
-                    general_stats_headers[k]["hidden"] = True
+            # Get general stats config for this module
+            module_config = config.general_stats_columns.get("nanostat", {})
+            if isinstance(module_config, dict) and "columns" in module_config:
+                # Use configured columns
+                general_stats_headers = {}
+                for k in headers:
+                    # Only add columns that are configured
+                    if k in module_config["columns"]:
+                        general_stats_headers[k] = headers[k].copy()
+                        # Update with any configured overrides
+                        general_stats_headers[k].update(module_config["columns"][k])
+                        general_stats_headers[k]["description"] = (
+                            general_stats_headers[k].get("description", headers[k]["description"]) + f" ({stat_title})"
+                        )
+            else:
+                # Default behavior - show only Read N50, hide the rest
+                general_stats_headers = {}
+                for k in headers:
+                    if headers[k].get("hidden"):
+                        continue
+                    general_stats_headers[k] = headers[k]
+                    general_stats_headers[k]["description"] = headers[k]["description"] + f" ({stat_title})"
+                    if k != f"Read length N50_{stat_type}":
+                        general_stats_headers[k]["hidden"] = True
 
-            self.general_stats_addcols(self.nanostat_data, general_stats_headers)
-            self.general_stats_added = True
+            if general_stats_headers:
+                self.general_stats_addcols(self.nanostat_data, general_stats_headers)
+                self.general_stats_added = True
 
     def reads_by_quality_plot(self):
         def _get_total_reads(_data_dict):

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -41,6 +41,31 @@ class CleanPattern(BaseModel):
     module: Optional[Union[str, List[str]]] = Field(None, description="Module(s) to apply this pattern to")
 
 
+class GeneralStatsColumnConfig(BaseModel):
+    """Configuration for a general stats column"""
+
+    title: Optional[str] = Field(None, description="Column title")
+    description: Optional[str] = Field(None, description="Column description")
+    namespace: Optional[str] = Field(None, description="Column namespace")
+    scale: Optional[str] = Field(None, description="Color scale")
+    format: Optional[str] = Field(None, description="Number format")
+    min: Optional[float] = Field(None, description="Minimum value")
+    max: Optional[float] = Field(None, description="Maximum value")
+    ceiling: Optional[float] = Field(None, description="Ceiling value")
+    floor: Optional[float] = Field(None, description="Floor value")
+    shared_key: Optional[str] = Field(None, description="Shared key name")
+    hidden: Optional[bool] = Field(None, description="Whether column is hidden by default")
+    placement: Optional[float] = Field(None, description="Column placement order")
+
+
+class GeneralStatsModuleConfig(BaseModel):
+    """Configuration for a module's general stats columns"""
+
+    columns: Dict[str, GeneralStatsColumnConfig] = Field(
+        default_factory=dict, description="Columns to show in general stats table. Keys are column IDs."
+    )
+
+
 class MultiQCConfig(BaseModel):
     """Schema for MultiQC config validation"""
 
@@ -142,6 +167,9 @@ class MultiQCConfig(BaseModel):
     max_table_rows: Optional[int] = Field(None, description="Maximum number of rows to show in tables")
     max_configurable_table_columns: Optional[int] = Field(
         None, description="Maximum number of columns to show in tables"
+    )
+    general_stats_columns: Dict[str, GeneralStatsModuleConfig] = Field(
+        default_factory=dict, description="Configuration for general stats columns per module. Keys are module IDs."
     )
     table_columns_visible: Optional[Dict[str, Union[bool, Dict[str, bool]]]] = Field(
         None, description="Which columns to show in tables"


### PR DESCRIPTION
Add a config option to customize which columns are added to gen stats per module, as well as override columns headers for those. Add support for NanoStat.

Fixes https://github.com/MultiQC/MultiQC/issues/2929
x-ref 
https://community.seqera.io/t/adding-supported-tool-table-columns-to-generalstats-table/447/4
https://github.com/MultiQC/MultiQC/issues/2928