### PR TITLE
Custom content: allow passing line plot series as list of tuples in JSON

### DIFF
--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -521,9 +521,17 @@ class MultiqcModule(BaseMultiqcModule):
             # Try to coerce x-axis to numeric
             if plot_type in [PlotType.LINE, PlotType.SCATTER]:
                 try:
+                    # a series is represented by a dict
                     ccdict.data = [{k: {float(x): v[x] for x in v} for k, v in ds.items()} for ds in plot_datasets]
-                except ValueError:
-                    pass
+                except (ValueError, TypeError):
+                    try:
+                        # a series is represented by a list of paris
+                        ccdict.data = [
+                            {_sname: {float(x): float(y) for x, y in _sdata} for _sname, _sdata in ds.items()}
+                            for ds in plot_datasets
+                        ]
+                    except ValueError:
+                        pass
 
             # Table
             if plot_type in [PlotType.TABLE, PlotType.VIOLIN]:

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -477,7 +477,7 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
                     sample_names.append(SampleName(s))
                 x_to_y = raw_data_by_sample[s]
                 if not isinstance(x_to_y, dict) and isinstance(x_to_y, Sequence):
-                    if isinstance(x_to_y[0], tuple):
+                    if isinstance(x_to_y[0], tuple) or (isinstance(x_to_y[0], list) and len(x_to_y[0]) == 2):
                         x_to_y = dict(x_to_y)
                     else:
                         x_to_y = {i: y for i, y in enumerate(x_to_y)}


### PR DESCRIPTION
Fix https://github.com/MultiQC/MultiQC/issues/3138

This config doesn't preserve the order of data points:

```json
{
  "id": "custom_linegraph",
  "section_name": "Custom Line Graph",
  "plot_type": "linegraph",
  "data": {
    "Row_1": {
      "0": 0,
      "31": 0,
      "32": 100,
      "34": 100,
      "35": 0,
      "59": 0,
      "60": 100,
      "146": 100,
      "147": 0,
      "300": 0
    }
  }
}
```

Allow passing values as a list of tuples instead:

```json
{
  "id": "custom_linegraph",
  "section_name": "Custom Line Graph",
  "plot_type": "linegraph",
  "data": {
    "Row_1": [
      [0, 0],
      [31, 0],
      [32, 100],
      [34, 100],
      [35, 0],
      [59, 0],
      [60, 100],
      [146, 100],
      [147, 0],
      [300, 0]
    ]
  }
}
```