### PR TITLE
fix: type error in python 3.13

### DIFF
--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -339,8 +339,8 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
 
         # Initialise this new module class and append to list
         else:
-            # Is this file asking to be a sub-section under a parent section?
-            mod_id = ccdict.config.get("parent_id", ccdict.config.get("id", mod_id))
+            # Is this file asking to be a subsection under a parent section?
+            mod_id = ccdict.config.get("parent_id", ccdict.config.get("id", mod_id))  # type: ignore
             section_id: SectionId = ccdict.config.get("section_id", mod_id)
 
             mod_anchor: Optional[Anchor] = None


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [x] Code is tested and works locally (including with `--strict` flag)
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
