### PR TITLE
get_s_name changes to get sample name from directory above qualimap outdir

### DIFF
--- a/multiqc/modules/qualimap/__init__.py
+++ b/multiqc/modules/qualimap/__init__.py
@@ -99,8 +99,14 @@ def parse_numerals(
 
 
 def get_s_name(module: BaseMultiqcModule, f):
-    s_name = os.path.basename(os.path.dirname(f["root"]))
-    s_name = module.clean_s_name(s_name, f)
-    if s_name.endswith(".qc"):
-        s_name = s_name[:-3]
-    return s_name
+    path_parts = os.path.normpath(f["root"]).split(os.sep)
+    try:
+        rpt_index = path_parts.index("raw_data_qualimapReport")
+        if rpt_index >= 2:
+            s_name = path_parts[rpt_index - 2]  # go two levels up
+        else:
+            s_name = os.path.basename(os.path.dirname(f["root"]))
+    except ValueError:
+        # fallback if raw_data_qualimapReport isn't in path
+        s_name = os.path.basename(os.path.dirname(f["root"]))
+    return module.clean_s_name(s_name, f)


### PR DESCRIPTION
This comment contains a description of changes (with reason)
Change is specifically to init.py for the qualimap module, changing get_s_name function to get the name from two levels above the raw_data_qualimapReport folder as it's resulting in incorrect sample names in a directory structure as highlighted in issue https://github.com/MultiQC/MultiQC/issues/3229

This is due to the fact the qualimap module already requires you to run qualimap with the -outdir option, but pulls the sample name for gc_dist and coverage from whatever you call the qualimap -outdir, resulting in constant overwriting of the sample name for these two parameters (in my case results in sample name "qualimap") if you don't also name it your sample name

Would create issues where qualimap -outdir is not within a directory structure where it inside a folder for each sample separately, but I am not sure how common this would be vs nesting workflow/pipeline output inside a folder per sample

```text
sample01/
├── assembly/
│   └── assembled.fasta
├── mapping/
│   └── mapped.bam
└── qualimap/
    ├── raw_data_qualimapReport/
    └── genome_results.txt

sample02/
├── assembly/
│   └── assembled.fasta
├── mapping/
│   └── mapped.bam
└── qualimap/
    ├── raw_data_qualimapReport/
    └── genome_results.txt
```
Thanks!
