### PR TITLE
Lighten colours with alpha instead of admixing white

### DIFF
--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -23,10 +23,10 @@ class MultiqcModule(BaseMultiqcModule):
             extra="""
             Somalier can be used to find sample swaps or duplicates in cancer
             projects, where there is often no jointly-called VCF across samples.
-        
+
             It is also extremely efficient and so can be used to find all-vs-all
             relatedness estimates for thousands of samples.
-        
+
             It also outputs information on sex, depth, heterozgyosity, and ancestry
             to be used for general QC.
             """,
@@ -702,7 +702,13 @@ def _make_col_alpha(cols, alpha):
     """Take an HTML colour value and return a rgba string with alpha"""
     cols_return = []
     for col in cols:
-        col_srgb = spectra.html(col)
-        cols_rgb = [c * 255.0 for c in col_srgb.clamped_rgb]
-        cols_return.append("rgba({},{},{},{})".format(*cols_rgb, alpha))
+        # Check if already in rgba format
+        if col.startswith("rgba("):
+            # Already has alpha, just return as-is
+            cols_return.append(col)
+        else:
+            # Convert to rgba
+            col_srgb = spectra.html(col)
+            cols_rgb = [c * 255.0 for c in col_srgb.clamped_rgb]
+            cols_return.append("rgba({},{},{},{})".format(*cols_rgb, alpha))
     return cols_return

--- a/multiqc/modules/xenome/xenome.py
+++ b/multiqc/modules/xenome/xenome.py
@@ -6,6 +6,7 @@ import spectra  # type: ignore
 
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 from multiqc.plots import bargraph, table
+from multiqc.utils.mqc_colour import mqc_colour_scale
 
 log = logging.getLogger(__name__)
 
@@ -155,12 +156,10 @@ class MultiqcModule(BaseMultiqcModule):
 
     @staticmethod
     def _lighten_color(code: str, lighten=1.0):
-        def _rgb_converter(x):
-            return max(0, min(1, 1 + ((x - 1) * lighten)))
-
+        """Use the common mqc_colour module to lighten colors with alpha transparency"""
+        scale = mqc_colour_scale()
         c = spectra.html(code)
-        c = spectra.rgb(*[_rgb_converter(v) for v in c.rgb])
-        return c.hexcode
+        return scale.lighten_colour(c, lighten)
 
     def _get_color(self, cls: Union[str, int], lighten=1.0, return_scale=False) -> str:
         if not isinstance(cls, int) and cls in self.all_species:
