### PR TITLE
Minor installation docs tweaks:

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -78,9 +78,9 @@ This checklist is for my own reference, as I forget the steps every time.
 
 ## Appendix
 
-### Rebuilding BioConda recipe from scratch
+### Rebuilding Bioconda recipe from scratch
 
-Instructions for complete rebuild of BioConda:
+Instructions for complete rebuild of Bioconda:
 
 <details>
 

--- a/docs/markdown/getting_started/installation.md
+++ b/docs/markdown/getting_started/installation.md
@@ -110,25 +110,20 @@ There are a few different ways to install MultiQC into your local Python environ
 
 ### Conda
 
-MultiQC is available on [BioConda](https://bioconda.github.io/).
+MultiQC is available on [Bioconda](https://bioconda.github.io/).
 
 ```bash
 conda install multiqc
 ```
 
-:::info
-
-The order of conda channels is important!
-Please make sure that you have [configured your conda channels](https://bioconda.github.io/#usage) prior to installing anything with BioConda:
+Note that the order of conda channels is important.
+Please make sure that you have [configured your conda channels](https://bioconda.github.io/#usage) prior to installing anything with Bioconda:
 
 ```bash
-conda config --add channels defaults
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
-
-:::
 
 :::warning
 
@@ -150,6 +145,15 @@ pip install multiqc
 
 Use the `--upgrade` flag to update to the latest version.
 
+If you have problems with read-only directories, you can install to
+your home directory with the `--user` parameter:
+
+```bash
+pip install --user multiqc
+```
+
+#### Development version
+
 If you would like the development version, the command is:
 
 ```bash
@@ -157,13 +161,6 @@ pip install git+https://github.com/MultiQC/MultiQC.git
 ```
 
 To update the dev version between releases, use `--upgrade --force-reinstall`. This is needed as the version number isn't changing.
-
-If you have problems with read-only directories, you can install to
-your home directory with the `--user` parameter:
-
-```bash
-pip install --user multiqc
-```
 
 ### Spack
 
@@ -206,6 +203,9 @@ pip install .
 
 This will fetch the latest development code. To update to the latest changes, use `git pull`.
 
+Use the `--editable` flag (`pip install -e .`) if you intend to develop the code locally.
+This symlinks the source files so that you don't have to reinstall every time you edit a file.
+
 `git` not installed? No problem - just download the flat files:
 
 ```bash
@@ -218,7 +218,7 @@ pip install .
 ### Nix
 
 If you're using the [nix package manager](https://nixos.org/download.html#download-nixm) with [flakes](https://nixos.wiki/wiki/Flakes) enabled, you can
-run `nix develop`in the cloned MultiQC repository to enter a shell
+run `nix develop` in the cloned MultiQC repository to enter a shell
 with required dependencies. To build MultiQC, run `nix build`.
 
 ## MultiQC container images
@@ -273,8 +273,6 @@ multiqc .
 
 :::
 
-:::note{title="Compute architectures"}
-
 These docker images are [multi-platform images](https://docs.docker.com/build/building/multi-platform/) – each build contains two digests, one for `linux/amd64` and one for `linux/arm64`.
 
 Generally, the Docker client should be clever enough to pull the digest appropriate for your local compute architecture.
@@ -283,8 +281,6 @@ However, if you wish you can force it with the `--platform` flag.
 ```bash
 docker pull --platform linux/arm64 multiqc/multiqc:latest
 ```
-
-:::
 
 ### GitHub Packages
 
@@ -328,7 +324,7 @@ If you prefer, you can download a pre-built Singularity image from BioContainers
 
 ### BioContainers
 
-[BioContainers](https://biocontainers.pro/) is a project that automatically builds Docker and Singularity container images from [BioConda](https://bioconda.github.io/). The images are less fine-tuned for MultiQC so tend to have a larger filesize, but they should work well and are convenient.
+[BioContainers](https://biocontainers.pro/) is a project that automatically builds Docker and Singularity container images from [Bioconda](https://bioconda.github.io/). The images are less fine-tuned for MultiQC so tend to have a larger filesize, but they should work well and are convenient.
 
 To see available images, visit the BioContainers [registry page for MultiQC](https://biocontainers.pro/tools/multiqc).
 

--- a/docs/markdown/getting_started/quick_start.md
+++ b/docs/markdown/getting_started/quick_start.md
@@ -18,7 +18,7 @@ Arguably, the easiest way to do this is with Conda
 1. [Download miniconda](https://conda.io/miniconda.html) for your operating system.
 2. Run the bash script and follow the prompts.
 3. Restart your terminal shell.
-4. [Configure your conda channels](https://bioconda.github.io/#usage) to work with BioConda:
+4. [Configure your conda channels](https://bioconda.github.io/#usage) to work with Bioconda:
    ```bash
    conda config --add channels bioconda
    conda config --add channels conda-forge

--- a/docs/markdown/modules/interop.md
+++ b/docs/markdown/modules/interop.md
@@ -27,7 +27,7 @@ of a subset of the original data (collapsed quality scores).
 
 This module parses the output from the InterOp Summary executable and creates a table view. The aim is to
 replicate the `Run & Lane Metrics` table from the [Illumina Basespace](https://basespace.illumina.com) interface.
-The executable used can easily be installed from the BioConda channel using
+The executable used can easily be installed from the Bioconda channel using
 `conda install -c bioconda illumina-interop`.
 
 The MultiQC interop module can parse the outputs of the `interop_summary` and `interop_index-summary` executables.

--- a/multiqc/modules/interop/interop.py
+++ b/multiqc/modules/interop/interop.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
     This module parses the output from the InterOp Summary executable and creates a table view. The aim is to
     replicate the `Run & Lane Metrics` table from the [Illumina Basespace](https://basespace.illumina.com) interface.
-    The executable used can easily be installed from the BioConda channel using
+    The executable used can easily be installed from the Bioconda channel using
     `conda install -c bioconda illumina-interop`.
 
     The MultiQC interop module can parse the outputs of the `interop_summary` and `interop_index-summary` executables.


### PR DESCRIPTION
- Bioconda, not BioConda
- Add heading for dev version installation under pip
- Remove some excessive admonitions
- Remove instruction around conda 'defaults' channel