### PR TITLE
Optimize parquet format

### DIFF
--- a/multiqc/core/plot_data_store.py
+++ b/multiqc/core/plot_data_store.py
@@ -8,14 +8,17 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Union
+from re import Pattern
+from typing import Any, Dict, Optional, Sequence, Set, Union
 
 import pandas as pd
-import pyarrow.parquet as pq  # type: ignore
+import pyarrow.parquet as pq
+from pydantic import ValidationError  # type: ignore
 
 from multiqc import config, report
 from multiqc.core import tmp_dir
 from multiqc.types import Anchor
+from multiqc.utils.config_schema import MultiQCConfig
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +49,7 @@ def save_plot_data(anchor: Anchor, df: pd.DataFrame) -> None:
     _update_parquet(df, anchor)
 
 
-def get_report_metadata(file_path: Optional[Union[str, Path]] = None) -> Optional[Dict[str, Any]]:
+def get_report_metadata(df: pd.DataFrame) -> Optional[Dict[str, Any]]:
     """
     Extract all report metadata from the parquet file.
 
@@ -55,43 +58,12 @@ def get_report_metadata(file_path: Optional[Union[str, Path]] = None) -> Optiona
 
     Returns a dictionary with modules, data_sources, creation_date, and config.
     """
-    if file_path is None:
-        parquet_file = tmp_dir.parquet_file()
-    else:
-        parquet_file = Path(file_path)
-
-    if not parquet_file.exists():
+    if df.empty:
         return None
 
     try:
         # Read the metadata table from the parquet file
-        df = pd.read_parquet(parquet_file)
-        metadata_df = df[df["anchor"] == "metadata"]
-
-        if metadata_df.empty:
-            # Try to read from metadata (legacy)
-            table = pq.read_table(parquet_file, columns=[])
-            if not table.schema.metadata:
-                return None
-
-            metadata = {k.decode("utf-8"): v.decode("utf-8") for k, v in table.schema.metadata.items()}
-
-            result = {}
-
-            # Extract metadata
-            if META_MODULES in metadata:
-                result["modules"] = json.loads(metadata[META_MODULES])
-
-            if META_DATA_SOURCES in metadata:
-                result["data_sources"] = json.loads(metadata[META_DATA_SOURCES])
-
-            if META_CREATION_DATE in metadata:
-                result["creation_date"] = metadata[META_CREATION_DATE]
-
-            if META_CONFIG in metadata:
-                result["config"] = json.loads(metadata[META_CONFIG])
-
-            return result
+        metadata_df = df[df["anchor"] == "run_metadata"]
 
         # New method: get metadata from DataFrame
         result = {}
@@ -105,8 +77,8 @@ def get_report_metadata(file_path: Optional[Union[str, Path]] = None) -> Optiona
             result["data_sources"] = json.loads(metadata_df["data_sources"].iloc[0])
 
         # Read creation date
-        if "creation_date" in metadata_df.columns and not metadata_df["creation_date"].empty:
-            result["creation_date"] = metadata_df["creation_date"].iloc[0]
+        if "timestamp" in metadata_df.columns and not metadata_df["timestamp"].empty:
+            result["timestamp"] = metadata_df["timestamp"].iloc[0]
 
         # Read config
         if "config" in metadata_df.columns and not metadata_df["config"].empty:
@@ -135,14 +107,10 @@ def save_report_metadata() -> None:
             "info": mod.info,
             "intro": mod.intro,
             "comment": mod.comment,
-        }
-
-        # Add sections
-        module_dict["sections"] = [section.model_dump() for section in mod.sections]
-
-        # Add software versions
-        module_dict["versions"] = {
-            name: [version for _, version in versions_tuples] for name, versions_tuples in mod.versions.items()
+            "sections": [section.model_dump(mode="json", exclude_none=True) for section in mod.sections],
+            "versions": {
+                name: [version for _, version in versions_tuples] for name, versions_tuples in mod.versions.items()
+            },
         }
 
         modules_data.append(module_dict)
@@ -163,45 +131,47 @@ def save_report_metadata() -> None:
         # Fall back to a format without timezone if we encounter encoding issues
         creation_date_str = report.creation_date.strftime("%Y-%m-%d, %H:%M")
 
-    # Config data
-    config_dict = {}
-    for key in [
-        "title",
-        "subtitle",
-        "intro_text",
-        "report_comment",
-        "report_header_info",
-        "short_version",
-        "version",
-        "git_hash",
-        "analysis_dir",
-        "output_dir",
-    ]:
-        if hasattr(config, key):
-            value = getattr(config, key)
-            # Convert Path objects to strings
-            if isinstance(value, Path):
-                value = str(value)
-            elif isinstance(value, list) and all(isinstance(x, Path) for x in value):
-                value = [str(x) for x in value]
-            config_dict[key] = value
+    def _clean_config_values(value: Any) -> Any:
+        """
+        Convert any patterns to strings, recursively.
+        """
+        if isinstance(value, set):
+            value = list(value)
 
