### PR TITLE
Add `boxplot_boxpoints` config option to pass to box plot

### DIFF
--- a/docs/markdown/development/plots.md
+++ b/docs/markdown/development/plots.md
@@ -393,6 +393,27 @@ html = box.plot(data, pconfig=...)
 Similarly to other plot types, multiple datasets can be passed as `data`, along with
 dataset-specific configurations provided with the `pconfig["data_labels"]` option.
 
+### Box plot outlier display
+
+The global configuration option `boxplot_boxpoints` controls how outliers are displayed in box plots by passing the value directly to Plotly's `boxpoints` parameter. This setting can be configured in your MultiQC config file:
+
+```yaml
+boxplot_boxpoints: "outliers" # Default: show only outliers
+```
+
+Available options (as defined by [Plotly's box trace reference](https://plotly.com/python/reference/box/#box-boxpoints)):
+
+- `"outliers"` (default): Show only outlier points beyond the whiskers
+- `"all"`: Show all data points
+- `"suspectedoutliers"`: Show only suspected outliers (points beyond 1.5 _ IQR but within 3 _ IQR)
+- `false`: Hide all data points, showing only the box and whiskers
+
+This setting applies to all box plots in the report and can be useful for:
+
+- Reducing visual clutter when dealing with many samples
+- Highlighting specific outlier patterns
+- Creating cleaner visualizations for presentations
+
 ## Scatter plots
 
 Scatter plots work in almost exactly the same way as line plots. Most (if not all)

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -137,6 +137,7 @@ plots_defer_loading_numseries: int
 num_datasets_plot_limit: int  # DEPRECATED in favour of plots_number_of_series_to_defer_loading
 lineplot_number_of_points_to_hide_markers: int
 barplot_legend_on_bottom: bool
+boxplot_boxpoints: Union[str, bool]
 violin_downsample_after: Optional[int]
 violin_min_threshold_outliers: int
 violin_min_threshold_no_points: int

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -90,6 +90,7 @@ plots_defer_loading_numseries: 100 # plot will require user to press button to r
 num_datasets_plot_limit: 100 # DEPRECATED in favour of plots_defer_loading_numseries
 lineplot_number_of_points_to_hide_markers: 50 # sum of data points in all samples
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)
+boxplot_boxpoints: "outliers" # box plot outlier display: "outliers", "all", "suspectedoutliers", or false
 violin_downsample_after: 2000 # downsample data for violin plot starting from this number os samples
 violin_min_threshold_outliers: 100 # for more than this number of samples, show only outliers
 violin_min_threshold_no_points: 1000 # for more than this number of samples, show no points

--- a/multiqc/plots/box.py
+++ b/multiqc/plots/box.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union, cast
 import plotly.graph_objects as go  # type: ignore
 import polars as pl
 
-from multiqc import report
+from multiqc import config, report
 from multiqc.plots.plot import BaseDataset, NormalizedPlotInputData, PConfig, Plot, PlotType, plot_anchor
 from multiqc.plots.utils import determine_barplot_height
 from multiqc.types import Anchor, SampleName
@@ -49,7 +49,7 @@ class Dataset(BaseDataset):
         dataset.data = list(reversed(dataset.data))
 
         dataset.trace_params.update(
-            boxpoints="outliers",
+            boxpoints=config.boxplot_boxpoints if config.boxplot_boxpoints is not None else "outliers",
             jitter=0.5,
             orientation="h",
             marker=dict(

--- a/multiqc/templates/default/assets/js/plots/box.js
+++ b/multiqc/templates/default/assets/js/plots/box.js
@@ -92,6 +92,11 @@ class BoxPlot extends Plot {
     return this.filteredSettings.map((sample, sampleIdx) => {
       let params = JSON.parse(JSON.stringify(traceParams)); // deep copy
 
+      // Override boxpoints with global config if available
+      if (mqc_config.boxplot_boxpoints !== undefined) {
+        params.boxpoints = mqc_config.boxplot_boxpoints;
+      }
+
       if (highlighted.length > 0) {
         if (sample.highlight !== null) {
           params.marker.color = sample.highlight;

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -30,6 +30,7 @@ page contents, it's machine-readable tags for browsers and search engines.
     "highlight_regex": config.highlight_regex,
     "decimalPoint_format": config.decimalPoint_format,
     "thousandsSep_format": config.thousandsSep_format,
+    "boxplot_boxpoints": config.boxplot_boxpoints,
 } | tojson
 }}</script>
 

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -155,6 +155,7 @@ class MultiQCConfig(BaseModel):
     barplot_legend_on_bottom: Optional[bool] = Field(
         None, description="Place bar plot legend at the bottom (not recommended)"
     )
+    boxplot_boxpoints: Optional[Union[str, bool]] = Field(None, description="Boxplot boxpoints setting")
     violin_downsample_after: Optional[int] = Field(
         None, description="Downsample data for violin plot starting from this number os samples"
     )

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -143,7 +143,7 @@ def test_boxplot_custom_boxpoints(boxpoints_value):
     # Test with "all" boxpoints (show all data points)
     plot_all = _verify_rendered(
         box.plot(
-            data,
+            data,  # type: ignore
             box.BoxPlotConfig(id=f"box_{boxpoints_value}", title=f"Box Plot - {boxpoints_value}"),
         )
     )

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -111,6 +111,48 @@ def test_boxplot():
     )
 
 
+@pytest.mark.parametrize(
+    "boxpoints_value",
+    ["outliers", "all", "suspectedoutliers", False],
+)
+def test_boxplot_custom_boxpoints(boxpoints_value):
+    """
+    Test box plot with custom boxpoints configuration using global config
+    """
+    config.boxplot_boxpoints = boxpoints_value
+
+    data = {
+        "Sample": [
+            # Tight distribution with few outliers
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            # Outliers
+            20,
+            50,
+        ],
+    }
+    # Test with "all" boxpoints (show all data points)
+    plot_all = _verify_rendered(
+        box.plot(
+            data,
+            box.BoxPlotConfig(id=f"box_{boxpoints_value}", title=f"Box Plot - {boxpoints_value}"),
+        )
+    )
+
+    plot_data_all = report.plot_data[plot_all.anchor]
+    trace_params_all = plot_data_all["datasets"][0]["trace_params"]
+    assert trace_params_all["boxpoints"] == boxpoints_value
+
+
 ############################################
 # Plot special cases.
 


### PR DESCRIPTION
Option to specify how to display outliers in a box plot.

Fix https://github.com/MultiQC/MultiQC/issues/3243 and https://community.seqera.io/t/hide-outliers-in-boxplot/2215