@@ -280,12 +279,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.add_section(
             description="This plot shows the number of reads classified by Xenome",
             helptext="""
-            There are 5 possible categories:  
+            There are 5 possible categories:
             * Reads found in graft species, e.g. **Human**
-            * Reads found in host species, e.g. **Mouse**  
+            * Reads found in host species, e.g. **Mouse**
             * **Both**: read was found in either of the species
             * **Neither**: Read was found in neither of the species
-            * **Ambiguous**: Read origin could not be adequately determined.  
+            * **Ambiguous**: Read origin could not be adequately determined.
             """,
             name="Summary classification",
             anchor="xenome_summary_bar_plot_section",

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -380,7 +380,7 @@ class BarPlotInputData(NormalizedPlotInputData[BarPlotConfig]):
             old_df_filtered = old_df.join(
                 new_keys,
                 on=["data_label", "sample"],
-                how="anti",  # anti-join = “rows in left not matched in right”
+                how="anti",  # anti-join = "rows in left not matched in right"
             )
 
             # Combine the dataframes, keeping all rows
@@ -449,9 +449,13 @@ class Dataset(BaseDataset):
             # Split long category names
             name = "<br>".join(split_long_string(input_cat["name"]))
 
+            # Colour is already in rgb format
+            if input_cat["color"].startswith("rgb"):
+                color_str = input_cat["color"]
             # Reformat color to be ready to add alpha in Plotly-JS
-            color = spectra.html(input_cat["color"])
-            color_str = ",".join([f"{int(float(x) * 256)}" for x in color.rgb])
+            else:
+                color = spectra.html(input_cat["color"])
+                color_str = ",".join([f"{int(float(x) * 256)}" for x in color.rgb])
 
             # Reverse the data to match the reversed samples
             cat: Category = Category(

--- a/multiqc/utils/mqc_colour.py
+++ b/multiqc/utils/mqc_colour.py
@@ -46,111 +46,21 @@ class mqc_colour_scale(object):
         "OrRd": ["#fff7ec", "#fee8c8", "#fdd49e", "#fdbb84", "#fc8d59", "#ef6548", "#d7301f", "#b30000", "#7f0000"],
         "PuBu": ["#fff7fb", "#ece7f2", "#d0d1e6", "#a6bddb", "#74a9cf", "#3690c0", "#0570b0", "#045a8d", "#023858"],
         "BuPu": ["#f7fcfd", "#e0ecf4", "#bfd3e6", "#9ebcda", "#8c96c6", "#8c6bb1", "#88419d", "#810f7c", "#4d004b"],
-        "Oranges": [
-            "#fff5eb",
-            "#fee6ce",
-            "#fdd0a2",
-            "#fdae6b",
-            "#fd8d3c",
-            "#f16913",
-            "#d94801",
-            "#a63603",
-            "#7f2704",
-        ],
+        "Oranges": ["#fff5eb", "#fee6ce", "#fdd0a2", "#fdae6b", "#fd8d3c", "#f16913", "#d94801", "#a63603", "#7f2704"],
         "BuGn": ["#f7fcfd", "#e5f5f9", "#ccece6", "#99d8c9", "#66c2a4", "#41ae76", "#238b45", "#006d2c", "#00441b"],
-        "YlOrBr": [
-            "#ffffe5",
-            "#fff7bc",
-            "#fee391",
-            "#fec44f",
-            "#fe9929",
-            "#ec7014",
-            "#cc4c02",
-            "#993404",
-            "#662506",
-        ],
+        "YlOrBr": ["#ffffe5", "#fff7bc", "#fee391", "#fec44f", "#fe9929", "#ec7014", "#cc4c02", "#993404", "#662506"],
         "YlGn": ["#ffffe5", "#f7fcb9", "#d9f0a3", "#addd8e", "#78c679", "#41ab5d", "#238443", "#006837", "#004529"],
         "Reds": ["#fff5f0", "#fee0d2", "#fcbba1", "#fc9272", "#fb6a4a", "#ef3b2c", "#cb181d", "#a50f15", "#67000d"],
         "RdPu": ["#fff7f3", "#fde0dd", "#fcc5c0", "#fa9fb5", "#f768a1", "#dd3497", "#ae017e", "#7a0177", "#49006a"],
-        "Greens": [
-            "#f7fcf5",
-            "#e5f5e0",
-            "#c7e9c0",
-            "#a1d99b",
-            "#74c476",
-            "#41ab5d",
-            "#238b45",
-            "#006d2c",
-            "#00441b",
-        ],
-        "YlGnBu": [
-            "#ffffd9",
-            "#edf8b1",
-            "#c7e9b4",
-            "#7fcdbb",
-            "#41b6c4",
-            "#1d91c0",
-            "#225ea8",
-            "#253494",
-            "#081d58",
-        ],
-        "Purples": [
-            "#fcfbfd",
-            "#efedf5",
-            "#dadaeb",
-            "#bcbddc",
-            "#9e9ac8",
-            "#807dba",
-            "#6a51a3",
-            "#54278f",
-            "#3f007d",
-        ],
+        "Greens": ["#f7fcf5", "#e5f5e0", "#c7e9c0", "#a1d99b", "#74c476", "#41ab5d", "#238b45", "#006d2c", "#00441b"],
+        "YlGnBu": ["#ffffd9", "#edf8b1", "#c7e9b4", "#7fcdbb", "#41b6c4", "#1d91c0", "#225ea8", "#253494", "#081d58"],
+        "Purples": ["#fcfbfd", "#efedf5", "#dadaeb", "#bcbddc", "#9e9ac8", "#807dba", "#6a51a3", "#54278f", "#3f007d"],
         "GnBu": ["#f7fcf0", "#e0f3db", "#ccebc5", "#a8ddb5", "#7bccc4", "#4eb3d3", "#2b8cbe", "#0868ac", "#084081"],
-        "Greys": [
-            "#ffffff",
-            "#f0f0f0",
-            "#d9d9d9",
-            "#bdbdbd",
-            "#969696",
-            "#737373",
-            "#525252",
-            "#252525",
-            "#000000",
-        ],
-        "YlOrRd": [
-            "#ffffcc",
-            "#ffeda0",
-            "#fed976",
-            "#feb24c",
-            "#fd8d3c",
-            "#fc4e2a",
-            "#e31a1c",
-            "#bd0026",
-            "#800026",
-        ],
+        "Greys": ["#ffffff", "#f0f0f0", "#d9d9d9", "#bdbdbd", "#969696", "#737373", "#525252", "#252525", "#000000"],
+        "YlOrRd": ["#ffffcc", "#ffeda0", "#fed976", "#feb24c", "#fd8d3c", "#fc4e2a", "#e31a1c", "#bd0026", "#800026"],
         "PuRd": ["#f7f4f9", "#e7e1ef", "#d4b9da", "#c994c7", "#df65b0", "#e7298a", "#ce1256", "#980043", "#67001f"],
-        "Blues": [
-            "#f7fbff",
-            "#deebf7",
-            "#c6dbef",
-            "#9ecae1",
-            "#6baed6",
-            "#4292c6",
-            "#2171b5",
-            "#08519c",
-            "#08306b",
-        ],
-        "PuBuGn": [
-            "#fff7fb",
-            "#ece2f0",
-            "#d0d1e6",
-            "#a6bddb",
-            "#67a9cf",
-            "#3690c0",
-            "#02818a",
-            "#016c59",
-            "#014636",
-        ],
+        "Blues": ["#f7fbff", "#deebf7", "#c6dbef", "#9ecae1", "#6baed6", "#4292c6", "#2171b5", "#08519c", "#08306b"],
+        "PuBuGn": ["#fff7fb", "#ece2f0", "#d0d1e6", "#a6bddb", "#67a9cf", "#3690c0", "#02818a", "#016c59", "#014636"],
         # diverging
         "Spectral": [
             "#9e0142",
@@ -303,17 +213,7 @@ class mqc_colour_scale(object):
             "#b15928",
         ],
         "Pastel2": ["#b3e2cd", "#fdcdac", "#cbd5e8", "#f4cae4", "#e6f5c9", "#fff2ae", "#f1e2cc", "#cccccc"],
-        "Pastel1": [
-            "#fbb4ae",
-            "#b3cde3",
-            "#ccebc5",
-            "#decbe4",
-            "#fed9a6",
-            "#ffffcc",
-            "#e5d8bd",
-            "#fddaec",
-            "#f2f2f2",
-        ],
+        "Pastel1": ["#fbb4ae", "#b3cde3", "#ccebc5", "#decbe4", "#fed9a6", "#ffffcc", "#e5d8bd", "#fddaec", "#f2f2f2"],
         # Originally from Highcharts
         "plot_defaults": [
             "#7cb5ec",
@@ -367,6 +267,20 @@ class mqc_colour_scale(object):
             self.minval = float(minval)
             self.maxval = float(maxval)
 
+    def lighten_colour(self, thecolour: spectra.Color, lighten: float) -> str:
+        """Given a spectra Color, create an rgba string with alpha transparency"""
+        alpha_values = []
+        for x in thecolour.rgb:
+            if abs(x - 1.0) < 1e-6:
+                alpha_values.append(1.0)
+            else:
+                lightened = max(0, min(1, 1 + ((x - 1) * lighten)))
+                alpha = (1 - lightened) / (1 - x)
+                alpha_values.append(max(0, min(1, alpha)))
+
+        r, g, b = [*thecolour.rgb]
+        return f"rgba({int(r * 255)},{int(g * 255)},{int(b * 255)},{min(alpha_values)})"
+
     def get_colour(
         self,
         val: Optional[Union[float, str]],
@@ -379,11 +293,6 @@ class mqc_colour_scale(object):
         if val is None:
             return ""
         assert val is not None
-
-        # Ported from the original JavaScript for continuity
-        # Seems to work better than adjusting brightness / saturation / luminosity
-        def rgb_converter(x: float) -> float:
-            return max(0, min(1, 1 + ((x - 1) * lighten)))
 
         try:
             thecolour: spectra.Color
@@ -407,13 +316,15 @@ class mqc_colour_scale(object):
                     # a unique color for each possible enumeration value.
                     val = deterministic_hash(str(val))
                 thecolour = spectra.html(self.colours[val % len(self.colours)])
-                thecolour = spectra.rgb(*[rgb_converter(float(v)) for v in thecolour.rgb])
+                if lighten > 0:
+                    return self.lighten_colour(thecolour, lighten)
                 return thecolour.hexcode
 
             # When there is only 1 color in scale, spectra.scale() will crash with DivisionByZero
             elif len(self.colours) == 1:
                 thecolour = spectra.html(self.colours[0])
-                thecolour = spectra.rgb(*[rgb_converter(float(v)) for v in thecolour.rgb])
+                if lighten > 0:
+                    return self.lighten_colour(thecolour, lighten)
                 return thecolour.hexcode
 
             else:
@@ -435,8 +346,12 @@ class mqc_colour_scale(object):
                 my_spectra_scale = cached_spectra_colour_scale(tuple(self.colours))
                 my_scale = my_spectra_scale.domain(domain_nums)
 
-                # Lighten colours
-                thecolour = spectra.rgb(*[rgb_converter(float(v)) for v in my_scale(val_float).rgb])
+                # Get the color from the scale
+                thecolour = my_scale(val_float)  # type: ignore
+
+                # Apply lightening with alpha
+                if lighten > 0:
+                    return self.lighten_colour(thecolour, lighten)
 
                 return thecolour.hexcode
 

--- a/multiqc/validation.py
+++ b/multiqc/validation.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 import re
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, Type, cast
+from typing import Any, Dict, Set, Tuple
 
 from PIL import ImageColor
 from pydantic import BaseModel
@@ -256,6 +256,24 @@ class ValidatedConfig(BaseModel):
             val_correct = f"rgb({val})"
         else:
             val_correct = val
+
+        # Check if it's an rgba format - ImageColor.getrgb doesn't support rgba
+        rgba_match = re.match(r"rgba\((\d+),\s*(\d+),\s*(\d+),\s*([0-9.]+)\)", val_correct)
+        if rgba_match:
+            # Validate that RGB values are in range 0-255
+            try:
+                r, g, b, a = rgba_match.groups()
+                if not all(0 <= int(v) <= 255 for v in [r, g, b]):
+                    raise ValueError("RGB values must be between 0 and 255")
+                if not 0 <= float(a) <= 1:
+                    raise ValueError("Alpha value must be between 0 and 1")
+            except ValueError as e:
+                add_validation_error(path_in_cfg, f"invalid color value '{val}': {e}")
+                return None
+            else:
+                return val  # Return the original rgba string
+
+        # For other formats, use ImageColor.getrgb
         try:
             ImageColor.getrgb(val_correct)
         except ValueError:

--- a/multiqc/validation.py
+++ b/multiqc/validation.py
@@ -155,7 +155,8 @@ class ValidatedConfig(BaseModel):
                 if config.strict:
                     raise ModuleConfigValidationError(message=msg, module_name=modname)
 
-        # By this point, data is a valid dict with only valid fields, but it still can raise PydanticValidationError with unexpected errors
+        # By this point, data is a valid dict with only valid fields, but it still can
+        # raise PydanticValidationError with unexpected errors
         super().__init__(**data)
 
     @classmethod


### PR DESCRIPTION
This PR refactors MultiQC's colour lightening functionality to use alpha transparency instead of mixing colours with white. This change ensures colours render correctly on both light and dark backgrounds.

- Updated `mqc_colour_scale.lighten_colour()` to return rgba strings with calculated alpha values instead of mixing with white
- Modified `get_colour()` method to use the new alpha-based lightening approach
- Updated bargraph plotting code to handle rgba color strings properly
- Added rgba color validation support in `ValidatedConfig.parse_color()`
- Refactored xenome module to use the common color lightening function instead of duplicating logic
- Updated somalier module's `_make_col_alpha()` to handle rgba input colors

⚠️ This is a fairly major PR that changes a key aspect of report rendering for all MultiQC runs