### PR TITLE
Allow writing parquet to custom location, including buckets

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -90,6 +90,7 @@ output_fn_name: str
 data_dir_name: str
 plots_dir_name: str
 data_format: str
+parquet_file_location: Optional[Union[str, Path]] = None
 force: bool
 verbose: bool
 no_ansi: bool

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -39,6 +39,7 @@ output_fn_name: "multiqc_report.html"
 data_dir_name: "multiqc_data"
 plots_dir_name: "multiqc_plots"
 data_format: "tsv"
+parquet_file_location: null
 force: false
 verbose: false
 no_ansi: false

--- a/multiqc/core/plot_data_store.py
+++ b/multiqc/core/plot_data_store.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, Set, Union
 
 import pandas as pd
 import pyarrow.parquet as pq  # type: ignore
+from cloudpathlib import CloudPath
 
 from multiqc import config, report
 from multiqc.core import tmp_dir
@@ -55,6 +56,7 @@ def get_report_metadata(file_path: Optional[Union[str, Path]] = None) -> Optiona
 
     Returns a dictionary with modules, data_sources, creation_date, and config.
     """
+    parquet_file: Union[CloudPath, Path]
     if file_path is None:
         parquet_file = tmp_dir.parquet_file()
     else:
@@ -265,7 +267,7 @@ def _update_parquet(df: pd.DataFrame, anchor: Anchor) -> None:
 
     # Write to file
     try:
-        merged_df.to_parquet(parquet_file, compression="gzip")
+        merged_df.to_parquet(str(parquet_file), compression="gzip")
     except Exception as e:
         logger.error(f"Error writing parquet file: {e}")
         raise

--- a/multiqc/core/tmp_dir.py
+++ b/multiqc/core/tmp_dir.py
@@ -1,7 +1,8 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
+from cloudpathlib import CloudPath, AnyPath
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +46,17 @@ def plots_tmp_dir(create=True) -> Path:
     return path
 
 
-def parquet_file() -> Path:
+def parquet_file() -> Union[CloudPath, Path]:
     """
-    Returns the path to the combined parquet file that contains all plot data
+    Returns the path to the combined parquet file that contains all plot data.
+    If config.parquet_file_location is set, it will use that location instead of the default.
     """
-    return data_tmp_dir() / "multiqc.parquet"
+    from multiqc import config
+
+    if config.parquet_file_location:
+        return AnyPath(config.parquet_file_location)
+
+    return AnyPath(data_tmp_dir()) / "multiqc.parquet"
 
 
 def new_tmp_dir():

--- a/multiqc/core/tmp_dir.py
+++ b/multiqc/core/tmp_dir.py
@@ -46,7 +46,7 @@ def plots_tmp_dir(create=True) -> Path:
     return path
 
 
-def parquet_file() -> Union[CloudPath, Path]:
+def parquet_file():
     """
     Returns the path to the combined parquet file that contains all plot data.
     If config.parquet_file_location is set, it will use that location instead of the default.
@@ -56,7 +56,7 @@ def parquet_file() -> Union[CloudPath, Path]:
     if config.parquet_file_location:
         return AnyPath(config.parquet_file_location)
 
-    return AnyPath(data_tmp_dir()) / "multiqc.parquet"
+    return AnyPath(data_tmp_dir() / "multiqc.parquet")
 
 
 def new_tmp_dir():

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -34,6 +34,7 @@ class ClConfig(BaseModel):
     filename: Optional[str] = None
     make_data_dir: Optional[bool] = None
     data_format: Optional[str] = None
+    parquet_file_location: Optional[Union[str, Path]] = None
     zip_data_dir: Optional[bool] = None
     force: Optional[bool] = None
     ignore_symlinks: Optional[bool] = None
@@ -156,6 +157,8 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None, log_to_file=Fal
         config.zip_data_dir = cfg.zip_data_dir
     if cfg.data_format is not None:
         config.data_format = cfg.data_format
+    if cfg.parquet_file_location is not None:
+        config.parquet_file_location = cfg.parquet_file_location
     if cfg.export_plots is not None:
         config.export_plots = cfg.export_plots
     if cfg.make_report is not None:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -104,6 +104,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--data-dir",
                 "--no-data-dir",
                 "--data-format",
+                "--parquet-location",
                 "--zip-data-dir",
                 "--no-report",
                 "--clean-up",
@@ -310,6 +311,12 @@ click.rich_click.OPTION_GROUPS = {
     "data_format",
     type=click.Choice(list(config.data_format_extensions.keys())),
     help="Output parsed data in a different format.",
+)
+@click.option(
+    "--parquet-location",
+    "parquet_file_location",
+    type=str,
+    help="Specify the location to write the parquet file (can be a path or S3 bucket URI).",
 )
 @click.option(
     "-z",

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -98,6 +98,7 @@ class MultiQCConfig(BaseModel):
     data_dir_name: Optional[str] = Field(None, description="Data directory name")
     plots_dir_name: Optional[str] = Field(None, description="Plots directory name")
     data_format: Optional[str] = Field(None, description="Data format for output files")
+    parquet_file_location: Optional[str] = Field(None, description="Parquet file location")
     force: Optional[bool] = Field(None, description="Overwrite existing reports")
     verbose: Optional[bool] = Field(None, description="Verbose output")
     no_ansi: Optional[bool] = Field(None, description="Disable ANSI output")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "jsonschema",
     "pandas",             # for parquet support
     "pyarrow",            # for parquet support
+    "cloudpathlib",
 ]
 requires-python = ">=3.8"
 authors = [
@@ -87,6 +88,15 @@ dev = [
     "pandas-stubs",
     "beautifulsoup4",
     "jupyter",              # for jupyter notebook example
+]
+s3 = [
+    "cloudpathlib[s3]",
+]
+gcp = [
+    "cloudpathlib[gcp]",
+]
+azure = [
+    "cloudpathlib[azure]",
 ]
 
 [project.urls]


### PR DESCRIPTION
E.g. 

```
multiqc data --parquet-location s3://my-bucket/multiqc.parquet
```

Or in `multiqc_config.yaml`

```yaml
parquet_file_location: s3://my-bucket/multiqc.parquet
```

Requires installing MultiQC optional dep, e.g. one of or all:

```
pip install 'multiqc[s3]'
pip install 'multiqc[gcp]'
pip install 'multiqc[azure]'
```