### PR TITLE
Add samtools ampliconclip stats support

### DIFF
--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -339,8 +339,8 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
 
         # Initialise this new module class and append to list
         else:
-            # Is this file asking to be a sub-section under a parent section?
-            mod_id = ccdict.config.get("parent_id", ccdict.config.get("id", mod_id))
+            # Is this file asking to be a subsection under a parent section?
+            mod_id = ccdict.config.get("parent_id", ccdict.config.get("id", mod_id))  # type: ignore
             section_id: SectionId = ccdict.config.get("section_id", mod_id)
 
             mod_anchor: Optional[Anchor] = None

--- a/multiqc/modules/samtools/ampliconclip.py
+++ b/multiqc/modules/samtools/ampliconclip.py
@@ -197,16 +197,6 @@ def parse_single_report(file_obj):
     """
     parsed_data: Dict[str, Optional[int]] = {k: None for k in ampliconclip_headers}
 
-    # source_to_key = {
-    #     data_dict["source_col"]: {
-    #         "title": data_dict["title"],
-    #         "description": data_dict["description"],
-    #         "shared_key": data_dict["shared_key"],
-    #         "hidden": data_dict["hidden"],
-    #     }
-    #     for data_key, data_dict in ampliconclip_headers.items()
-    # }
-
     source_to_key = {data_dict["source_col"]: data_key for data_key, data_dict in ampliconclip_headers.items()}
     source_to_key["COMMAND"] = None
 

--- a/multiqc/modules/samtools/ampliconclip.py
+++ b/multiqc/modules/samtools/ampliconclip.py
@@ -1,0 +1,212 @@
+import logging
+import re
+from typing import Dict
+
+from multiqc import BaseMultiqcModule, config
+from multiqc.plots import violin
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+# ampliconclip has value thing per line, documented here (search for ampliconclip):
+# http://www.htslib.org/doc/samtools.html
+ampliconclip_headers = {
+    "ampliconclip_total_reads": {
+        "title": "Total Reads",
+        "description": f"Total Reads ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "TOTAL READS",
+    },
+    "ampliconclip_total_clipped": {
+        "title": "Total Clipped",
+        "description": "Total Clipped ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "TOTAL CLIPPED"
+    },
+    "ampliconclip_forward_clipped": {
+        "title": "Forward Clipped",
+        "description": "Forward Clipped ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "FORWARD CLIPPED",
+    },
+    "ampliconclip_reverse_clipped": {
+        "title": "Reverse Clipped",
+        "description": "Reverse Clipped ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "REVERSE CLIPPED",
+    },
+    "ampliconclip_both_clipped": {
+        "title": "Both Clipped",
+        "description": "Both Clipped ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "BOTH CLIPPED",
+    },
+    "ampliconclip_not_clipped": {
+        "title": "Not Clipped",
+        "description": "Not Clipped ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "NOT CLIPPED",
+    },
+    "ampliconclip_excluded_reads": {
+        "title": "Excluded Reads",
+        "description": "Excluded Reads({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "EXCLUDED",
+    },
+    "ampliconclip_filtered_reads": {
+        "title": "Filtered Reads",
+        "description": "Filtered Reads ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "FILTERED",
+    },
+    "ampliconclip_failed_reads": {
+        "title": "Failed Reads",
+        "description": "Failed Reads ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "FAILED",
+    },
+    "ampliconclip_written_reads": {
+        "title": "Written Reads",
+        "description": "Written Reads ({config.read_count_desc})",
+        "shared_key": "read_count",
+        "hidden": True,
+        "source_col": "WRITTEN",
+    },
+}
+
+def parse_samtools_ampliconclip(module: BaseMultiqcModule):
+    """Find Samtools ampliconclip logs and parse their data"""
+
+    print("DEBUG HERE")
+    samtools_ampliconclip: Dict = dict()
+    for f in module.find_log_files("samtools/ampliconclip"):
+        print(f"DEBUG HERE f: {f}")
+        parsed_data = parse_single_report(f["f"])
+        if len(parsed_data) > 0:
+            if f["s_name"] in samtools_ampliconclip:
+                log.debug(f"Duplicate sample name found! Overwriting: {f['s_name']}")
+            module.add_data_source(f, section="ampliconclip")
+            samtools_ampliconclip[f["s_name"]] = parsed_data
+
+    # Filter to strip out ignored sample names
+    samtools_ampliconclip = module.ignore_samples(samtools_ampliconclip)
+
+    if len(samtools_ampliconclip) == 0:
+        return 0
+
+    # Superfluous function call to confirm that it is used in this module
+    # Replace None with actual version if it is available
+    module.add_software_version(None)
+
+    # General Stats Table
+
+    # Get general stats headers using the utility function, will read config.general_stats_columns
+    general_stats_headers = module.get_general_stats_headers(all_headers=ampliconclip_headers)
+
+    # Add headers to general stats table
+    if general_stats_headers:
+        module.general_stats_addcols(samtools_ampliconclip, general_stats_headers, namespace="ampliconclip")
+
+    # Make a violin plot
+    keys_counts = {
+        key: {
+            "shared_key": "read_count",
+            "modify": None,
+            "format": None,
+            "suffix": None,
+            "title": data["title"],
+        }
+        for key, data in ampliconclip_headers.items()
+    }
+
+    data_pct: Dict = dict()
+    for sample, d in samtools_ampliconclip.items():
+        data_pct[sample] = dict()
+        total = d["ampliconclip_total_reads"]
+        if total > 0:
+            for metric, cnt in d.items():
+                data_pct[sample][f"{metric}_pct"] = cnt / total * 100
+    keys_pct = {
+        f"{metric}_pct": dict(
+            title=header["title"],
+            min=0,
+            max=100,
+            suffix="%",
+            shared_key=None,
+        )
+        for metric, header in keys_counts.items()
+    }
+
+    module.add_section(
+        name="Amplicon Clip",
+        anchor="samtools-ampliconclip",
+        description="This module parses the output from <code>samtools ampliconclip</code>",
+        plot=violin.plot(
+            samtools_ampliconclip,
+            headers=keys_counts,
+            pconfig={
+                "id": "samtools-ampliconclip-table",
+                "title": "Samtools: ampliconclip: read count",
+            },
+        ),
+    )
+
+    module.add_section(
+        name="Amplicon Clip: Percentage of total",
+        anchor="samtools-ampliconclip-pct",
+        description="This module parses the output from <code>samtools ampliconclip</code>",
+        plot=violin.plot(
+            data_pct,
+            headers=keys_pct,
+            pconfig={
+                "id": "samtools-ampliconclip-pct-table",
+                "title": "Samtools: ampliconclip: percentage of total",
+            },
+        ),
+    )
+
+    # Write parsed report data to a file (restructure first)
+    module.write_data_file(samtools_ampliconclip, "multiqc_samtools_ampliconclip")
+
+    # Return the number of logs that were found
+    return len(samtools_ampliconclip)
+
+
+def parse_single_report(file_obj):
+    """
+    Take a filename, parse the data assuming it's a ampliconclip file
+    Returns a dictionary of metrics to value
+    """
+    parsed_data: Dict = {
+        k: None
+        for k in ampliconclip_headers
+    }
+
+    source_to_key = {
+        data_dict["source_col"]: data_key
+        for data_key, data_dict in ampliconclip_headers.items()
+    }
+    source_to_key["COMMAND"] = None
+
+    for line in file_obj.splitlines():
+        source, value = line.split(":", maxsplit=1)
+        data_key = source_to_key[source]
+        if data_key is None:
+            continue
+        parsed_data[data_key] = int(value)
+
+    # check that all the values were found
+    for k, v in parsed_data.items():
+        if v is None:
+            raise ValueError(f"Missing value '{k}' for samtools ampliconclip")
+    
+    return parsed_data

--- a/multiqc/modules/samtools/ampliconclip.py
+++ b/multiqc/modules/samtools/ampliconclip.py
@@ -23,7 +23,7 @@ ampliconclip_headers = {
         "description": "Total Clipped ({config.read_count_desc})",
         "shared_key": "read_count",
         "hidden": True,
-        "source_col": "TOTAL CLIPPED"
+        "source_col": "TOTAL CLIPPED",
     },
     "ampliconclip_forward_clipped": {
         "title": "Forward Clipped",
@@ -82,6 +82,7 @@ ampliconclip_headers = {
         "source_col": "WRITTEN",
     },
 }
+
 
 def parse_samtools_ampliconclip(module: BaseMultiqcModule):
     """Find Samtools ampliconclip logs and parse their data"""
@@ -186,15 +187,9 @@ def parse_single_report(file_obj):
     Take a filename, parse the data assuming it's a ampliconclip file
     Returns a dictionary of metrics to value
     """
