### PR TITLE
Fix merging modules from multiple parquet files

### DIFF
--- a/multiqc/core/plot_data_store.py
+++ b/multiqc/core/plot_data_store.py
@@ -113,6 +113,10 @@ def get_report_metadata(df: pl.DataFrame) -> Optional[Dict[str, Any]]:
         if "config" in metadata_df.columns and not metadata_df.get_column("config").is_empty():
             result["config"] = json.loads(metadata_df.get_column("config")[0])
 
+        # Read software versions
+        if "software_versions" in metadata_df.columns and not metadata_df.get_column("software_versions").is_empty():
+            result["software_versions"] = json.loads(metadata_df.get_column("software_versions")[0])
+
         return result
     except Exception as e:
         logger.error(f"Error extracting report metadata from parquet: {e}")
@@ -191,6 +195,7 @@ def save_report_metadata() -> None:
             "data_sources": [json.dumps(data_sources_dict)],
             "multiqc_version": [config.version if hasattr(config, "version") else ""],
             "modules": [json.dumps(modules_data)],
+            "software_versions": [json.dumps(dict(report.software_versions))],
         }
     )
 

--- a/multiqc/core/special_case_modules/load_multiqc_data.py
+++ b/multiqc/core/special_case_modules/load_multiqc_data.py
@@ -291,7 +291,6 @@ class LoadMultiqcData(BaseMultiqcModule):
                                             merged_content = existing_section.content
 
                                     # Preserve plot-related attributes from whichever section has them
-                                    merged_plot = new_section.plot or existing_section.plot
                                     merged_plot_anchor = new_section.plot_anchor or existing_section.plot_anchor
 
                                     # Create merged section with combined content
@@ -306,7 +305,6 @@ class LoadMultiqcData(BaseMultiqcModule):
                                         comment=new_section.comment,
                                         helptext=new_section.helptext,
                                         content_before_plot=new_section.content_before_plot,
-                                        plot=merged_plot,  # Use merged plot
                                         content=merged_content,
                                         print_section=new_section.print_section,
                                         plot_anchor=merged_plot_anchor,  # Use merged plot_anchor
@@ -354,9 +352,9 @@ class LoadMultiqcData(BaseMultiqcModule):
             # Load data sources
             if "data_sources" in metadata:
                 for mod_id, source_dict in metadata["data_sources"].items():
-                    for section, sources in source_dict.items():
+                    for section_name, sources in source_dict.items():
                         for sname, source in sources.items():
-                            report.data_sources[mod_id][section][sname] = source
+                            report.data_sources[mod_id][section_name][sname] = source
 
             # Set creation date
             if "creation_date" in metadata:
@@ -400,7 +398,7 @@ class LoadMultiqcData(BaseMultiqcModule):
                             log.debug(f"Successfully merged plot input data for {anchor}")
 
                             # Create the plot object from the merged data (this ensures proper color assignment)
-                            merged_plot = create_plot_from_input_data(merged_plot_input)
+                            merged_plot: Union[Plot, str, None] = create_plot_from_input_data(merged_plot_input)
                             if merged_plot is not None:
                                 report.plot_by_id[anchor] = merged_plot
                                 log.debug(f"Updated plot object for {anchor} with merged data")

--- a/multiqc/core/special_case_modules/load_multiqc_data.py
+++ b/multiqc/core/special_case_modules/load_multiqc_data.py
@@ -8,7 +8,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import packaging.version
 import polars as pl
@@ -16,6 +16,7 @@ import polars as pl
 from multiqc import config, report
 from multiqc.base_module import BaseMultiqcModule, Section
 from multiqc.core import plot_data_store
+from multiqc.core.software_versions import parse_version, sort_versions
 from multiqc.plots.bargraph import BarPlot, BarPlotInputData
 from multiqc.plots.box import BoxPlot, BoxPlotInputData
 from multiqc.plots.heatmap import HeatmapNormalizedInputData, HeatmapPlot
@@ -28,7 +29,11 @@ from multiqc.types import Anchor, PlotType
 log = logging.getLogger(__name__)
 
 
-def load_plot_input(plot_input_data_dict: Dict) -> Tuple[NormalizedPlotInputData, Union[Plot, str, None]]:
+def create_plot_input_data_only(plot_input_data_dict: Dict) -> NormalizedPlotInputData:
+    """
+    Create only the plot input data object from a dictionary, without creating the plot object.
+    """
+
     # Process the JSON data to replace NaN markers with proper NaN values
     def replace_nan_markers(obj: Any) -> Any:
         import math
