### PR TITLE
Picard: enhance QualityByCycleMetrics to support original quality scores

### DIFF
--- a/multiqc/modules/picard/QualityByCycleMetrics.py
+++ b/multiqc/modules/picard/QualityByCycleMetrics.py
@@ -11,7 +11,15 @@ log = logging.getLogger(__name__)
 
 
 def parse_reports(self):
-    """Find Picard QualityByCycleMetrics reports and parse their data"""
+    """
+    Find Picard QualityByCycleMetrics reports and parse their data.
+
+    Supports both standard format (CYCLE, MEAN_QUALITY) and extended format
+    (CYCLE, MEAN_QUALITY, MEAN_ORIGINAL_QUALITY) for BQSR comparison.
+
+    Returns:
+        Set of sample names that were successfully parsed
+    """
 
     # First try the extended format with MEAN_ORIGINAL_QUALITY
     headers_extended = ["CYCLE", "MEAN_QUALITY", "MEAN_ORIGINAL_QUALITY"]
@@ -52,6 +60,12 @@ def parse_reports(self):
     if not all_data:
         return set()
 
+    # Filter out empty samples
+    all_data = {s_name: s_data for s_name, s_data in all_data.items() if s_data}
+
+    if not all_data:
+        return set()
+
     # Superfluous function call to confirm that it is used in this module
     # Replace None with actual version if it is available
     self.add_software_version(None)
@@ -71,22 +85,29 @@ def parse_reports(self):
     }
 
     # Prepare data for plotting
-    if has_original_quality:
+    lg_mean_quality = {}
+    lg_original_quality = {}
+
+    for s_name in all_data:
+        if not all_data[s_name]:
+            continue
+
+        # All samples get mean quality data
+        lg_mean_quality[s_name] = {cycle: data["MEAN_QUALITY"] for cycle, data in all_data[s_name].items()}
+
+        # Only samples with MEAN_ORIGINAL_QUALITY get original quality data
+        try:
+            sample_data = next(iter(all_data[s_name].values()))
+            if "MEAN_ORIGINAL_QUALITY" in sample_data:
+                lg_original_quality[s_name] = {
+                    cycle: data["MEAN_ORIGINAL_QUALITY"] for cycle, data in all_data[s_name].items()
+                }
+        except StopIteration:
+            log.warning(f"No cycle data found for sample {s_name}")
+            continue
+
+    if has_original_quality and lg_original_quality:
         # Plot both mean quality and mean original quality
-        lg_mean_quality = {}
-        lg_original_quality = {}
-
-        for s_name in all_data:
-            # All samples get mean quality data
-            lg_mean_quality[s_name] = dict((cycle, data["MEAN_QUALITY"]) for cycle, data in all_data[s_name].items())
-
-            # Only samples with MEAN_ORIGINAL_QUALITY get original quality data
-            if "MEAN_ORIGINAL_QUALITY" in next(iter(all_data[s_name].values())):
-                lg_original_quality[s_name] = dict(
-                    (cycle, data["MEAN_ORIGINAL_QUALITY"]) for cycle, data in all_data[s_name].items()
-                )
-
-        # Combine both datasets with data labels
         plot_data = [lg_mean_quality, lg_original_quality]
 
         # Update plot config with data labels
