### PR TITLE
bcftools: fix singleton count calculation to include indels

### DIFF
--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -171,9 +171,10 @@ def parse_bcftools_stats(module: BaseMultiqcModule) -> int:
                 sample = module.clean_s_name(s[2].strip(), f)
                 bcftools_stats_sample_singletons[s_name][sample] = dict()
                 bcftools_stats_sample_singletons[s_name][sample]["singletons"] = int(s[10].strip())
-                bcftools_stats_sample_singletons[s_name][sample]["rest"] = (
-                    int(s[3].strip()) + int(s[4].strip()) + int(s[5].strip()) - int(s[10].strip())
-                )
+                # Calculate total variants (SNPs + indels) - singletons
+                # s[3]=nRefHom, s[4]=nNonRefHom, s[5]=nHets (SNPs only), s[8]=nIndels
+                total_variants = int(s[3].strip()) + int(s[4].strip()) + int(s[5].strip()) + int(s[8].strip())
+                bcftools_stats_sample_singletons[s_name][sample]["rest"] = total_variants - int(s[10].strip())
 
             # Per-sample coverage stats
             if s[0] == "PSC" and len(s_names) > 0:


### PR DESCRIPTION
## Summary
- Fixes incorrect singleton count calculation in bcftools module that could produce negative values
- Changes calculation to properly include both SNPs and indels when computing "rest" category

## Details
The previous implementation had a bug where it subtracted `nSingletons` (which includes both SNPs and indels) from SNP counts only (`nRefHom + nNonRefHom + nHets`). This caused negative values when the number of singletons exceeded the number of SNPs.

The fix calculates the total number of variants as `SNPs + indels` before subtracting singletons:
```python
# Old (incorrect)
bcftools_stats_sample_singletons[s_name][sample]["rest"] = (
    int(s[3].strip()) + int(s[4].strip()) + int(s[5].strip()) - int(s[10].strip())
)

# New (correct)  
total_variants = int(s[3].strip()) + int(s[4].strip()) + int(s[5].strip()) + int(s[8].strip())
bcftools_stats_sample_singletons[s_name][sample]["rest"] = total_variants - int(s[10].strip())
```

## Test plan
- [x] Tested with existing bcftools test data from `test-data/data/modules/bcftools/issue_1832/`
- [x] Verified calculation produces correct positive values
- [x] Ran pre-commit hooks and linting successfully

Fixes #3273

🤖 Generated with [Claude Code](https://claude.ai/code)