### PR TITLE
Picard: fix VariantCallingMetrics to support sample renaming

### DIFF
--- a/multiqc/modules/picard/VariantCallingMetrics.py
+++ b/multiqc/modules/picard/VariantCallingMetrics.py
@@ -130,7 +130,7 @@ def collect_data(module):
         s_name = None
         for header, value in table_in(f["f"], pre_header_string="## METRICS CLASS"):
             if header == "SAMPLE_ALIAS":
-                s_name = value
+                s_name = module.clean_s_name(value, f)
                 if s_name in data:
                     log.debug(f"Duplicate sample name found in {f['fn']}! Overwriting: {s_name}")
                 data[s_name] = dict()


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
