### PR TITLE
Fix fastp sample naming for paired-end reads

### DIFF
--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -211,9 +211,9 @@ class MultiqcModule(BaseMultiqcModule):
             if m:
                 s_names.append(m.group(2))
                 # Second input for paired end?
-                m = re.search(r"--in2\s(.+?)(?:\s-|$)", cmd)
+                m = re.search(r"(-I|--in2)\s(.+?)(?:\s-|$)", cmd)
                 if m:
-                    s_names.append(m.group(1))
+                    s_names.append(m.group(2))
                 s_name = self.clean_s_name(s_names, f)
             else:
                 s_name = f["s_name"]


### PR DESCRIPTION
## Summary

- Fixes fastp module sample naming issue for paired-end reads
- Now correctly extracts sample names from both R1 and R2 files
- Sample names like "sample_R1_001" are now properly cleaned to "sample"

## Problem

The fastp module was not correctly extracting sample names for paired-end data because it was only looking for the `--in2` flag, but fastp actually uses `-I` (capital I) for the second input file. This caused the sample name to only be derived from the R1 file, resulting in names like "9-1_male_S9_R1_001" instead of the correct "9-1_male_S9".

## Solution

- Updated regex pattern to look for both `-I` and `--in2` flags
- Fixed group index to correctly extract filename from the new pattern

## Testing

- Tested with existing fastp test data
- Verified sample names are now correctly extracted as paired-end base names
- All existing fastp tests pass

Fixes #3279

🤖 Generated with [Claude Code](https://claude.ai/code)