### PR TITLE
add before-filtering mean r1/r2 length to general stats

### DIFF
--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -257,6 +257,13 @@ class MultiqcModule(BaseMultiqcModule):
         except KeyError:
             log.debug(f"fastp JSON did not have a 'duplication' key: '{s_name}'")
 
+        # Parse before_filtering
+        try:
+            for k in parsed_json["summary"]["before_filtering"]:
+                self.fastp_data[s_name][f"before_filtering_{k}"] = float(parsed_json["summary"]["before_filtering"][k])
+        except KeyError:
+            log.debug(f"fastp JSON did not have a 'summary'-'before_filtering' keys: '{s_name}'")
+
         # Parse after_filtering
         try:
             for k in parsed_json["summary"]["after_filtering"]:
@@ -427,6 +434,18 @@ class MultiqcModule(BaseMultiqcModule):
                     "description": "Percentage adapter-trimmed reads",
                     "suffix": "%",
                     "scale": "RdYlGn-rev",
+                },
+                "before_filtering_read1_mean_length": {
+                    "title": "Mean R1 Length",
+                    "description": "Mean read length of R1",
+                    "suffix": "bp",
+                    "hidden": True,
+                },
+                "before_filtering_read2_mean_length": {
+                    "title": "Mean R2 Length",
+                    "description": "Mean read length of R2",
+                    "suffix": "bp",
+                    "hidden": True,
                 },
             },
         )


### PR DESCRIPTION
Just adds two hidden columns to fastp general stats:

<img width="1583" height="189" alt="2025-07-23_18-52" src="https://github.com/user-attachments/assets/ab7e36f3-006c-473a-b577-76670faec7d9" />
