### PR TITLE
Missing modules to general stats: Busco, CheckM, CheckM2, GTDB-Tk

### DIFF
--- a/multiqc/modules/busco/busco.py
+++ b/multiqc/modules/busco/busco.py
@@ -65,6 +65,39 @@ class MultiqcModule(BaseMultiqcModule):
                 plot=self.busco_plot(lin),
             )
 
+        # Add most important stats to the general table
+        headers = {
+            "complete": {
+                "title": "Complete BUSCOs",
+                "description": "Number of complete BUSCOs",
+                "min": 0,
+                "hidden": True,
+            },
+            "complete_single_copy": {
+                "title": "Complete and single-copy BUSCOs",
+                "description": "Number of complete and single-copy BUSCOs",
+                "min": 0,
+            },
+            "complete_duplicated": {
+                "title": "Complete and duplicated BUSCOs",
+                "description": "Number of complete and duplicated BUSCOs",
+                "min": 0,
+                "hidden": True,
+            },
+            "fragmented": {
+                "title": "Fragmented BUSCOs",
+                "description": "Number of fragmented BUSCOs",
+                "min": 0,
+                "hidden": True,
+            },
+            "missing": {
+                "title": "Missing BUSCOs",
+                "description": "Number of missing BUSCOs",
+                "min": 0,
+            },
+        }
+        self.general_stats_addcols(self.busco_data, headers)
+
     def parse_busco_log(self, f):
         parsed_data = {}
         for line in f["f"].splitlines():

--- a/multiqc/modules/checkm/checkm.py
+++ b/multiqc/modules/checkm/checkm.py
@@ -46,6 +46,29 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.mag_quality_table(data_by_sample)
 
+        # Add important columns to general table
+        headers = {
+            "Completeness": {
+                "title": "Completeness",
+                "description": "Estimated completeness of genome as determined from the presence/absence of marker genes and the expected collocalization of these genes",
+                "min": 0,
+                "max": 100,
+                "suffix": "%",
+                "scale": "Purples",
+                "format": "{:,.2f}",
+            },
+            "Contamination": {
+                "title": "Contamination",
+                "description": "Estimated contamination of genome as determined by the presence of multi-copy marker genes and the expected collocalization of these genes",
+                "min": 0,
+                "max": 100,
+                "suffix": "%",
+                "scale": "Reds",
+                "format": "{:,.2f}",
+            },
+        }
+        self.general_stats_addcols(data_by_sample, headers)
+
     def parse_file(self, f, data_by_sample):
         """Parses the file from `checkm qa`.
         Outputs from this command can come in several formats and with spaces or tabs.

--- a/multiqc/modules/checkm2/checkm2.py
+++ b/multiqc/modules/checkm2/checkm2.py
@@ -45,6 +45,33 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.mag_quality_table(data_by_sample)
 
+        # Add the important columns to the general stats table
+        headers = {
+            "Completeness": {
+                "title": "Predicted Completeness",
+                "description": "The percentage of MAG length relative to predicted total MAG length.",
+                "min": 0,
+                "max": 100,
+                "suffix": "%",
+                "scale": "YlGn",
+            },
+            "Contamination": {
+                "title": "Predicted Contamination",
+                "description": "The length of the contaminating portion relative to the expected (complete, uncontaminated) genome length.",
+                "min": 0,
+                "suffix": "%",
+                "format": "{:,.2f}",
+                "scale": "YlOrRd",
+            },
+            "Genome_Size": {
+                "title": "Genome Size",
+                "description": "The predicted size of the genome",
+                "scale": "YlGn",
+                "hidden": True
+            },
+        }
+        self.general_stats_addcols(data_by_sample, headers)
+
     def parse_file(self, f, data_by_sample):
         """Parse the quality_report.tsv output."""
         reader = csv.DictReader(StringIO(f["f"]), delimiter="\t")

--- a/multiqc/modules/checkm2/checkm2.py
+++ b/multiqc/modules/checkm2/checkm2.py
@@ -67,7 +67,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "title": "Genome Size",
                 "description": "The predicted size of the genome",
                 "scale": "YlGn",
-                "hidden": True
+                "hidden": True,
             },
         }
         self.general_stats_addcols(data_by_sample, headers)

--- a/multiqc/modules/gtdbtk/gtdbtk.py
+++ b/multiqc/modules/gtdbtk/gtdbtk.py
@@ -43,6 +43,30 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.closest_taxa_table(data_by_sample)
 
+        # Add important columns to the general stats table
+        headers = {
+            "classification": {
+                "title": "Classification",
+                "description": "GTDB taxonomy string inferred by the GTDB-Tk.",
+            },
+            "ANI": {
+                "title": "ANI to closest genome",
+                "description": "Depending on the classification method, either the 'closest_genome_ani' or 'closest_placement_ani'.",
+                "min": 0,
+                "max": 100,
+                "hidden": True,
+            },
+            "AF": {
+                "title": "AF to closest genome",
+                "description": "Depending on the classification method, either the 'closest_genome_af' or 'closest_placement_af'.",
+                "min": 0,
+                "max": 1,
+                "scale": "Purples",
+                "hidden": True,
+            },
+        }
+        self.general_stats_addcols(data_by_sample, headers)
+
     def parse_file(self, f, data_by_sample):
         """Parse the summary.tsv outputs."""
         column_names = (


### PR DESCRIPTION
tl;dr: This is an update to 4 modules that where nothing was being added to the general stats table.

In working on [nf-core/mag PR#841](https://github.com/nf-core/mag/pull/841), I noticed that some of the modules were not adding anything to the general stats table. Here I just add some code to change that.

I know updating multiple modules isn't ideal, but given it is just a minor update to them and it is the same general thing in all of them, I thought it might be ok. I can split this into multiple PRs if needed. 

- [x] This comment contains a description of changes (with reason)