@@ -49,29 +54,65 @@ def load_plot_input(plot_input_data_dict: Dict) -> Tuple[NormalizedPlotInputData
     plot_type = PlotType.from_str(processed_dict["plot_type"])
 
     plot_input: NormalizedPlotInputData
-    plot: Union[Plot, str, None]
 
     if plot_type == PlotType.LINE:
         plot_input = LinePlotNormalizedInputData(**processed_dict)
-        plot = LinePlot.from_inputs(plot_input)
     elif plot_type == PlotType.BAR:
         plot_input = BarPlotInputData(**processed_dict)
-        plot = BarPlot.from_inputs(plot_input)
     elif plot_type == PlotType.BOX:
         plot_input = BoxPlotInputData(**processed_dict)
-        plot = BoxPlot.from_inputs(plot_input)
     elif plot_type == PlotType.HEATMAP:
         plot_input = HeatmapNormalizedInputData(**processed_dict)
-        plot = HeatmapPlot.from_inputs(plot_input)
     elif plot_type == PlotType.VIOLIN or plot_type == PlotType.TABLE:
         plot_input = ViolinPlotInputData(**processed_dict)
-        plot = ViolinPlot.from_inputs(plot_input)
     elif plot_type == PlotType.SCATTER:
         plot_input = ScatterNormalizedInputData(**processed_dict)
-        plot = ScatterPlot.from_inputs(plot_input)
     else:
         raise ValueError(f"Unknown plot type: {plot_type}")
 
+    return plot_input
+
+
+def create_plot_from_input_data(plot_input: NormalizedPlotInputData) -> Union[Plot, str, None]:
+    """
+    Create a plot object from plot input data.
+    """
+    if plot_input.plot_type == PlotType.LINE:
+        from multiqc.plots.linegraph import LinePlot
+
+        return LinePlot.from_inputs(cast(LinePlotNormalizedInputData, plot_input))
+    elif plot_input.plot_type == PlotType.BAR:
+        from multiqc.plots.bargraph import BarPlot
+
+        return BarPlot.from_inputs(cast(BarPlotInputData, plot_input))
+    elif plot_input.plot_type == PlotType.VIOLIN or plot_input.plot_type == PlotType.TABLE:
+        from multiqc.plots.violin import ViolinPlot
+
+        return ViolinPlot.from_inputs(cast(ViolinPlotInputData, plot_input))
+    elif plot_input.plot_type == PlotType.BOX:
+        from multiqc.plots.box import BoxPlot
+
+        return BoxPlot.from_inputs(cast(BoxPlotInputData, plot_input))
+    elif plot_input.plot_type == PlotType.SCATTER:
+        from multiqc.plots.scatter import ScatterPlot
+
+        return ScatterPlot.from_inputs(cast(ScatterNormalizedInputData, plot_input))
+    elif plot_input.plot_type == PlotType.HEATMAP:
+        from multiqc.plots.heatmap import HeatmapPlot
+
+        return HeatmapPlot.from_inputs(cast(HeatmapNormalizedInputData, plot_input))
+    else:
+        log.warning(f"Unknown plot type {plot_input.plot_type}, cannot create plot object")
+        return None
+
+
+def load_plot_input(plot_input_data_dict: Dict) -> Tuple[NormalizedPlotInputData, Union[Plot, str, None]]:
+    """
+    Load plot input data and create plot object from a dictionary.
+    This function combines create_plot_input_data_only and create_plot_from_input_data.
+    """
+    plot_input = create_plot_input_data_only(plot_input_data_dict)
+    plot = create_plot_from_input_data(plot_input)
     return plot_input, plot
 
 
@@ -83,11 +124,17 @@ class LoadMultiqcData(BaseMultiqcModule):
             info="loads multiqc data",
         )
 
+        # Dictionary to collect all software versions from all parquet files
+        self.collected_software_versions: Dict[str, List[str]] = {}
+
         # First, try to find parquet file
         parquet_files = self.find_log_files("multiqc_data")
         if parquet_files:
             for f in parquet_files:
                 self.load_parquet_file(Path(f["root"]) / f["fn"])
