### PR TITLE
PRINSEQ++: Fix logger warnings

### DIFF
--- a/multiqc/modules/prinseqplusplus/prinseqplusplus.py
+++ b/multiqc/modules/prinseqplusplus/prinseqplusplus.py
@@ -52,7 +52,7 @@ class MultiqcModule(BaseMultiqcModule):
         """Parsing Logs."""
         s_name = f["s_name"]
         if self.prinseqplusplus_data.get(s_name) is not None:
-            log.warn(f"Duplicate sample name found! Overwriting: {s_name}")
+            log.warning(f"Duplicate sample name found! Overwriting: {s_name}")
 
         self.prinseqplusplus_data[s_name] = {}
         self.add_data_source(f, s_name=s_name)


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

## PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
