### PR TITLE
Remove bedrock availability check when creating client

### DIFF
--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -489,16 +489,6 @@ class AWSBedrockClient(Client):
     def __init__(self):
         super().__init__()
 
-        # Check Bedrock availability with detailed error reporting
-        is_available, error_msg = _check_bedrock_availability()
-        if not is_available:
-            if "boto3 not installed" in str(error_msg):
-                raise ImportError(
-                    'AI summary through AWS bedrock requires "boto3" to be installed. Install it with `pip install boto3`'
-                )
-            else:
-                raise RuntimeError(f"AWS Bedrock is not available: {error_msg}")
-
         self.model = config.ai_model
         self.name = "aws_bedrock"
         self.title = "AWS Bedrock"


### PR DESCRIPTION
Fixes https://github.com/MultiQC/MultiQC/issues/3342

I understand these rigorous checks for auto-detecting whether bedrock is available (I'm not sure how else you'd check - maybe a naive `AWS_DEFAULT_REGION` or `AWS_REGION` env var). Anyway, users can always override the auto-detect logic and bypass it.

However if I tell multiqc to use bedrock, I'd like it to try to use bedrock. It shouldn't decide it doesn't think it'll be able to succeed on that endeavour, I'd hope aws error messages are good enough (no region configured, no permissions, etc).