+
+            # After loading all files, process and deduplicate software versions
+            self._process_collected_software_versions()
 
     def load_parquet_file(self, path: Union[str, Path]):
         """
@@ -110,7 +157,22 @@ class LoadMultiqcData(BaseMultiqcModule):
             # Load modules
             if "modules" in metadata:
                 for mod_dict in metadata["modules"]:
-                    sections = [Section(**section) for section in mod_dict.pop("sections")]
+                    # Extract module data first so we can use it for section defaults
+                    anchor = mod_dict.get("anchor", "")
+                    name = mod_dict.get("name", "")
+                    info = mod_dict.get("info", "")
+                    intro = mod_dict.get("intro", "")
+                    comment = mod_dict.get("comment", "")
+
+                    # Create sections, providing default values for missing required fields
+                    sections = []
+                    for section_data in mod_dict.pop("sections"):
+                        # Ensure required fields have default values if missing
+                        section_data.setdefault("id", section_data.get("anchor", ""))
+                        section_data.setdefault("module", name)  # Use the module name
+                        section_data.setdefault("module_anchor", anchor)  # Use the module anchor
+                        section_data.setdefault("description", "")
+                        sections.append(Section(**section_data))
 
                     # Convert versions to expected format
                     versions: Dict[str, List[Tuple[Optional[packaging.version.Version], str]]] = {}
@@ -120,12 +182,12 @@ class LoadMultiqcData(BaseMultiqcModule):
                             name: [(None, version) for version in versions] for name, versions in versions_data.items()
                         }
 
-                    # Extract other module data
-                    anchor = mod_dict.pop("anchor")
-                    name = mod_dict.pop("name")
-                    info = mod_dict.pop("info", "")
-                    intro = mod_dict.pop("intro", "")
-                    comment = mod_dict.pop("comment", "")
+                    # Remove already extracted data from mod_dict
+                    mod_dict.pop("anchor", None)
+                    mod_dict.pop("name", None)
+                    mod_dict.pop("info", None)
+                    mod_dict.pop("intro", None)
+                    mod_dict.pop("comment", None)
 
                     # Special handling for Software Versions modules - skip them to avoid duplicates
                     if anchor == "multiqc_software_versions" and name == "Software Versions":
@@ -142,9 +204,11 @@ class LoadMultiqcData(BaseMultiqcModule):
                                     matches = re.findall(row_pattern, section.content)
 
                                     for software_name, version in matches:
-                                        # Add to global software_versions using software name as group
-                                        report.software_versions[software_name][software_name].append(version)
-                                        log.debug(f"Added software version: {software_name} = {version}")
+                                        # Collect software versions for later processing
+                                        if software_name not in self.collected_software_versions:
+                                            self.collected_software_versions[software_name] = []
+                                        self.collected_software_versions[software_name].append(version)
+                                        log.debug(f"Collected software version: {software_name} = {version}")
 
                         log.info(
                             "Skipping Software Versions module from parquet file - extracted data to global software_versions"
@@ -158,7 +222,74 @@ class LoadMultiqcData(BaseMultiqcModule):
                     mod.intro = intro
                     mod.comment = comment
 
-                    log.info(f"Loading module {mod.name} from parquet")
+                    # Check for duplicate modules and merge if found (same logic as exec_modules.py)
+                    existing_mod = None
+                    for prev_mod in report.modules:
+                        if prev_mod.anchor == mod.anchor:
+                            existing_mod = prev_mod
+                            break
+
+                    if existing_mod:
+                        # Merge the existing module into the new one
+                        mod.merge(existing_mod)  # This only merges versions
+
+                        # Also merge sections manually since the base merge() doesn't do this
+                        existing_sections = {s.anchor: s for s in existing_mod.sections}
+                        new_sections = {s.anchor: s for s in mod.sections}
+
+                        # Combine sections - if anchors match, we'll need to merge the section content
+                        merged_sections = []
+                        all_section_anchors = set(existing_sections.keys()) | set(new_sections.keys())
+
+                        for section_anchor in all_section_anchors:
+                            if section_anchor in existing_sections and section_anchor in new_sections:
+                                # Both modules have this section - we need to merge them
+                                existing_section = existing_sections[section_anchor]
+                                new_section = new_sections[section_anchor]
+
+                                # For now, combine content (this works for tables and plots)
+                                # In the future, might need more sophisticated merging based on section type
+                                merged_content = existing_section.content
+                                if new_section.content and new_section.content != existing_section.content:
+                                    # If content is different, append it
+                                    if merged_content:
+                                        merged_content += "\n\n" + new_section.content
+                                    else:
+                                        merged_content = new_section.content
+
+                                # Use the new section as base but with merged content
+                                merged_section = Section(
+                                    name=new_section.name,
+                                    anchor=new_section.anchor,
+                                    id=new_section.id,
+                                    description=new_section.description,
+                                    module=new_section.module,
+                                    module_anchor=new_section.module_anchor,
+                                    module_info=new_section.module_info,
+                                    comment=new_section.comment,
+                                    helptext=new_section.helptext,
+                                    content_before_plot=new_section.content_before_plot,
+                                    plot=new_section.plot,  # The plot object will be merged in plotting code
+                                    content=merged_content,
+                                    print_section=new_section.print_section,
+                                    plot_anchor=new_section.plot_anchor,
+                                    ai_summary=new_section.ai_summary,
+                                )
+                                merged_sections.append(merged_section)
+
+                            elif section_anchor in existing_sections:
+                                # Only in existing module
+                                merged_sections.append(existing_sections[section_anchor])
+                            else:
+                                # Only in new module
+                                merged_sections.append(new_sections[section_anchor])
+
+                        mod.sections = merged_sections
+                        log.info(f'Updating module "{existing_mod.name}" with data from parquet')
+                        report.modules.remove(existing_mod)
+                    else:
+                        log.info(f"Loading module {mod.name} from parquet")
+
                     report.modules.append(mod)
 
             # Load global software versions data
@@ -167,8 +298,10 @@ class LoadMultiqcData(BaseMultiqcModule):
                 log.info("Loading global software versions data from parquet file")
                 for group_name, group_versions in software_versions_data.items():
                     for software_name, versions_list in group_versions.items():
-                        for version_str in versions_list:
-                            report.software_versions[group_name][software_name].append(version_str)
+                        # Collect software versions for later processing
+                        if software_name not in self.collected_software_versions:
+                            self.collected_software_versions[software_name] = []
+                        self.collected_software_versions[software_name].extend(versions_list)
 
             # Load data sources
             if "data_sources" in metadata:
@@ -201,10 +334,38 @@ class LoadMultiqcData(BaseMultiqcModule):
                     plot_input_data = row["plot_input_data"]
                     plot_input_data_dict = json.loads(plot_input_data)
                     try:
-                        plot_input, plot = load_plot_input(plot_input_data_dict)
-                        report.plot_input_data[anchor] = plot_input
-                        if plot is not None:
-                            report.plot_by_id[anchor] = plot
+                        # First, create only the plot input data (without the plot object)
+                        plot_input = create_plot_input_data_only(plot_input_data_dict)
+                        log.info(f"Loading plot input data for {anchor}, type: {plot_input.__class__.__name__}")
+
+                        # Check if we already have plot input data for this anchor (from previous parquet files)
+                        if anchor in report.plot_input_data:
+                            # Merge the existing data with the new data using the appropriate merge method
+                            existing_plot_input = report.plot_input_data[anchor]
+                            log.info(
+                                f"Found existing plot input data for {anchor}, merging {existing_plot_input.__class__.__name__} with {plot_input.__class__.__name__}"
+                            )
+
+                            # Use the merge class method from the plot input data class
+                            merged_plot_input = existing_plot_input.__class__.merge(existing_plot_input, plot_input)
+                            report.plot_input_data[anchor] = merged_plot_input
+                            log.info(f"Successfully merged plot input data for {anchor}")
+
+                            # Create the plot object from the merged data (this ensures proper color assignment)
+                            merged_plot = create_plot_from_input_data(merged_plot_input)
+                            if merged_plot is not None:
+                                report.plot_by_id[anchor] = merged_plot
+                                log.info(f"Updated plot object for {anchor} with merged data")
+
+                        else:
+                            # No existing data, just add the new data and create plot object
+                            log.info(f"No existing plot input data for {anchor}, adding new data")
+                            report.plot_input_data[anchor] = plot_input
+
+                            # Create the plot object from the input data
+                            plot = create_plot_from_input_data(plot_input)
+                            if plot is not None:
+                                report.plot_by_id[anchor] = plot
                     except Exception as e:
                         log.error(f"Error loading plot input data {anchor}: {e}")
                         if config.strict:
@@ -214,3 +375,29 @@ class LoadMultiqcData(BaseMultiqcModule):
             log.error(f"Error loading data from parquet file: {e}")
             if config.strict:
                 raise e
+
+    def _process_collected_software_versions(self):
+        """
+        Process collected software versions: parse, deduplicate, sort, and add to report.software_versions
+        """
+        for software_name, version_strings in self.collected_software_versions.items():
+            if version_strings:
+                # Parse versions and create tuples of (Version object, version string)
+                ver_and_verstr = []
+                for version_str in version_strings:
+                    # Split comma-separated versions (in case they're combined)
+                    individual_versions = [v.strip() for v in version_str.split(",") if v.strip()]
+                    for individual_version in individual_versions:
+                        ver_and_verstr.append((parse_version(individual_version), individual_version))
+
+                # Remove duplicates by converting to set and back to list
+                ver_and_verstr = list(set(ver_and_verstr))
+
+                # Sort versions using MultiQC's sorting logic
+                sorted_versions = sort_versions(ver_and_verstr)
+
+                # Add to global software_versions (using software name as group name)
+                final_versions = [version_str for _, version_str in sorted_versions]
+                report.software_versions[software_name][software_name].extend(final_versions)
+
+                log.info(f"Processed {len(final_versions)} versions for {software_name}: {', '.join(final_versions)}")

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -509,8 +509,10 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
         Merge normalized data from old run and new run, leveraging our tabular representation
         for more efficient and reliable merging.
         """
