### PR TITLE
Ignore pyc files when copying html files

### DIFF
--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -510,11 +510,18 @@ def _write_html_report(to_stdout: bool, report_path: Optional[Path], return_html
     except AttributeError:
         pass  # Not a child theme
     else:
-        shutil.copytree(parent_template.template_dir, tmp_dir.get_tmp_dir(), dirs_exist_ok=True)
+        shutil.copytree(
+            parent_template.template_dir,
+            tmp_dir.get_tmp_dir(),
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("*.pyc"),
+        )
 
     # Copy the template files to the tmp directory (`dirs_exist_ok` makes sure
     # parent template files are overwritten)
-    shutil.copytree(template_mod.template_dir, tmp_dir.get_tmp_dir(), dirs_exist_ok=True)
+    shutil.copytree(
+        template_mod.template_dir, tmp_dir.get_tmp_dir(), dirs_exist_ok=True, ignore=shutil.ignore_patterns("*.pyc")
+    )
 
     # Function to include file contents in Jinja template
     def include_file(name, fdir=tmp_dir.get_tmp_dir(), b64=False):


### PR DESCRIPTION
In an environment where MultiQC is used by multiple users, the generated pyc files are owned by whichever user ran MultiQC for the first time after installation. Subsequent runs by other users generate errors, for example 
```py
File "/path/lib/python3.11/site-packages/multiqc/core/write_results.py", line 90, in write_results
    _write_html_report(paths.to_stdout, paths.report_path)
  File "/path/lib/python3.11/site-packages/multiqc/core/write_results.py", line 461, in _write_html_report
    shutil.copytree(parent_template.template_dir, tmp_dir.get_tmp_dir(), dirs_exist_ok=True)
  File "/path/lib/python3.11/shutil.py", line 573, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/lib/python3.11/shutil.py", line 527, in _copytree
    raise Error(errors)
shutil.Error: [('/path/lib/python3.11/site-packages/multiqc/templates/default/__pycache__/__init__.cpython-311.pyc', '/scratch/tmphz85j65c/__pycache__/__init__.cpython-311.pyc', "[Errno 13] Permission denied: '/path/lib/python3.11/site-packages/multiqc/templates/default/__pycache__/__init__.cpython-311.pyc'")]
```
Adding ignore seems to get around this issue.
