### PR TITLE
Use universal `config.use_filename_as_sample_name`, depreate module-specific flags

### DIFF
--- a/docs/markdown/getting_started/config.md
+++ b/docs/markdown/getting_started/config.md
@@ -338,14 +338,22 @@ use_filename_as_sample_name: true
 ```
 
 This affects all modules and all search patterns. If you want to limit this to just
-one or more specific search patterns, you can do by giving a list:
+one or more specific modules or search patterns, you can do by giving a list:
 
 ```yaml
 use_filename_as_sample_name:
-  - cutadapt
-  - picard/gcbias
-  - picard/markdups
+  - verifybamid
+  - verifybamid/selfsm
+  - prokka
+  - trimmomatic
+  - fastp
+  - picard
 ```
+
+You can specify either:
+
+- Module anchors (e.g., `verifybamid`, `prokka`) to apply to all search patterns for that module
+- Search pattern keys (e.g., `verifybamid/selfsm`, `picard/gcbias`) to apply to specific patterns
 
 Note that this should be the search pattern key and not just the module name.
 This is because some modules search for multiple files.

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -776,15 +776,23 @@ class BaseMultiqcModule:
 
         # For modules setting s_name from file contents, set s_name back to the filename
         # (if wanted in the config)
-        if filename is not None and (
-            config.use_filename_as_sample_name is True
-            or (
-                isinstance(config.use_filename_as_sample_name, list)
-                and search_pattern_key is not None
-                and search_pattern_key in config.use_filename_as_sample_name
-            )
-        ):
-            trimmed_name = SampleName(filename)
+        if filename is not None:
+            should_use_filename = False
+
+            # Check if we should use filename for this specific module/pattern
+            if isinstance(config.use_filename_as_sample_name, list):
+                # Check for module anchor (e.g., "verifybamid")
+                if self.anchor in config.use_filename_as_sample_name:
+                    should_use_filename = True
+                # Check for search pattern key (e.g., "verifybamid/selfsm")
+                elif search_pattern_key is not None and search_pattern_key in config.use_filename_as_sample_name:
+                    should_use_filename = True
+            # Check if we should use filename for all modules
+            elif config.use_filename_as_sample_name is True:
+                should_use_filename = True
+
+            if should_use_filename:
+                trimmed_name = SampleName(filename)
 
         # if s_name comes from file contents, it may have a file path
         # For consistency with other modules, we keep just the basename

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -194,7 +194,7 @@ export_plot_formats: List[str]
 filesearch_file_shared: List[str]
 custom_content: Dict
 fn_clean_sample_names: bool
-use_filename_as_sample_name: bool
+use_filename_as_sample_name: Union[bool, List[str]]
 fn_clean_exts: List[CleanPatternT]
 fn_clean_trim: List[str]
 fn_ignore_files: List[str]

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -205,7 +205,16 @@ custom_content:
 fn_clean_sample_names: true
 
 # Option to use the filename as the sample name if desired
-# Set to True to apply for all modules. Define a list of search pattern keys to be specific.
+# Set to True to apply for all modules. Define a list of module/search pattern keys to be specific.
+# Examples:
+# use_filename_as_sample_name: true  # Apply to all modules
+# use_filename_as_sample_name:       # Apply to specific modules/patterns
+#   - verifybamid
+#   - verifybamid/selfsm
+#   - prokka
+#   - trimmomatic
+#   - fastp
+#   - picard
 use_filename_as_sample_name: false
 
 # Used for cleaning sample names. Should be strings.

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel
 
 from multiqc import config, report
 from multiqc.core import log_and_rich, plugin_hooks
-from multiqc.utils.config_schema import AiProviderLiteral
 from multiqc.core.exceptions import RunError
+from multiqc.utils.config_schema import AiProviderLiteral
 
 logger = logging.getLogger(__name__)
 

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -28,7 +28,7 @@ class ClConfig(BaseModel):
     template: Optional[str] = None
     require_logs: Optional[bool] = None
     output_dir: Optional[Union[str, Path]] = None
-    use_filename_as_sample_name: Optional[bool] = None
+    use_filename_as_sample_name: Optional[Union[bool, List[str]]] = None
     replace_names: Optional[str] = None
     sample_names: Optional[str] = None
     sample_filters: Optional[str] = None

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -174,7 +174,22 @@ class MultiqcModule(BaseMultiqcModule):
             return None, {}
 
         s_name = None
-        if getattr(config, "fastp", {}).get("s_name_filenames", False):
+        # Check if we should use filename instead of parsed sample name
+        should_use_filename = False
+        if isinstance(config.use_filename_as_sample_name, list):
+            # Check for module anchor
+            if self.anchor in config.use_filename_as_sample_name:
+                should_use_filename = True
+        elif config.use_filename_as_sample_name is True:
+            should_use_filename = True
+        elif getattr(config, "fastp", {}).get("s_name_filenames", False):
+            # Deprecated option - warn user
+            log.warning(
+                "The 'fastp.s_name_filenames' config option is deprecated. Use the global 'use_filename_as_sample_name' option instead."
+            )
+            should_use_filename = True
+
+        if should_use_filename:
             s_name = f["s_name"]
 
         if s_name is None:

--- a/multiqc/modules/picard/util.py
+++ b/multiqc/modules/picard/util.py
@@ -122,9 +122,23 @@ def extract_sample_name(
     MultiQC needs to take the sample name elsewhere rather than the file name,
     so it tries to parse the command line recorded in the output header.
 
-    This approach can be disabled with `config.picard_config.s_name_filenames`
+    This approach can be disabled with `config.use_filename_as_sample_name`
     """
-    if getattr(config, "picard_config", {}).get("s_name_filenames", False):
+    should_use_filename = False
+    if isinstance(config.use_filename_as_sample_name, list):
+        # Check for module anchor
+        if "picard" in config.use_filename_as_sample_name:
+            should_use_filename = True
+    elif config.use_filename_as_sample_name is True:
+        should_use_filename = True
+    elif getattr(config, "picard_config", {}).get("s_name_filenames", False):
+        # Deprecated option - warn user
+        log.warning(
+            "The 'picard_config.s_name_filenames' config option is deprecated. Use the global 'use_filename_as_sample_name' option instead."
+        )
+        should_use_filename = True
+
+    if should_use_filename:
         return None
 
     # Name of the option that contains the name of the input file to fetch the sample name.

--- a/multiqc/modules/prokka/prokka.py
+++ b/multiqc/modules/prokka/prokka.py
@@ -13,7 +13,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     - `prokka_table`: default `False`. Show a table in the report.
     - `prokka_barplot`: default `True`. Show a barplot in the report.
-    - `prokka_fn_snames`: default `False`. Use filenames for sample names (see below).
+    - `prokka_fn_snames`: default `False`. Use filenames for sample names (DEPRECATED - use global `use_filename_as_sample_name` instead).
 
     Sample names are generated using the first line in the prokka reports:
 
@@ -25,7 +25,7 @@ class MultiqcModule(BaseMultiqcModule):
     the third is the sample name. So the above will give a sample name of
     `Sample1`.
 
-    If you prefer, you can set `config.prokka_fn_snames` to `True` and MultiQC
+    If you prefer, you can set `config.use_filename_as_sample_name` to `True` and MultiQC
     will instead use the log filename as the sample name.
     """
 
@@ -136,7 +136,21 @@ class MultiqcModule(BaseMultiqcModule):
             organism = first_line.strip().split(":", 1)[1]
             s_name = f["s_name"]
         # Don't try to guess sample name if requested in the config
-        if getattr(config, "prokka_fn_snames", False):
+        should_use_filename = False
+        if isinstance(config.use_filename_as_sample_name, list):
+            # Check for module anchor
+            if self.anchor in config.use_filename_as_sample_name:
+                should_use_filename = True
+        elif config.use_filename_as_sample_name is True:
+            should_use_filename = True
+        elif getattr(config, "prokka_fn_snames", False):
+            # Deprecated option - warn user
+            log.warning(
+                "The 'prokka_fn_snames' config option is deprecated. Use the global 'use_filename_as_sample_name' option instead."
+            )
+            should_use_filename = True
+
+        if should_use_filename:
             s_name = f["s_name"]
 
         if s_name in self.prokka:

--- a/multiqc/modules/trimmomatic/trimmomatic.py
+++ b/multiqc/modules/trimmomatic/trimmomatic.py
@@ -23,9 +23,10 @@ class MultiqcModule(BaseMultiqcModule):
     the filenames as sample names instead. To do so, use the following config option:
 
     ```yaml