+        logger.debug(f"LinePlot merge called for anchor {new_data.anchor}")
         new_df = new_data.to_df()
         if new_df.is_empty():
+            logger.debug("LinePlot merge: new_df is empty, returning old_data")
             return old_data
 
         old_df = old_data.to_df()
@@ -518,21 +520,33 @@ class LinePlotNormalizedInputData(NormalizedPlotInputData[LinePlotConfig], Gener
         # If we have both old and new data, merge them
         merged_df = new_df
         if old_df is not None and not old_df.is_empty():
+            logger.debug(
+                f"LinePlot merge: both old and new data present, merging. Old: {old_df.shape}, New: {new_df.shape}"
+            )
             # Get the list of samples that exist in both old and new data, for each dataset
             new_keys = new_df.select(["data_label", "sample"]).unique()
+            logger.debug(f"LinePlot merge: new_keys shape: {new_keys.shape}")
 
             # Keep only the rows in old_df whose (data_label, sample) pair
             # does *not* appear in new_keys. An anti-join is the cleanest way to express this.
             old_df_filtered = old_df.join(
                 new_keys,
                 on=["data_label", "sample"],
-                how="anti",  # anti-join = “rows in left not matched in right”
+                how="anti",  # anti-join = "rows in left not matched in right"
             )
+            logger.debug(f"LinePlot merge: old_df_filtered shape: {old_df_filtered.shape}")
 
             # Combine the filtered old data with new data
             merged_df = pl.concat([old_df_filtered, new_df], how="diagonal")
+            logger.debug(f"LinePlot merge: merged_df shape: {merged_df.shape}")
+        else:
+            logger.debug("LinePlot merge: no old data or old data is empty, using new data only")
 
-        return cls.from_df(merged_df, new_data.pconfig, new_data.anchor)
+        result = cls.from_df(merged_df, new_data.pconfig, new_data.anchor)
+        logger.debug(
+            f"LinePlot merge: created result with {len(result.data)} datasets, {len(result.sample_names)} samples"
+        )
+        return result
 
 
 class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
@@ -624,6 +638,8 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
                         pairs = dict(series.pairs)
                         series.pairs = [(x, pairs[x]) for x in xs]
 
+        inputs.save_to_parquet()
+
         scale = mqc_colour.mqc_colour_scale("plot_defaults")
         for _, series_by_sample in enumerate(datasets):
             for si, series in enumerate(series_by_sample):
@@ -636,7 +652,6 @@ class LinePlot(Plot[Dataset[KeyT, ValT], LinePlotConfig], Generic[KeyT, ValT]):
             anchor=inputs.anchor,
             sample_names=sample_names,
         )
