### PR TITLE
Add support for `config.plot_theme`

### DIFF
--- a/docs/markdown/development/plots.md
+++ b/docs/markdown/development/plots.md
@@ -59,6 +59,15 @@ a filename when exporting plots, and all plots should have a title when exported
 Plot titles should use the format _Module name: Plot name_ (this is partly for
 ease of use within MegaQC and other downstream tools).
 
+### Plotly themes
+
+MultiQC plots use Plotly for visualization. You can customize the appearance of all plots by setting a Plotly theme using the `plot_theme` configuration option. This option accepts any [registered Plotly theme](https://plotly.com/python/templates/#view-available-themes)
+name as a string.
+
+```yaml
+plot_theme: "plotly_dark"
+```
+
 ## Bar graphs
 
 Simple data can be plotted in bar graphs. Many MultiQC modules make use

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -134,6 +134,7 @@ plots_export_font_scale: float
 plots_force_interactive: bool
 plots_flat_numseries: int
 plots_defer_loading_numseries: int
+plot_theme: Optional[str]
 num_datasets_plot_limit: int  # DEPRECATED in favour of plots_number_of_series_to_defer_loading
 lineplot_number_of_points_to_hide_markers: int
 barplot_legend_on_bottom: bool

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -87,6 +87,7 @@ plots_export_font_scale: 1.0 # set to 1.5 for bigger fonts
 plots_force_interactive: false
 plots_flat_numseries: 2000
 plots_defer_loading_numseries: 100 # plot will require user to press button to render plot
+plot_theme: null # Plotly theme template - any registered Plotly theme name (e.g. "plotly", "plotly_white", "plotly_dark", "ggplot2", "seaborn", "simple_white", "none")
 num_datasets_plot_limit: 100 # DEPRECATED in favour of plots_defer_loading_numseries
 lineplot_number_of_points_to_hide_markers: 50 # sum of data points in all samples
 barplot_legend_on_bottom: false # place legend at the bottom of the bar plot (not recommended)

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -721,17 +721,17 @@ class HeatmapPlot(Plot[Dataset, HeatmapConfig]):
                 f"""
                 <div class="btn-group" role="group">
                     <button
-                        type="button" 
-                        class="btn btn-default btn-sm {"" if self.pconfig.cluster_switch_clustered_active else "active"}" 
-                        data-action="unclustered" 
+                        type="button"
+                        class="btn btn-default btn-sm {"" if self.pconfig.cluster_switch_clustered_active else "active"}"
+                        data-action="unclustered"
                         data-plot-anchor="{self.anchor}"
                     >
                         Sorted by sample
                     </button>
                     <button
-                        type="button" 
-                        class="btn btn-default btn-sm {"active" if self.pconfig.cluster_switch_clustered_active else ""}" 
-                        data-action="clustered" 
+                        type="button"
+                        class="btn btn-default btn-sm {"active" if self.pconfig.cluster_switch_clustered_active else ""}"
+                        data-action="clustered"
                         data-plot-anchor="{self.anchor}"
                     >
                         Clustered

--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -43,6 +43,34 @@ logger = logging.getLogger(__name__)
 
 check_plotly_version()
 
+# Create and register MultiQC default Plotly template
+multiqc_plotly_template = dict(
+    layout=go.Layout(
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        font=dict(family="'Lucida Grande', 'Open Sans', verdana, arial, sans-serif"),
+        colorway=mqc_colour.mqc_colour_scale.COLORBREWER_SCALES["plot_defaults"],
+        xaxis=dict(
+            gridcolor="rgba(0,0,0,0.05)",
+            zerolinecolor="rgba(0,0,0,0.05)",
+            color="rgba(0,0,0,0.3)",  # axis labels
+            tickfont=dict(size=10, color="rgba(0,0,0,1)"),
+        ),
+        yaxis=dict(
+            gridcolor="rgba(0,0,0,0.05)",
+            zerolinecolor="rgba(0,0,0,0.05)",
+            color="rgba(0,0,0,0.3)",  # axis labels
+            tickfont=dict(size=10, color="rgba(0,0,0,1)"),
+        ),
+        title=dict(font=dict(size=20)),
+        modebar=dict(
+            bgcolor="rgba(0, 0, 0, 0)",
+            color="rgba(0, 0, 0, 0.5)",
+            activecolor="rgba(0, 0, 0, 1)",
+        ),
+    )
+)
+
 
 class FlatLine(ValidatedConfig):
     """
@@ -586,33 +614,24 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
         if showlegend is None:
             showlegend = True if flat else False
 
+        # Use the specified template or default to multiqc
+        template = config.plot_theme if config.plot_theme else go.layout.Template(multiqc_plotly_template)
+
         layout: go.Layout = go.Layout(
+            template=template,
             title=go.layout.Title(
                 text=pconfig.title,
                 xanchor="center",
                 x=0.5,
-                font=dict(size=20),
             ),
             xaxis=go.layout.XAxis(
-                gridcolor="rgba(0,0,0,0.05)",
-                zerolinecolor="rgba(0,0,0,0.05)",
-                color="rgba(0,0,0,0.3)",  # axis labels
-                tickfont=dict(size=10, color="rgba(0,0,0,1)"),
                 automargin=True,  # auto-expand axis to fit the tick labels
             ),
             yaxis=go.layout.YAxis(
-                gridcolor="rgba(0,0,0,0.05)",
-                zerolinecolor="rgba(0,0,0,0.05)",
-                color="rgba(0,0,0,0.3)",  # axis labels
-                tickfont=dict(size=10, color="rgba(0,0,0,1)"),
                 automargin=True,  # auto-expand axis to fit the tick labels
             ),
             height=height,
             width=width,
-            paper_bgcolor="white",
-            plot_bgcolor="white",
-            font=dict(family="'Lucida Grande', 'Open Sans', verdana, arial, sans-serif"),
-            colorway=mqc_colour.mqc_colour_scale.COLORBREWER_SCALES["plot_defaults"],
             autosize=True,
             margin=go.layout.Margin(
                 pad=5,  # pad sample names in a bar graph a bit
@@ -623,11 +642,6 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
             ),
             hoverlabel=go.layout.Hoverlabel(
                 namelength=-1,  # do not crop sample names inside hover label <extra></extra>
-            ),
-            modebar=go.layout.Modebar(
-                bgcolor="rgba(0, 0, 0, 0)",
-                color="rgba(0, 0, 0, 0.5)",
-                activecolor="rgba(0, 0, 0, 1)",
             ),
             showlegend=showlegend,
             legend=go.layout.Legend(
@@ -640,6 +654,7 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
             if flat
             else None,
         )
+
         # Layout update for the counts/percentage switch
         pct_axis_update = dict(
             ticksuffix="%",
@@ -1248,7 +1263,7 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
         if not config.no_ai:
             ai_btn = f"""
             <div class="ai-plot-buttons-container" style="float: right;">
-                <button 
+                <button
                     class="btn btn-default btn-sm ai-copy-content ai-copy-content-plot ai-copy-button-wrapper"
                     style="margin-left: 1px;"
                     data-section-anchor="{section_anchor}"
@@ -1256,7 +1271,7 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
                     data-module-anchor="{module_anchor}"
                     data-view="plot"
                     type="button"
-                    data-toggle="tooltip" 
+                    data-toggle="tooltip"
                     title="Copy plot data for use with AI tools like ChatGPT"
                 >
                     <span style="vertical-align: baseline">
@@ -1281,7 +1296,7 @@ class Plot(BaseModel, Generic[DatasetT, PConfigT]):
                     data-action="generate"
                     data-clear-text="Clear summary"
                     type="button"
-                    data-toggle="tooltip" 
+                    data-toggle="tooltip"
                     aria-controls="{section_anchor}_ai_summary_wrapper"
                 >
                     <span style="vertical-align: baseline">

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -275,7 +275,6 @@ class Dataset(BaseDataset):
         """
         Create a Plotly figure for a dataset
         """
-
         fig = go.Figure(layout=layout)
         MAX_ANNOTATIONS = 10  # Maximum number of dots to be annotated directly on the plot
         n_annotated = len([el for el in self.points if "annotation" in el])

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -149,6 +149,11 @@ class MultiQCConfig(BaseModel):
     plots_defer_loading_numseries: Optional[int] = Field(
         None, description="Number of series to defer loading - user will need to press button to render plot"
     )
+    plot_theme: Optional[str] = Field(
+        None,
+        description="Plotly theme template - any registered Plotly theme name "
+        "(e.g. 'plotly', 'plotly_white', 'plotly_dark', 'ggplot2', 'seaborn', 'simple_white', 'none')",
+    )
     lineplot_number_of_points_to_hide_markers: Optional[int] = Field(
         None, description="Number of points to hide markers - sum of data points in all samples"
     )
@@ -263,11 +268,11 @@ class MultiQCConfig(BaseModel):
 
     parquet_format: Optional[Literal["long", "wide"]] = Field(
         None,
-        description="""Parquet table format. Long format has columns 'sample_name', 'metric_name' and 'val_raw', 
-        'val_raw_type', 'val_str'. To select values for a certain metric, you need to filter based on its name. In contrast, 
-        the wide format has columns named after metrics, prefixed with table name and optional namespace. It's easier to 
+        description="""Parquet table format. Long format has columns 'sample_name', 'metric_name' and 'val_raw',
+        'val_raw_type', 'val_str'. To select values for a certain metric, you need to filter based on its name. In contrast,
+        the wide format has columns named after metrics, prefixed with table name and optional namespace. It's easier to
         for analytics, however, might hit limits on the maximal number of columns in certain edge cases, as well as
-        have potential issues in case of mixed types (i.e. if some values are non-numeric, as Parquet requires a column 
+        have potential issues in case of mixed types (i.e. if some values are non-numeric, as Parquet requires a column
         to have a single type).
         """,
     )


### PR DESCRIPTION
This PR adds a new `plot_theme` configuration option that allows users to customize the visual appearance of all plots in MultiQC reports using any registered Plotly theme.

- Added `plot_theme` configuration option (accepts any Plotly theme name like `"plotly_dark"`, `"ggplot2"`, `"seaborn"`, etc.)
- Created a custom MultiQC default plotly theme that preserves existing styling when no theme is specified
- Refactored plot initialization to use templates instead of hardcoded layout properties
- Updated configuration schema and documentation

Users can now set their preferred theme, eg: `plot_theme: "plotly_dark"`  

When no theme is specified, plots use the same styling as before. When a theme is set, all plots consistently use that theme's styling.