-    trimmomatic:
-      s_name_filenames: true
+    use_filename_as_sample_name: true
     ```
+
+    Note: The old `trimmomatic.s_name_filenames` option is deprecated and will be removed in a future version.
     """
 
     def __init__(self):
@@ -75,7 +76,21 @@ class MultiqcModule(BaseMultiqcModule):
 
     def parse_trimmomatic(self, f):
         s_name = None
-        if getattr(config, "trimmomatic", {}).get("s_name_filenames", False):
+        should_use_filename = False
+        if isinstance(config.use_filename_as_sample_name, list):
+            # Check for module anchor
+            if self.anchor in config.use_filename_as_sample_name:
+                should_use_filename = True
+        elif config.use_filename_as_sample_name is True:
+            should_use_filename = True
+        elif getattr(config, "trimmomatic", {}).get("s_name_filenames", False):
+            # Deprecated option - warn user
+            log.warning(
+                "The 'trimmomatic.s_name_filenames' config option is deprecated. Use the global 'use_filename_as_sample_name' option instead."
+            )
+            should_use_filename = True
+
+        if should_use_filename:
             s_name = f["s_name"]
         for line in f["f"]:
             # Get the sample name

--- a/multiqc/modules/verifybamid/verifybamid.py
+++ b/multiqc/modules/verifybamid/verifybamid.py
@@ -15,6 +15,16 @@ class MultiqcModule(BaseMultiqcModule):
 
     If no chip data was parsed, these columns will not be added to the MultiQC report.
 
+    By default, the module extracts sample names from the first column of the `.selfSM` file.
+    If you prefer to use the filename as the sample name instead, you can set the global
+    `use_filename_as_sample_name` option:
+
+    ```yaml
+    use_filename_as_sample_name:
+      - verifybamid
+      - verifybamid/selfsm
+    ```
+
     Should you wish to remove one of these columns from the general statistics table add the below lines to the table_columns_visible section of your config file
 
         table_columns_visible:
@@ -120,7 +130,16 @@ class MultiqcModule(BaseMultiqcModule):
             # for all rows after the first
             else:
                 # clean the sample name (first column) and assign to s_name
-                s_name = self.clean_s_name(s[0], f)
+                if config.use_filename_as_sample_name is True or (
+                    isinstance(config.use_filename_as_sample_name, list)
+                    and (
+                        self.anchor in config.use_filename_as_sample_name
+                        or "verifybamid/selfsm" in config.use_filename_as_sample_name
+                    )
+                ):
+                    s_name = self.clean_s_name(f["s_name"], f)
+                else:
+                    s_name = self.clean_s_name(s[0], f)
                 # create a dictionary entry with the first column as a key (sample name) and empty dictionary as a value
                 parsed_data[s_name] = {}
                 # for each item in list of items in the row

--- a/multiqc/utils/config_schema.json
+++ b/multiqc/utils/config_schema.json
@@ -2204,11 +2204,17 @@
           "type": "boolean"
         },
         {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
           "type": "null"
         }
       ],
       "default": null,
-      "description": "Use filename as sample name",
+      "description": "Use filename as sample name (can be bool for all modules or list for specific modules/patterns)",
       "title": "Use Filename As Sample Name"
     },
     "fn_clean_exts": {

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -233,7 +233,7 @@ class MultiQCConfig(BaseModel):
     custom_content: Optional[Dict[str, Any]] = Field(None, description="Custom content")
     fn_clean_sample_names: Optional[bool] = Field(None, description="Clean sample names")
     use_filename_as_sample_name: Optional[Union[bool, List[str]]] = Field(
-        None,
+        False,
         description="Use filename as sample name (can be bool for all modules or list for specific modules/patterns)",
     )
     fn_clean_exts: Optional[List[Union[str, CleanPattern]]] = Field(

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -232,7 +232,10 @@ class MultiQCConfig(BaseModel):
     filesearch_file_shared: Optional[List[str]] = Field(None, description="Filesearch file shared")
     custom_content: Optional[Dict[str, Any]] = Field(None, description="Custom content")
     fn_clean_sample_names: Optional[bool] = Field(None, description="Clean sample names")
-    use_filename_as_sample_name: Optional[bool] = Field(None, description="Use filename as sample name")
+    use_filename_as_sample_name: Optional[Union[bool, List[str]]] = Field(
+        None,
+        description="Use filename as sample name (can be bool for all modules or list for specific modules/patterns)",
+    )
     fn_clean_exts: Optional[List[Union[str, CleanPattern]]] = Field(
         None, description="Extensions to clean from sample names"
     )

--- a/tests/test_modules_run.py
+++ b/tests/test_modules_run.py
@@ -94,6 +94,8 @@ def test_write_data_file(monkeypatch, tmp_path, config_options, expected_to_writ
         (True, False, None, "SAMPLE_FROM_FILENAME.stderr"),
         (None, None, True, "subdir | SAMPLE_FROM_CONTENTS"),
         (True, None, True, "subdir | SAMPLE_FROM_FILENAME"),
+        (["trimmomatic"], None, None, "SAMPLE_FROM_FILENAME"),
+        (["other_module"], None, None, "SAMPLE_FROM_CONTENTS"),  # Should not affect trimmomatic
     ],
 )
 def test_use_filename_as_sample_name(


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/2571
Fix https://github.com/MultiQC/MultiQC/issues/3239
