### PR TITLE
docs: Fix links causing Docusaurus warnings 

### DIFF
--- a/docs/markdown/getting_started/installation.md
+++ b/docs/markdown/getting_started/installation.md
@@ -12,7 +12,7 @@ If you're new to software packaging, this page can be a little overwhelming.
 If in doubt, a general rule is:
 
 - _Running MultiQC in a pipeline?_ &nbsp; Use [Docker](#docker) or [Singularity](#singularity).
-- _Running MultiQC locally?_ &nbsp; Use [Pip](#pip) or [Conda](#conda).
+- _Running MultiQC locally?_ &nbsp; Use [Pip](#pip--pypi) or [Conda](#conda).
 
 :::tip{title="Installation cheat sheet"}
 

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -72,7 +72,7 @@ class MultiqcModule(BaseMultiqcModule):
     :::
 
     You can customise the patterns used for finding these files in your
-    MultiQC config (see [Module search patterns](#module-search-patterns)).
+    MultiQC config (see [Module search patterns](https://docs.seqera.io/multiqc/getting_started/config#module-search-patterns)).
     The below code shows the default file patterns:
 
     ```yaml

--- a/multiqc/modules/featurecounts/featurecounts.py
+++ b/multiqc/modules/featurecounts/featurecounts.py
@@ -36,7 +36,7 @@ class MultiqcModule(BaseMultiqcModule):
     As of MultiQC v1.10, the module should also work with output from
     [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html).
     Note that your filenames must end in `.summary` to be discovered.
-    See [Module search patterns](#module-search-patterns) for how to customise this.
+    See [Module search patterns](https://docs.seqera.io/multiqc/getting_started/config#module-search-patterns) for how to customise this.
 
     Please note that if files are in "Rsubread mode" then lines will be split by any
     whitespace, instead of tab characters. As such, filenames with spaces in will


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
