### PR TITLE
supporting symbols in scatter plot

### DIFF
--- a/multiqc/templates/default/assets/js/plots/scatter.js
+++ b/multiqc/templates/default/assets/js/plots/scatter.js
@@ -70,6 +70,7 @@ class ScatterPlot extends Plot {
       };
       params.marker.opacity = point["opacity"] ?? params.marker.opacity;
       params.marker.color = point["color"] ?? params.marker.color;
+      params.marker.symbol = point["symbol"] ?? params.marker.symbol;
       if (highlighted.length > 0) params.marker.color = point.highlight ?? "#cccccc";
 
       return {


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] Code is tested and works locally (including with `--strict` flag)

I modified scatter.py and scatter.js to display symbols as well. 