### PR TITLE
Allow both table id and table anchor in table custom config

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -496,7 +496,7 @@ def test_dash_styles():
 
 
 def test_table_default_sort():
-    from multiqc.plots.table_object import _get_sortlist
+    from multiqc.plots.table_object import _get_sortlist_js
 
     headers: Dict[str, ColumnDict] = {"x": {"title": "Metric X"}, "y": {"title": "Metric Y"}}
     p = table.plot(
@@ -508,9 +508,12 @@ def test_table_default_sort():
         pconfig=table.TableConfig(
             id="table",
             title="Table",
-            defaultsort=[{"column": "y", "direction": "desc"}, {"column": "x", "direction": "asc"}],
+            defaultsort=[
+                {"column": "y", "direction": "desc"},
+                {"column": "x", "direction": "asc"},
+            ],
         ),
     )
     assert isinstance(p, Plot)
-    sortlist = _get_sortlist(p.datasets[0].dt)
-    assert sortlist == "[[2, 1], [1, 0]]"
+    sort_string = _get_sortlist_js(p.datasets[0].dt)
+    assert sort_string == "[[2, 1], [1, 0]]"


### PR DESCRIPTION
Allow both e.g.

```
custom_plot_config:
  samtools-coverage-table_table:
    defaultsort:
      - column: "Mean depth"
```

And

```
custom_plot_config:
  samtools-coverage-table:
    defaultsort:
      - column: "Mean depth"
```

The former one is used internally to distinguish table from the corresponding violin plot, but that detail should be hidden from user.