### PR TITLE
Add configurable helptext to general statistics table

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -153,6 +153,7 @@ collapse_tables: bool
 max_table_rows: int
 max_configurable_table_columns: int
 general_stats_columns: Dict[str, Dict]
+general_stats_helptext: str
 table_columns_visible: Dict[str, Union[bool, Dict[str, bool]]]
 table_columns_placement: Dict[str, Dict[str, float]]
 table_columns_name: Dict[str, Union[str, Dict[str, str]]]

--- a/multiqc/config_defaults.yaml
+++ b/multiqc/config_defaults.yaml
@@ -106,6 +106,7 @@ collapse_tables: true
 max_table_rows: 500
 max_configurable_table_columns: 200
 general_stats_columns: {}
+general_stats_helptext: null
 table_columns_visible: {}
 table_columns_placement: {}
 table_columns_name: {}

--- a/multiqc/templates/default/assets/css/default_multiqc.css
+++ b/multiqc/templates/default/assets/css/default_multiqc.css
@@ -231,6 +231,10 @@ kbd {
   column-gap: 10px;
 }
 
+.general-stats-help-btn {
+  overflow: auto;
+}
+
 h2.mqc-module-title {
   margin: 0;
 }

--- a/multiqc/templates/default/general_stats.html
+++ b/multiqc/templates/default/general_stats.html
@@ -39,6 +39,18 @@ This block generates the General Statistics table at the top of the report.
     <div class="ai-summary-error" id="general_stats_table_ai_summary_error" style="display: none;"></div>
   </div>
 
+  {% if config.general_stats_helptext is not none and config.general_stats_helptext | length > 0 %}
+  <div class="general-stats-help-btn">
+    <button class="btn btn-default btn-sm pull-right btn-help" type="button" data-toggle="collapse" data-target="#general_stats_table_helptext" aria-expanded="false" aria-controls="general_stats_table_helptext">
+      <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+      Help
+    </button>
+  </div>
+  <div class="collapse mqc-section-helptext " id="general_stats_table_helptext">
+    <div class="well">{{ config.general_stats_helptext }}</div>
+  </div>
+  {% endif %}
+
   {{ report.general_stats_html }}
 </div>
 {% endif %}

--- a/multiqc/utils/config_schema.py
+++ b/multiqc/utils/config_schema.py
@@ -195,6 +195,9 @@ class MultiQCConfig(BaseModel):
     general_stats_columns: Dict[str, GeneralStatsModuleConfig] = Field(
         default_factory=dict, description="Configuration for general stats columns per module. Keys are module IDs."
     )
+    general_stats_helptext: str = Field(
+        None, description="Help text for general statistics table."
+    )
     table_columns_visible: Optional[Dict[str, Union[bool, Dict[str, bool]]]] = Field(
         None, description="Which columns to show in tables"
     )


### PR DESCRIPTION
Similar to other sections, this adds expandable helptext to general statistics.

I explored various options for where to put this config as I was trying to avoid a top-level config. For other sections, it's configured as part of the section itself. Therefore it didn't make sense to put it in the `pconfig` for general stats.

I'm open to other ideas on where to nest this config.

<img width="1620" height="215" alt="2025-09-08_23-43" src="https://github.com/user-attachments/assets/e0ffd44c-a0dd-4cbb-a901-b01d1c036c49" />

<img width="1600" height="285" alt="2025-09-08_23-43_1" src="https://github.com/user-attachments/assets/6c71ee3e-ebdb-452d-b2cd-a8f63b19b7da" />