-    parsed_data: Dict = {
-        k: None
-        for k in ampliconclip_headers
-    }
+    parsed_data: Dict = {k: None for k in ampliconclip_headers}
 
-    source_to_key = {
-        data_dict["source_col"]: data_key
-        for data_key, data_dict in ampliconclip_headers.items()
-    }
+    source_to_key = {data_dict["source_col"]: data_key for data_key, data_dict in ampliconclip_headers.items()}
     source_to_key["COMMAND"] = None
 
     for line in file_obj.splitlines():
@@ -208,5 +203,5 @@ def parse_single_report(file_obj):
     for k, v in parsed_data.items():
         if v is None:
             raise ValueError(f"Missing value '{k}' for samtools ampliconclip")
-    
+
     return parsed_data

--- a/multiqc/modules/samtools/samtools.py
+++ b/multiqc/modules/samtools/samtools.py
@@ -2,6 +2,7 @@ import logging
 
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 
+from .ampliconclip import parse_samtools_ampliconclip
 from .coverage import parse_samtools_coverage
 from .flagstat import parse_samtools_flagstat
 from .idxstats import parse_samtools_idxstats
@@ -16,12 +17,13 @@ class MultiqcModule(BaseMultiqcModule):
     """
     Supported commands:
 
-    - `stats`
+    - `ampliconclip`
+    - `coverage`
     - `flagstats`
     - `idxstats`
-    - `rmdup`
-    - `coverage`
     - `markdup`
+    - `rmdup`
+    - `stats`
 
     #### idxstats
 
@@ -109,12 +111,14 @@ class MultiqcModule(BaseMultiqcModule):
             hidden: false
     ```
 
-    Each samtools submodule has its own namespace in the configuration:
-    - `samtools/stats`
-    - `samtools/flagstat`
-    - `samtools/rmdup`
-    - `samtools/markdup`
+    Each samtools submodule has its own namespace in the configuration
+    - `samtools/ampliconclip`
     - `samtools/coverage`
+    - `samtools/flagstats`
+    - `samtools/idxstats`
+    - `samtools/markdup`
+    - `samtools/rmdup`
+    - `samtools/stats`
 
     """
 
@@ -131,6 +135,10 @@ class MultiqcModule(BaseMultiqcModule):
         n = dict()
 
         # Call submodule functions
+        n["ampliconclip"] = parse_samtools_ampliconclip(self)
+        if n["ampliconclip"] > 0:
+            log.info(f"Found {n['ampliconclip']} stats reports")
+
         n["stats"] = parse_samtools_stats(self)
         if n["stats"] > 0:
             log.info(f"Found {n['stats']} stats reports")

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -888,6 +888,11 @@ samtools/idxstats:
   fn: "*idxstat*"
 samtools/rmdup:
   contents: "[bam_rmdup"
+samtools/ampliconclip:
+  contents:
+    - "COMMAND:"
+    - "samtools ampliconclip"
+  num_lines: 11
 samtools/coverage:
   contents: "#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq"
   num_lines: 10


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Adding support for the stats file from `samtools ampliconclip`.

<!-- If this PR is for a NEW module - delete if not -->

- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
See: https://github.com/MultiQC/test-data/pull/347
- [x] Code is tested and works locally (including with `--strict` flag)
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
