### PR TITLE
get_s_name changes to get sample name from directory above qualimap outdir

### DIFF
--- a/multiqc/modules/qualimap/__init__.py
+++ b/multiqc/modules/qualimap/__init__.py
@@ -99,7 +99,8 @@ def parse_numerals(
 
 
 def get_s_name(module: BaseMultiqcModule, f):
-    s_name = os.path.basename(os.path.dirname(f["root"]))
+    # Go two directories up: raw_data_qualimapReport → qualimap → sample_name
+    s_name = os.path.basename(os.path.dirname(os.path.dirname(f["root"])))
     s_name = module.clean_s_name(s_name, f)
     if s_name.endswith(".qc"):
         s_name = s_name[:-3]


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Change is specifically to __init__.py for the qualimap module, changing get_s_name function to get the name from the directory above the current output as it's resulting in incorrect sample names in a folder structure as highlighted in issue #3229

This is due to the fact the qualimap module already requires you to run qualimap with the -outdir option, but pulls the sample name for gc_dist and coverage from whatever you call the qualimap -outdir, resulting in constant overwriting of the sample name for these two parameters (in my case results in sample name "qualimap")

Would create issues where qualimap -outdir is not within a directory structure where it inside a folder for each sample separately, but I am not sure how common this would be vs nesting workflow/pipeline output inside a folder per sample

```text
sample01/
├── assembly/
│   └── assembled.fasta
├── mapping/
│   └── mapped.bam
└── qualimap/
    ├── raw_data_qualimapReport/
    └── genome_results.txt

sample02/
├── assembly/
│   └── assembled.fasta
├── mapping/
│   └── mapped.bam
└── qualimap/
    ├── raw_data_qualimapReport/
    └── genome_results.txt
```

Thanks!