### PR TITLE
Use `OrderedDict` for `saved_raw_data_keys` to increase performance

### DIFF
--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -1110,7 +1110,7 @@ class BaseMultiqcModule:
             i += 1
 
         # To map back keys data to specific module
-        report.saved_raw_data_keys.append(fn)
+        report.saved_raw_data_keys[fn] = None
 
         # Save the file (usualy TSV)
         report.write_data_file(data, fn, sort_cols, data_format)

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -1251,7 +1251,7 @@ data-table-anchor="{dt.anchor}" data-violin-anchor="{violin_anchor}" data-toggle
         report.write_data_file(flatten_raw_vals, fname)
         if config.data_dump_file_write_raw:
             report.write_data_file(flatten_raw_vals, fname, data_format="json")
-            report.saved_raw_data_keys.append(fname)
+            report.saved_raw_data_keys[fname] = None
 
     # Build the bootstrap modal to customise columns and order
     modal = ""

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import sys
 import time
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from datetime import datetime
 from pathlib import Path, PosixPath
 from typing import (
@@ -128,7 +128,7 @@ general_stats_data: Dict[SectionKey, Dict[SampleGroup, List[InputRow]]]
 general_stats_headers: Dict[SectionKey, Dict[ColumnKey, ColumnDict]]
 software_versions: Dict[str, Dict[str, List[str]]]  # map software tools to unique versions
 plot_compressed_json: str
-saved_raw_data_keys: List[str]  # to make sure write_data_file don't overwrite for repeated modules
+saved_raw_data_keys: OrderedDict[str, None]  # to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order.
 saved_raw_data: Dict[str, Any] = dict()  # only populated if preserve_module_raw_data is enabled
 
 
@@ -223,7 +223,7 @@ def reset():
     general_stats_headers = dict()
     software_versions = defaultdict(lambda: defaultdict(list))
     plot_compressed_json = ""
-    saved_raw_data_keys = []
+    saved_raw_data_keys = OrderedDict()
     saved_raw_data = dict()
 
     plot_data_store.reset()
@@ -1166,7 +1166,7 @@ def multiqc_dump_json(data_dir: Path):
                 fh.write(',\n    "report_saved_raw_data": {\n')
 
                 # Write each key's data individually
-                for i, key in enumerate(saved_raw_data_keys):
+                for i, key in enumerate(saved_raw_data_keys.keys()):
                     if (json_path := data_dir / f"{key}.json").exists():
                         fh.write(f'        "{key}": ')
                         # Stream the contents of the individual JSON file

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -128,9 +128,8 @@ general_stats_data: Dict[SectionKey, Dict[SampleGroup, List[InputRow]]]
 general_stats_headers: Dict[SectionKey, Dict[ColumnKey, ColumnDict]]
 software_versions: Dict[str, Dict[str, List[str]]]  # map software tools to unique versions
 plot_compressed_json: str
-saved_raw_data_keys: OrderedDict[
-    str, None
-]  # to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order.
+# to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order:
+saved_raw_data_keys: OrderedDict[str, None]
 saved_raw_data: Dict[str, Any] = dict()  # only populated if preserve_module_raw_data is enabled
 
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -128,7 +128,9 @@ general_stats_data: Dict[SectionKey, Dict[SampleGroup, List[InputRow]]]
 general_stats_headers: Dict[SectionKey, Dict[ColumnKey, ColumnDict]]
 software_versions: Dict[str, Dict[str, List[str]]]  # map software tools to unique versions
 plot_compressed_json: str
-saved_raw_data_keys: OrderedDict[str, None]  # to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order.
+saved_raw_data_keys: OrderedDict[
+    str, None
+]  # to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order.
 saved_raw_data: Dict[str, Any] = dict()  # only populated if preserve_module_raw_data is enabled
 
 


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

I have a workflow with about 2000 charts in one section. This causes multiqc to keep rolling IDs to give each chart a unique ID in the section. Specifically this logic: https://github.com/MultiQC/MultiQC/blob/581178b725fd185546f8a2cbb56c78df3df5183e/multiqc/base_module.py#L1108

Now the problem: `saved_raw_data_keys` is a list. On the 2000th chart, it loops 2000 times looking up in a list of 1999 elements. I believe this is n^2 complexity. No bueno.

From where this logic [was introduced](https://github.com/MultiQC/MultiQC/pull/3044), it seems that insertion order is important. For this reason, I went with an `OrderedDict` instead of a `set`. I also considered sorting `saved_raw_data_keys` at _read_ time, but I wasn't sure if it needs to be in insertion order or just stably ordered. If the latter, we could just use `sorted(...)` when reading it. If the former, an `OrderedDict` solves it (I think).

The net effect is a task went from 5h23m to 20m.

Side note: I checked the [dev docs](https://docs.seqera.io/multiqc/development/contributing) for instructions on how to lint/typecheck/test. I didn't find anything. Forgive me if this is documented somewhere.