-    # Plot data
-    plot_data_dict = {}
-    for anchor, plot_data in report.plot_data.items():
-        plot_data_dict[anchor] = plot_data
+        if isinstance(value, Pattern):
+            return str(value)
+        elif isinstance(value, dict):
+            return {k: _clean_config_values(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [_clean_config_values(item) for item in value]
+
+        return value
+
+    # Create MultiqcConfig object from config and dump it to dict
+    config_dict = {}
+    try:
+        # Extract fields from config that match the schema
+        config_fields = {key: getattr(config, key) for key in MultiQCConfig.model_fields if hasattr(config, key)}
+        # Convert any patterns to strings, recursively
+        config_fields = _clean_config_values(config_fields)
+        # Create and validate config object
+        config_obj = MultiQCConfig(**config_fields)
+        # Dump to dict
+        config_dict = config_obj.model_dump(mode="json", exclude_none=True)
+    except ValidationError as e:
+        logger.error(f"Error validating config: {e}")
 
     # Create metadata DataFrame
     metadata_df = pd.DataFrame(
         {
-            "anchor": ["metadata"],
-            "type": ["metadata"],
-            "modules": [json.dumps(modules_data)],
-            "data_sources": [json.dumps(data_sources_dict)],
-            "creation_date": [creation_date_str],
+            "type": ["run_metadata"],
+            "anchor": ["run_metadata"],
+            "timestamp": [creation_date_str],
+            "run_id": [config.title],
             "config": [json.dumps(config_dict)],
-            "plot_data": [json.dumps(plot_data_dict)],
+            "data_sources": [json.dumps(data_sources_dict)],
             "multiqc_version": [config.version if hasattr(config, "version") else ""],
+            "modules": [json.dumps(modules_data)],
         }
     )
 
@@ -281,8 +251,18 @@ def reset():
 
 
 def parse_value(value: Any, value_type: str) -> Any:
+    """
+    Parse a string value back to its original type, handling special markers.
+    """
+    import math
+
+    # Handle special NaN marker
+    if isinstance(value, str) and value == "__NAN__MARKER__":
+        return math.nan
+
+    # Handle regular type conversion
     if value_type == "int":
-        return int(value)
+        return int(float(value))  # Handle float strings that represent integers
     elif value_type == "float":
         return float(value)
     elif value_type == "bool":

--- a/multiqc/core/plot_data_store.py
+++ b/multiqc/core/plot_data_store.py
@@ -7,12 +7,10 @@ It also stores all report metadata (modules, data sources, configs) to make repo
 import json
 import logging
 import os
-from pathlib import Path
 from re import Pattern
-from typing import Any, Dict, Optional, Sequence, Set, Union
+from typing import Any, Dict, List, Optional, Set
 
 import pandas as pd
-import pyarrow.parquet as pq
 from pydantic import ValidationError  # type: ignore
 
 from multiqc import config, report
@@ -99,7 +97,7 @@ def save_report_metadata() -> None:
     parquet_file = tmp_dir.parquet_file()
 
     # Prepare metadata row
-    modules_data = []
+    modules_data: List[Dict[str, Any]] = []
     for mod in report.modules:
         module_dict: Dict[str, Any] = {
             "name": mod.name,

--- a/multiqc/interactive.py
+++ b/multiqc/interactive.py
@@ -141,7 +141,7 @@ def list_samples() -> List[str]:
     for _, plot in report.plot_by_id.items():
         if isinstance(plot, Plot):
             for ds in plot.datasets:
-                samples |= set(ds.samples_names())
+                samples |= set(ds.sample_names())
 
     # Also add samples from report.plot_data
     for plot_id, plot_dump in report.plot_data.items():

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -576,6 +576,7 @@ class MultiqcModule(BaseMultiqcModule):
                     "title": "fastp: Top overrepresented sequences",
                     "col1_header": "Overrepresented sequence",
                     "sort_rows": False,
+                    "rows_are_samples": False,
                 },
             ),
         )

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -1276,6 +1276,7 @@ class MultiqcModule(BaseMultiqcModule):
                     "title": "FastQC: Top overrepresented sequences",
                     "col1_header": "Overrepresented sequence",
                     "sort_rows": False,
+                    "rows_are_samples": False,
                 },
             ),
         )

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -16,7 +16,6 @@ from natsort import natsorted
 from pydantic import BaseModel, Field
 
 from multiqc import config, report
-from multiqc.core import tmp_dir
 from multiqc.core.exceptions import RunError
 from multiqc.core.plot_data_store import save_plot_data
 from multiqc.plots.plot import (
@@ -216,6 +215,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
             pconfig=pconf,
             data=filtered_datasets,
             cats=categories_per_ds,
+            creation_date=report.creation_date,
         )
 
     def to_df(self) -> pd.DataFrame:
@@ -236,7 +236,6 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
                         cat_conf = self.cats[ds_idx].get(category_name)
 
                     record = {
-                        "anchor": self.anchor,
                         "dataset_idx": ds_idx,
                         "dataset_label": dataset_label,
                         "sample": str(sample_name),
@@ -259,8 +258,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
                     records.append(record)
 
         df = pd.DataFrame(records)
-        self.finalize_df(df)
-        return df
+        return self.finalize_df(df)
 
     @classmethod
     def from_df(cls, df: pd.DataFrame, pconfig: Union[Dict, BarPlotConfig], anchor: Anchor) -> "BarPlotInputData":
@@ -268,7 +266,8 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
         Load plot data from a parquet file.
         """
         # Handle None case
-        if df.empty:
+        creation_date = cls.creation_date_from_df(df)
+        if cls.df_is_empty(df):
             pconf = (
                 pconfig
                 if isinstance(pconfig, BarPlotConfig)
@@ -280,6 +279,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
                 pconfig=pconf,
                 data=[],
                 cats=[],
+                creation_date=creation_date,
             )
 
         pconf = cast(BarPlotConfig, BarPlotConfig.from_df(df))
@@ -343,6 +343,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
             pconfig=pconf,
             data=datasets,
             cats=cats_per_dataset,
+            creation_date=creation_date,
         )
 
     @classmethod
@@ -386,7 +387,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
 
             # For duplicates (same sample, category, dataset), keep the latest version
             # Sort by timestamp (newest last)
-            merged_df.sort_values("timestamp", inplace=True)
+            merged_df.sort_values("creation_date", inplace=True)
 
         save_plot_data(new_data.anchor, merged_df)
 

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -432,6 +432,9 @@ class Dataset(BaseDataset):
     cats: List[Category]
     samples: List[str]
 
+    def sample_names(self) -> List[SampleName]:
+        return [SampleName(sample) for sample in self.samples]
+
     @staticmethod
     def create(
         dataset: BaseDataset,
@@ -546,7 +549,7 @@ class Dataset(BaseDataset):
 class BarPlot(Plot[Dataset, BarPlotConfig]):
     datasets: List[Dataset]
 
-    def samples_names(self) -> List[SampleName]:
+    def sample_names(self) -> List[SampleName]:
         names: List[SampleName] = []
         for ds in self.datasets:
             names.extend(SampleName(sample) for sample in ds.samples)

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -250,8 +250,7 @@ class BoxPlotInputData(NormalizedPlotInputData):
 
         # Add timestamp and run_id to new data
         new_df["timestamp"] = datetime.now().isoformat()
-        if hasattr(config, "kwargs") and "run_id" in config.kwargs:
-            new_df["run_id"] = config.kwargs["run_id"]
+        new_df["run_id"] = config.title
 
         old_df = old_data.to_df()
 
@@ -262,24 +261,16 @@ class BoxPlotInputData(NormalizedPlotInputData):
             if "run_id" not in old_df.columns and hasattr(config, "kwargs") and "run_id" in config.kwargs:
                 old_df["run_id"] = "previous_run"  # Default value for old data without run_id
 
-            # Make sure old data has timestamp
-            if "timestamp" not in old_df.columns:
-                old_df["timestamp"] = datetime.now().isoformat()
-
             # Combine the dataframes, keeping all rows
             merged_df = pd.concat([old_df, new_df], ignore_index=True)
 
             # For duplicates (same sample, dataset, value_idx), keep the latest version
-            if "timestamp" in merged_df.columns:
-                # Sort by timestamp (newest last)
-                merged_df.sort_values("timestamp", inplace=True)
+            # Sort by timestamp (newest last)
+            merged_df.sort_values("timestamp", inplace=True)
 
-                # Group by the key identifiers and keep the last entry (newest)
-                dedupe_columns = ["dataset_idx", "sample_name", "value_idx"]
-                if "run_id" in merged_df.columns:
-                    dedupe_columns.append("run_id")
-
-                merged_df = merged_df.drop_duplicates(subset=dedupe_columns, keep="last")
+            # Group by the key identifiers and keep the last entry (newest)
+            dedupe_columns = ["dataset_idx", "sample_name", "value_idx", "run_id"]
+            merged_df = merged_df.drop_duplicates(subset=dedupe_columns, keep="last")
 
         # Save the merged data for future reference
         save_plot_data(new_data.anchor, merged_df)

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -33,6 +33,9 @@ class Dataset(BaseDataset):
     data: List[BoxT]
     samples: List[str]
 
+    def sample_names(self) -> List[SampleName]:
+        return [SampleName(sample) for sample in self.samples]
+
     @staticmethod
     def create(
         dataset: BaseDataset,
@@ -304,10 +307,10 @@ class BoxPlotInputData(NormalizedPlotInputData):
 class BoxPlot(Plot[Dataset, BoxPlotConfig]):
     datasets: List[Dataset]
 
-    def samples_names(self) -> List[SampleName]:
+    def sample_names(self) -> List[SampleName]:
         names: List[SampleName] = []
         for ds in self.datasets:
-            names.extend(SampleName(sample) for sample in ds.samples)
+            names.extend(ds.sample_names())
         return names
 
     @staticmethod

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -306,6 +306,14 @@ class Dataset(BaseDataset):
     xcats_samples: bool = True
     ycats_samples: bool = True
 
+    def sample_names(self) -> List[SampleName]:
+        sns = []
+        if self.xcats_samples:
+            sns.extend(SampleName(cat) for cat in self.xcats)
+        if self.ycats_samples:
+            sns.extend(SampleName(cat) for cat in self.ycats)
+        return sns
+
     @staticmethod
     def create(
         dataset: BaseDataset,
@@ -415,7 +423,7 @@ class HeatmapPlot(Plot[Dataset, HeatmapConfig]):
     max: Optional[float] = None
     cluster_switch_clustered_active: bool = False
 
-    def samples_names(self) -> List[SampleName]:
+    def sample_names(self) -> List[SampleName]:
         names: List[SampleName] = []
         if self.xcats_samples:
             for ds in self.datasets:

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -307,12 +307,12 @@ class Dataset(BaseDataset):
     ycats_samples: bool = True
 
     def sample_names(self) -> List[SampleName]:
-        sns = []
+        snames: List[SampleName] = []
         if self.xcats_samples:
-            sns.extend(SampleName(cat) for cat in self.xcats)
+            snames.extend(SampleName(cat) for cat in self.xcats)
         if self.ycats_samples:
-            sns.extend(SampleName(cat) for cat in self.ycats)
-        return sns
+            snames.extend(SampleName(cat) for cat in self.ycats)
+        return snames
 
     @staticmethod
     def create(

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -115,13 +115,14 @@ class HeatmapNormalizedInputData(NormalizedPlotInputData):
                 if isinstance(pconfig, HeatmapConfig)
                 else cast(HeatmapConfig, HeatmapConfig.from_pconfig_dict(pconfig))
             )
-            return HeatmapNormalizedInputData(
+            return cls(
                 anchor=anchor,
                 rows=[],
                 xcats=[],
                 ycats=[],
                 pconfig=pconf,
                 plot_type=PlotType.HEATMAP,
+                creation_date=cls.creation_date_from_df(df),
             )
 
         pconf = cast(HeatmapConfig, HeatmapConfig.from_df(df))
@@ -150,13 +151,14 @@ class HeatmapNormalizedInputData(NormalizedPlotInputData):
 
         cls.data_labels_from_df(df, pconf)
 
-        return HeatmapNormalizedInputData(
+        return cls(
             anchor=anchor,
             rows=rows,  # type: ignore
             xcats=xcats,
             ycats=ycats,
             pconfig=pconf,
             plot_type=PlotType.HEATMAP,
+            creation_date=cls.creation_date_from_df(df),
         )
 
     @classmethod
@@ -182,6 +184,7 @@ class HeatmapNormalizedInputData(NormalizedPlotInputData):
             ycats=new_data.ycats,
             pconfig=new_data.pconfig,
             plot_type=PlotType.HEATMAP,
+            creation_date=report.creation_date,
         )
 
     @staticmethod
@@ -237,6 +240,7 @@ class HeatmapNormalizedInputData(NormalizedPlotInputData):
             xcats=list(xcats),
             ycats=list(ycats),
             pconfig=pconf,
+            creation_date=report.creation_date,
         )
 
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -2,6 +2,7 @@
 
 import io
 import logging
+import math
 import os
 import random
 from datetime import datetime
@@ -325,6 +326,10 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
             dataset_label = self.extract_data_label(ds_idx)
             for series in dataset:
                 for x, y in series.pairs:
+                    # Convert NaN values to string marker for safe serialization
+                    x_val = "__NAN__MARKER__" if isinstance(x, float) and math.isnan(x) else str(x)
+                    y_val = "__NAN__MARKER__" if isinstance(y, float) and math.isnan(y) else str(y)
+
                     record = {
                         "anchor": self.anchor,
                         "dataset_idx": ds_idx,
@@ -332,8 +337,8 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
                         "sample_name": series.name,
                         # values can be be different types (int, float, str...), especially across
                         # plots. parquet requires values of the same type. so we cast them to str
-                        "x_val": str(x),
-                        "y_val": str(y),
+                        "x_val": x_val,
+                        "y_val": y_val,
                         "x_val_type": type(x).__name__,
                         "y_val_type": type(y).__name__,
                         "series_color": series.color,

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -5,8 +5,6 @@ import logging
 import math
 import os
 import random
-from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, Generic, List, Literal, Mapping, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 import pandas as pd
@@ -331,7 +329,6 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
                     y_val = "__NAN__MARKER__" if isinstance(y, float) and math.isnan(y) else str(y)
 
                     record = {
-                        "anchor": self.anchor,
                         "dataset_idx": ds_idx,
                         "dataset_label": dataset_label,
                         "sample_name": series.name,
@@ -351,15 +348,15 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
 
         # Create DataFrame from records
         df = pd.DataFrame(records)
-        self.finalize_df(df)
-        return df
+        return self.finalize_df(df)
 
     @classmethod
     def from_df(
         cls, df: pd.DataFrame, pconfig: Union[Dict, LinePlotConfig], anchor: Anchor
     ) -> "LinePlotNormalizedInputData[KeyT, ValT]":
         pconf: LinePlotConfig
-        if df.empty:
+        creation_date = cls.creation_date_from_df(df)
+        if cls.df_is_empty(df):
             pconf = (
                 pconfig
                 if isinstance(pconfig, LinePlotConfig)
@@ -371,6 +368,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
                 data=[],
                 pconfig=pconf,
                 sample_names=[],
+                creation_date=creation_date,
             )
         pconf = cast(LinePlotConfig, LinePlotConfig.from_df(df))
 
@@ -441,6 +439,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
             data=datasets,
             pconfig=pconf,
             sample_names=sample_names,
+            creation_date=creation_date,
         )
 
     @staticmethod
@@ -497,6 +496,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
             data=datasets,
             pconfig=pconf,
             sample_names=sample_names,
+            creation_date=report.creation_date,
         )
 
     @classmethod

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -355,7 +355,6 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
         cls, df: pd.DataFrame, pconfig: Union[Dict, LinePlotConfig], anchor: Anchor
     ) -> "LinePlotNormalizedInputData[KeyT, ValT]":
         pconf: LinePlotConfig
-        creation_date = cls.creation_date_from_df(df)
         if cls.df_is_empty(df):
             pconf = (
                 pconfig
@@ -368,7 +367,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
                 data=[],
                 pconfig=pconf,
                 sample_names=[],
-                creation_date=creation_date,
+                creation_date=cls.creation_date_from_df(df),
             )
         pconf = cast(LinePlotConfig, LinePlotConfig.from_df(df))
 
@@ -439,7 +438,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
             data=datasets,
             pconfig=pconf,
             sample_names=sample_names,
-            creation_date=creation_date,
+            creation_date=cls.creation_date_from_df(df),
         )
 
     @staticmethod

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -124,6 +124,9 @@ class LinePlotConfig(PConfig):
 class Dataset(BaseDataset, Generic[KeyT, ValT]):
     lines: List[Series[KeyT, ValT]]
 
+    def sample_names(self) -> List[SampleName]:
+        return [SampleName(line.name) for line in self.lines]
+
     def get_x_range(self) -> Tuple[Optional[KeyT], Optional[KeyT]]:
         if not self.lines:
             return None, None
@@ -544,7 +547,7 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
     datasets: List[Dataset[KeyT, ValT]]
     sample_names: List[SampleName]
 
-    def samples_names(self) -> List[SampleName]:
+    def all_sample_names(self) -> List[SampleName]:
         return self.sample_names
 
     def _plot_ai_header(self) -> str:

--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -248,7 +248,7 @@ class BaseDataset(BaseModel):
     pct_range: Dict[str, Any]
     n_samples: int
 
-    def samples_names(self) -> List[SampleName]:
+    def sample_names(self) -> List[SampleName]:
         raise NotImplementedError
 
     def create_figure(

--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -8,7 +8,6 @@ import platform
 import random
 import re
 import subprocess
-import threading
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
@@ -19,7 +18,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Set,
     Tuple,
     Type,
     TypeVar,

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -294,6 +294,9 @@ def plot(
 class Dataset(BaseDataset):
     points: List[PointT]
 
+    def sample_names(self) -> List[SampleName]:
+        return [SampleName(sample) for sample in self.points.keys()]
+
     @staticmethod
     def create(
         dataset: BaseDataset,

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -295,7 +295,7 @@ class Dataset(BaseDataset):
     points: List[PointT]
 
     def sample_names(self) -> List[SampleName]:
-        return [SampleName(sample) for sample in self.points.keys()]
+        return [SampleName(point["name"]) for point in self.points if point.get("name") is not None]
 
     @staticmethod
     def create(

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -295,7 +295,9 @@ class Dataset(BaseDataset):
     points: List[PointT]
 
     def sample_names(self) -> List[SampleName]:
-        return [SampleName(point["name"]) for point in self.points if point.get("name") is not None]
+        return [
+            SampleName(point["name"]) for point in self.points if "name" in point and isinstance(point["name"], str)
+        ]
 
     @staticmethod
     def create(

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+import math
 import stat
 from collections import defaultdict
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
@@ -68,13 +69,19 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
                     # Add all point data
                     for key, val in point.items():
                         if key == "x":
-                            record["x"] = str(val)
+                            # Convert NaN values to string marker for safe serialization
+                            x_val = "__NAN__MARKER__" if isinstance(val, float) and math.isnan(val) else str(val)
+                            record["x"] = x_val
                             record["x_type"] = type(val).__name__
-                        if key == "y":
-                            record["y"] = str(val)
+                        elif key == "y":
+                            # Convert NaN values to string marker for safe serialization
+                            y_val = "__NAN__MARKER__" if isinstance(val, float) and math.isnan(val) else str(val)
+                            record["y"] = y_val
                             record["y_type"] = type(val).__name__
                         else:
-                            record[f"point_{key}"] = str(val)
+                            # For other values, also handle NaN
+                            point_val = "__NAN__MARKER__" if isinstance(val, float) and math.isnan(val) else str(val)
+                            record[f"point_{key}"] = point_val
                     records.append(record)
 
         df = pd.DataFrame(records)

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -59,7 +59,6 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
 
                 for point_idx, point in enumerate(points):
                     record = {
-                        "anchor": self.anchor,
                         "dataset_idx": ds_idx,
                         "dataset_label": dataset_label,
                         "sample_name": sample_name,
@@ -85,8 +84,7 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
                     records.append(record)
 
         df = pd.DataFrame(records)
-        self.finalize_df(df)
-        return df
+        return self.finalize_df(df)
 
     @staticmethod
     def create(
@@ -104,6 +102,7 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
             plot_type=PlotType.SCATTER,
             datasets=data,
             pconfig=pconf,
+            creation_date=report.creation_date,
         )
 
     @classmethod
@@ -190,11 +189,12 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
             merged_pconf = ScatterConfig(**new_data.pconfig.model_dump())
             merged_pconf.data_labels = merged_data_labels
 
-            return ScatterNormalizedInputData(
+            return cls(
                 plot_type=PlotType.SCATTER,
                 anchor=new_data.anchor,
                 datasets=merged_datasets,
                 pconfig=merged_pconf,
+                creation_date=report.creation_date,
             )
         else:
             # If no data labels, preserve old behavior (return new data)
@@ -202,11 +202,12 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
             if old_data.pconfig.extra_series and new_data.pconfig.extra_series is None:
                 merged_pconf = ScatterConfig(**new_data.pconfig.model_dump())
                 merged_pconf.extra_series = old_data.pconfig.extra_series
-                return ScatterNormalizedInputData(
+                return cls(
                     plot_type=PlotType.SCATTER,
                     anchor=new_data.anchor,
                     datasets=new_data.datasets,
                     pconfig=merged_pconf,
+                    creation_date=report.creation_date,
                 )
             return new_data
 
@@ -228,6 +229,7 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
                 datasets=[],
                 pconfig=pconf,
                 plot_type=PlotType.SCATTER,
+                creation_date=cls.creation_date_from_df(df),
             )
 
         pconf = cast(ScatterConfig, ScatterConfig.from_df(df))
@@ -267,6 +269,7 @@ class ScatterNormalizedInputData(NormalizedPlotInputData):
             plot_type=PlotType.SCATTER,
             datasets=datasets,
             pconfig=pconf,
+            creation_date=cls.creation_date_from_df(df),
         )
 
 

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -35,6 +35,7 @@ class TableConfig(PConfig):
     scale: Union[str, bool] = "GnBu"
     min: Optional[Union[int, float]] = None
     parse_numeric: bool = True
+    rows_are_samples: bool = True
 
     def __init__(self, path_in_cfg: Optional[Tuple[str, ...]] = None, **data):
         super().__init__(path_in_cfg=path_in_cfg or ("table",), **data)

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -1,10 +1,14 @@
+"""
+Violin plot module. Also handles scatter plots and tables.
+"""
+
 import copy
 import json
 import logging
 import math
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -108,6 +112,56 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         # Create DataFrame with appropriate dtypes
         df = pd.DataFrame(records, dtype=object).astype(column_types)
+        self.finalize_df(df)
+        return df
+
+    def to_wide_df(self) -> pd.DataFrame:
+        """
+        Save plot data to a parquet file using a tabular representation where metrics are columns
+        and samples are rows, optimized for cross-run analysis. Used for parquet data dump.
+        """
+        if self.is_empty() or not self.pconfig.rows_are_samples:
+            return pd.DataFrame()
+
+        # Get ordered headers first
+        ordered_headers = list(self.dt.get_headers_in_order())
+
+        # Now transform directly to wide format with metrics as columns
+        wide_records = []
+
+        # Process each section and its rows
+        for section_idx, section in enumerate(self.dt.section_by_id.values()):
+            section_key = list(self.dt.section_by_id.keys())[section_idx]
+
+            # Process each sample in this section
+            for sample_name, group_rows in section.rows_by_sgroup.items():
+                for row in group_rows:
+                    # Create base record with sample information
+                    wide_record: Dict[str, Any] = {
+                        "type": "table_row",
+                        "section_key": str(section_key),
+                        "sample_name": str(sample_name),
+                    }
+
+                    # Process each metric/column in the order from get_headers_in_order()
+                    for _, metric_name, _ in ordered_headers:
+                        if metric_name not in row.data:
+                            continue
+
+                        cell = row.data[metric_name]
+                        # Skip empty values
+                        if cell is None or cell.raw is None or cell.fmt == "":
+                            continue
+
+                        # Store both the value and its type for proper reconstruction
+                        wide_record[f"col_{metric_name}"] = cell.mod
+
+                    # Only add records that have at least one metric
+                    if any(k.startswith("col_") for k in wide_record.keys()):
+                        wide_records.append(wide_record)
+
+        # Create the wide format DataFrame
+        df = pd.DataFrame(wide_records)
         self.finalize_df(df)
         return df
 
@@ -282,8 +336,8 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
     @classmethod
     def merge(cls, old_data: "ViolinPlotInputData", new_data: "ViolinPlotInputData") -> "ViolinPlotInputData":
         """
-        Merge normalized data from old run and new run, leveraging similar
-        tabular representation approach as used for bar and line graphs.
+        Merge normalized data from old run and new run, using the wide format representation
+        with metrics as columns.
         """
         # Create dataframe for new data
         if new_data.is_empty():
@@ -291,36 +345,21 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         old_df = old_data.to_df()
         new_df = new_data.to_df()
-        # Add timestamp and run_id to new data
-        new_df["timestamp"] = datetime.now().isoformat()
-        if hasattr(config, "kwargs") and "run_id" in config.kwargs:
-            new_df["run_id"] = config.kwargs["run_id"]
 
         # If we have both old and new data, merge them
         merged_df = None
         if old_df is not None and not old_df.empty:
-            # Make sure old data has run_id
-            if "run_id" not in old_df.columns and hasattr(config, "kwargs") and "run_id" in config.kwargs:
-                old_df["run_id"] = "previous_run"  # Default value for old data without run_id
-
-            # Make sure old data has timestamp
-            if "timestamp" not in old_df.columns:
-                old_df["timestamp"] = datetime.now().isoformat()
-
             # Combine the dataframes, keeping all rows
             merged_df = pd.concat([old_df, new_df], ignore_index=True)
 
             # For duplicates (same sample, metric, dataset, section), keep the latest version
-            if "timestamp" in merged_df.columns:
-                # Sort by timestamp (newest last)
-                merged_df.sort_values("timestamp", inplace=True)
+            # Sort by timestamp (newest last)
+            merged_df.sort_values("timestamp", inplace=True)
 
-                # Group by the key identifiers and keep the last entry (newest)
-                dedupe_columns = ["dt_anchor", "section_key", "sample_name", "metric_name"]
-                if "run_id" in merged_df.columns:
-                    dedupe_columns.append("run_id")
+            # Group by the key identifiers and keep the last entry (newest)
+            dedupe_columns = ["dt_anchor", "section_key", "sample_name", "run_id"]
 
-                merged_df = merged_df.drop_duplicates(subset=dedupe_columns, keep="last")
+            merged_df = merged_df.drop_duplicates(subset=dedupe_columns, keep="last")
         else:
             merged_df = new_df
 

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -150,7 +150,12 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
                             continue
 
                         # Store both the value and its type for proper reconstruction
-                        wide_record[f"col_{metric_name}"] = cell.mod
+                        try:
+                            float_val = float(cell.mod)
+                        except ValueError:
+                            float_val = float("nan")
+                        wide_record[f"col_{metric_name}_val"] = float_val
+                        wide_record[f"col_{metric_name}_str"] = cell.fmt
 
                     # Only add records that have at least one metric
                     if any(k.startswith("col_") for k in wide_record.keys()):
@@ -440,8 +445,8 @@ class Dataset(BaseDataset):
     show_table_by_default: bool
     is_downsampled: bool
 
-    def samples_names(self) -> List[SampleName]:
-        return self.all_samples
+    def sample_names(self) -> List[SampleName]:
+        return self.all_samples if self.dt.pconfig.rows_are_samples else []
 
     @staticmethod
     def values_and_headers_from_dt(
@@ -824,10 +829,10 @@ class ViolinPlot(Plot[Dataset, TableConfig]):
     n_samples: int
     table_anchor: Anchor
 
-    def samples_names(self) -> List[SampleName]:
+    def all_sample_names(self) -> List[SampleName]:
         names: List[SampleName] = []
         for ds in self.datasets:
-            names.extend(ds.samples_names())
+            names.extend(ds.sample_names())
         return names
 
     @staticmethod

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -7,8 +7,7 @@ import json
 import logging
 import math
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -241,7 +241,9 @@ class MultiQCConfig(BaseModel):
     )
 
     # Search patterns
-    sp: Optional[Dict[str, SearchPattern]] = Field(None, description="Search patterns for finding tool outputs")
+    sp: Optional[Dict[str, Union[SearchPattern, List[SearchPattern]]]] = Field(
+        None, description="Search patterns for finding tool outputs"
+    )
 
     class Config:
         extra = "allow"  # Allow additional fields that aren't in the schema

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,5 +1,6 @@
 import difflib
 import json
+from datetime import datetime, timedelta
 
 import multiqc
 from multiqc.core.update_config import ClConfig
@@ -122,6 +123,7 @@ def test_merge_linegraph():
         data=[dataset1],
         pconfig=pconfig,
         sample_names=[SampleName("Sample1"), SampleName("Sample2")],
+        creation_date=datetime.now() - timedelta(days=1),
     )
 
     # Create second input data - two samples: "Sample1" (overlapping) and "Sample3" (new)
@@ -135,6 +137,7 @@ def test_merge_linegraph():
         data=[dataset2],
         pconfig=pconfig,
         sample_names=[SampleName("Sample1"), SampleName("Sample3")],
+        creation_date=datetime.now(),
     )
 
     # Merge the two inputs
@@ -199,6 +202,7 @@ def test_merge_bargraph():
         data=[dataset1],
         cats=[cats1],
         pconfig=pconfig,
+        creation_date=datetime.now() - timedelta(days=1),
     )
 
     # Create second input data - two samples: "Sample1" (overlapping) and "Sample3" (new)
@@ -219,6 +223,7 @@ def test_merge_bargraph():
         data=[dataset2],
         cats=[cats2],
         pconfig=pconfig,
+        creation_date=datetime.now(),
     )
 
     # Merge the two inputs

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -49,14 +49,20 @@ def test_rerun_and_combine(data_dir, tmp_path):
     """
     # Run MultiQC on inputs A
     run_a_dir = tmp_path / "run_a"
-    multiqc.run(data_dir / "modules/fastp/single_end", cfg=ClConfig(output_dir=run_a_dir))
+    multiqc.run(
+        data_dir / "modules/fastp/single_end",
+        cfg=ClConfig(
+            output_dir=run_a_dir,
+            strict=True,
+        ),
+    )
 
     # Run MultiQC on outputs of A + inputs B
     run_combined_dir = tmp_path / "run_combined"
     multiqc.run(
         data_dir / "modules/fastp/SAMPLE.json",
         run_a_dir / "multiqc_data" / "multiqc.parquet",
-        cfg=ClConfig(output_dir=run_combined_dir),
+        cfg=ClConfig(output_dir=run_combined_dir, strict=True),
     )
 
     with open(run_combined_dir / "multiqc_data" / "multiqc_data.json") as f:
@@ -67,11 +73,21 @@ def test_rerun_and_combine(data_dir, tmp_path):
     multiqc.run(
         data_dir / "modules/fastp/single_end",
         data_dir / "modules/fastp/SAMPLE.json",
-        cfg=ClConfig(output_dir=run_normal_dir),
+        cfg=ClConfig(output_dir=run_normal_dir, strict=True),
     )
 
     with open(run_normal_dir / "multiqc_data" / "multiqc_data.json") as f:
         report_normal_data = json.load(f)
+
+    # # Write report plot data to separate files for inspection
+    # combined_plot_data_file = tmp_path / "combined_plot_data.json"
+    # normal_plot_data_file = tmp_path / "normal_plot_data.json"
+    # with open(combined_plot_data_file, "w") as f:
+    #     json.dump(report_combined_data["report_plot_data"], f, indent=4)
+    # with open(normal_plot_data_file, "w") as f:
+    #     json.dump(report_normal_data["report_plot_data"], f, indent=4)
+    # print(f"\nCombined plot data written to: {combined_plot_data_file}")
+    # print(f"Normal plot data written to: {normal_plot_data_file}")
 
     # Compare only the relevant fields, not the entire report
     # The 'config_analysis_dir_abs' will be different between runs

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -4,10 +4,9 @@ import json
 import multiqc
 from multiqc.core.update_config import ClConfig
 from multiqc.plots.bargraph import BarPlotConfig, BarPlotInputData, CatConf
-from multiqc.plots.box import BoxPlotConfig, BoxPlotInputData
 from multiqc.plots.linegraph import LinePlotConfig, LinePlotNormalizedInputData, Series
 from multiqc.plots.plot import PlotType, plot_anchor
-from multiqc.types import Anchor, SampleName
+from multiqc.types import SampleName
 
 
 def test_rerun_parquet(data_dir, tmp_path):


### PR DESCRIPTION
* Dump plots as JSON blobs
* Keep `to_df` and `from_df` methods only for merging runs
* Add violin/table as a wide table with metrics as columns, when sample are rows.