-        inputs.save_to_parquet()
         return plot
 
 

--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -416,11 +416,17 @@ class NormalizedPlotInputData(BaseModel, Generic[PConfigT]):
         """
         # Try to load previous data (empty or unloadable means no data from previous run)
         old_data = report.plot_input_data.get(new_data.anchor)
+        logger.debug(f"merge_with_previous for {new_data.anchor}: found old_data = {old_data is not None}")
         if old_data is None or old_data.is_empty():
+            logger.debug(f"merge_with_previous for {new_data.anchor}: no old data or empty, using new data only")
             merged_data = new_data
         else:
             # Merge using class-specific implementation
+            logger.debug(
+                f"merge_with_previous for {new_data.anchor}: merging {old_data.__class__.__name__} with {new_data.__class__.__name__}"
+            )
             merged_data = cls.merge(cast(NormalizedPlotInputDataT, old_data), new_data)
+            logger.debug(f"merge_with_previous for {new_data.anchor}: merge completed")
         return merged_data
 
     def finalize_df(self, df: pl.DataFrame) -> pl.DataFrame:


### PR DESCRIPTION
A few fixes for loading from parquet files:
* Fix merge modules from the same module when they have different sets of plots (probably from different tools versions) - fixes https://github.com/MultiQC/MultiQC/issues/3253
* Properly merge "Software Versions" section