@@ -108,10 +129,6 @@ def parse_reports(self):
         """
     else:
         # Plot only mean quality (legacy behavior)
-        lg_mean_quality = {}
-        for s_name in all_data:
-            lg_mean_quality[s_name] = dict((cycle, data["MEAN_QUALITY"]) for cycle, data in all_data[s_name].items())
-
         plot_data = [lg_mean_quality]
         description = "Plot shows the mean base quality by cycle."
         helptext_addition = ""

--- a/multiqc/modules/picard/QualityByCycleMetrics.py
+++ b/multiqc/modules/picard/QualityByCycleMetrics.py
@@ -1,6 +1,7 @@
 """MultiQC submodule to parse output from Picard MeanQualityByCycle"""
 
 import logging
+from typing import Any, Dict
 
 from multiqc.plots import linegraph
 
@@ -58,7 +59,7 @@ def parse_reports(self):
         # Only overwrite if the extended data is actually extended (has MEAN_ORIGINAL_QUALITY)
         for s_name, s_data in all_data_extended.items():
             if s_data:  # Ensure sample has data
-                sample_data = next(iter(s_data.values()), {})
+                sample_data: Dict[str, Any] = next(iter(s_data.values()), {})
                 if "MEAN_ORIGINAL_QUALITY" in sample_data:
                     all_data[s_name] = s_data
                     has_original_quality = True

--- a/multiqc/modules/picard/QualityByCycleMetrics.py
+++ b/multiqc/modules/picard/QualityByCycleMetrics.py
@@ -13,16 +13,41 @@ log = logging.getLogger(__name__)
 def parse_reports(self):
     """Find Picard QualityByCycleMetrics reports and parse their data"""
 
-    headers = ["CYCLE", "MEAN_QUALITY"]
-    formats = [int, float]
-    all_data = read_histogram(
+    # First try the extended format with MEAN_ORIGINAL_QUALITY
+    headers_extended = ["CYCLE", "MEAN_QUALITY", "MEAN_ORIGINAL_QUALITY"]
+    formats_extended = [int, float, float]
+    all_data_extended = read_histogram(
         self,
         "picard/quality_by_cycle",
-        headers,
-        formats,
+        headers_extended,
+        formats_extended,
         picard_tool="MeanQualityByCycle",
         sentieon_algo="MeanQualityByCycle",
     )
+
+    # Then try the standard format for any remaining files
+    headers_standard = ["CYCLE", "MEAN_QUALITY"]
+    formats_standard = [int, float]
+    all_data_standard = read_histogram(
+        self,
+        "picard/quality_by_cycle",
+        headers_standard,
+        formats_standard,
+        picard_tool="MeanQualityByCycle",
+        sentieon_algo="MeanQualityByCycle",
+    )
+
+    # Combine all data - extended format takes precedence for samples that have it
+    all_data = {}
+    has_original_quality = False
+
+    # Add standard format data first
+    all_data.update(all_data_standard)
+
+    # Add extended format data (may overwrite standard format for same samples)
+    if all_data_extended:
+        all_data.update(all_data_extended)
+        has_original_quality = True
 
     if not all_data:
         return set()
@@ -45,23 +70,65 @@ def parse_reports(self):
         "ymin": 0,
     }
 
-    lg = {}
-    for s_name in all_data:
-        lg[s_name] = dict((cycle, data["MEAN_QUALITY"]) for cycle, data in all_data[s_name].items())
+    # Prepare data for plotting
+    if has_original_quality:
+        # Plot both mean quality and mean original quality
+        lg_mean_quality = {}
+        lg_original_quality = {}
+
+        for s_name in all_data:
+            # All samples get mean quality data
+            lg_mean_quality[s_name] = dict((cycle, data["MEAN_QUALITY"]) for cycle, data in all_data[s_name].items())
+
+            # Only samples with MEAN_ORIGINAL_QUALITY get original quality data
+            if "MEAN_ORIGINAL_QUALITY" in next(iter(all_data[s_name].values())):
+                lg_original_quality[s_name] = dict(
+                    (cycle, data["MEAN_ORIGINAL_QUALITY"]) for cycle, data in all_data[s_name].items()
+                )
+
+        # Combine both datasets with data labels
+        plot_data = [lg_mean_quality, lg_original_quality]
+
+        # Update plot config with data labels
+        pconfig.update(
+            {
+                "data_labels": [
+                    {"name": "Recalibrated Quality", "ylab": "Mean Base Quality"},
+                    {"name": "Original Quality", "ylab": "Mean Base Quality"},
+                ]
+            }
+        )
+
+        description = "Plot shows the mean base quality by cycle, comparing recalibrated quality scores with original quality scores."
+        helptext_addition = """
+        
+        When Base Quality Score Recalibration (BQSR) has been applied, this plot shows both the 
+        recalibrated quality scores (Mean Quality) and the original quality scores (Mean Original Quality). 
+        This comparison helps assess the effectiveness of BQSR or other quality adjustments.
+        """
+    else:
+        # Plot only mean quality (legacy behavior)
+        lg_mean_quality = {}
+        for s_name in all_data:
+            lg_mean_quality[s_name] = dict((cycle, data["MEAN_QUALITY"]) for cycle, data in all_data[s_name].items())
+
+        plot_data = [lg_mean_quality]
+        description = "Plot shows the mean base quality by cycle."
+        helptext_addition = ""
 
     self.add_section(
         name="Mean Base Quality by Cycle",
         anchor=f"{self.anchor}-quality-by-cycle",
-        description="Plot shows the mean base quality by cycle.",
-        helptext="""
+        description=description,
+        helptext=f"""
         This metric gives an overall snapshot of sequencing machine performance.
         For most types of sequencing data, the output is expected to show a slight
         reduction in overall base quality scores towards the end of each read.
 
         Spikes in quality within reads are not expected and may indicate that technical
-        problems occurred during sequencing.
+        problems occurred during sequencing.{helptext_addition}
         """,
-        plot=linegraph.plot([lg], pconfig),
+        plot=linegraph.plot(plot_data, pconfig),
     )
 
     # Return the number of detected samples to the parent module


### PR DESCRIPTION
## Summary

- Add support for MEAN_ORIGINAL_QUALITY column in QualityByCycleMetrics reports
- Enable comparison between recalibrated and original quality scores when BQSR has been applied
- Maintain backward compatibility with standard format files
- Enhanced visualization with data labels to distinguish quality metrics

## Changes Made

- Modified `parse_reports()` to try both extended (with MEAN_ORIGINAL_QUALITY) and standard formats
- Updated plotting logic to display both recalibrated and original quality scores when available
- Added data labels for better plot interpretation
- Enhanced help text to explain the BQSR comparison functionality

## Test Plan

- [x] Test with standard format files (backward compatibility)
- [x] Test with extended format files containing MEAN_ORIGINAL_QUALITY
- [x] Verify plot rendering with dual datasets
- [x] Check help text and data labels display correctly

Closes #3142

🤖 Generated with [Claude Code](https://claude.ai/code)