### PR TITLE
Make sure multiqc.log has full debug log

### DIFF
--- a/multiqc/core/log_and_rich.py
+++ b/multiqc/core/log_and_rich.py
@@ -45,11 +45,13 @@ def init_log(log_to_file: bool = False):
     # Remove log handlers left from previous calls to multiqc.run. Makes the function idempotent
     logger.handlers.clear()
 
+    # Global level should be the most verbose across all handlers (in our case, file handler is always DEBUG)
+    logger.setLevel(logging.DEBUG)
+
     # Console log level
     log_level = "DEBUG" if config.verbose else "INFO"
     if config.quiet:
         log_level = "WARNING"
-    logger.setLevel(log_level)
 
     # Remove DEBUG level for the PIL.PngImagePlugin and other third-party dependency loggers
     logging.getLogger("PIL").setLevel(logging.INFO)

--- a/multiqc/core/plot_data_store.py
+++ b/multiqc/core/plot_data_store.py
@@ -229,7 +229,7 @@ def save_report_metadata() -> None:
         # Write to file
         metadata_df.to_parquet(parquet_file, compression="gzip")
 
-    logger.debug("Saved report metadata to parquet file")
+    logger.debug(f"Saved parquet file {parquet_file}")
 
 
 def _update_parquet(df: pd.DataFrame, anchor: Anchor) -> None:

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -118,6 +118,9 @@ def write_results() -> None:
             )
         )
 
+    if paths.report_path:
+        logger.debug(f"Report HTML written to {paths.report_path}")
+
     # Zip the data directory if requested
     if config.zip_data_dir and paths.data_dir is not None:
         shutil.make_archive(str(paths.data_dir), format="zip", root_dir=str(paths.data_dir))
@@ -126,8 +129,10 @@ def write_results() -> None:
         except Exception as e:
             logger.warning(f"Couldn't remove data dir: {e}")
 
-    if paths.report_path:
-        logger.debug(f"Report HTML written to {paths.report_path}")
+    # Copy log to the multiqc_data dir. Keeping it in the tmp dir in case if it's an interactive session
+    # that goes beyond this write_results run.
+    if log_and_rich.log_tmp_fn and paths.data_dir:
+        shutil.copy2(log_and_rich.log_tmp_fn, str(paths.data_dir))
 
 
 def _maybe_relative_path(path: Path) -> Path:
@@ -403,11 +408,6 @@ def _write_data_files(data_dir: Path) -> None:
 
     # Modules have run, so data directory should be complete by now. Move its contents.
     logger.debug(f"Moving data file from '{report.data_tmp_dir()}' to '{data_dir}'")
-
-    # Copy log to the multiqc_data dir. Keeping it in the tmp dir in case if it's an interactive session
-    # that goes beyond this write_results run.
-    if log_and_rich.log_tmp_fn:
-        shutil.copy2(log_and_rich.log_tmp_fn, report.data_tmp_dir())
 
     # Save metadata to parquet file
     plot_data_store.save_report_metadata()

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -118,9 +118,6 @@ def write_results() -> None:
             )
         )
 
-    if paths.report_path:
-        logger.debug(f"Report HTML written to {paths.report_path}")
-
     # Zip the data directory if requested
     if config.zip_data_dir and paths.data_dir is not None:
         shutil.make_archive(str(paths.data_dir), format="zip", root_dir=str(paths.data_dir))
@@ -128,6 +125,9 @@ def write_results() -> None:
             util_functions.rmtree_with_retries(paths.data_dir)
         except Exception as e:
             logger.warning(f"Couldn't remove data dir: {e}")
+
+    if paths.report_path:
+        logger.debug(f"Report HTML written to {paths.report_path}")
 
     # Copy log to the multiqc_data dir. Keeping it in the tmp dir in case if it's an interactive session
     # that goes beyond this write_results run.


### PR DESCRIPTION
When the global log level is INFO, even if the file handler log level is DEBUG, it would be downgraded to INFO. So need to always set the global level to DEBUG, and separately set up the level for console handler.

Also making sure that the log file moved to the data dir _after_ all the last log statements are printed.