### PR TITLE
Require maintainer access for /review command

### DIFF
--- a/.github/workflows/claude-code-review-trigger.yml
+++ b/.github/workflows/claude-code-review-trigger.yml
@@ -21,27 +21,20 @@ jobs:
        contains(github.event.comment.body, '/review'))
 
     steps:
-      - name: Check commenter write access
-        id: check-access
+      - name: Require maintainer access
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PERM=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" -q '.permission')
-          if [[ "$PERM" == "admin" || "$PERM" == "write" ]]; then
-            echo "has_write=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_write=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: ${{ github.event.comment.user.login }} has '$PERM' permission (write required)"
-          fi
+          echo "${{ github.event.comment.user.login }} has permission: $PERM"
+          [[ "$PERM" =~ ^(admin|maintain|write)$ ]] || exit 1
 
       - name: Checkout repository
-        if: steps.check-access.outputs.has_write == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Save PR info
-        if: steps.check-access.outputs.has_write == 'true'
         run: |
           mkdir -p pr-info
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -57,7 +50,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload PR info
-        if: steps.check-access.outputs.has_write == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-info

--- a/.github/workflows/claude-code-review-trigger.yml
+++ b/.github/workflows/claude-code-review-trigger.yml
@@ -21,12 +21,27 @@ jobs:
        contains(github.event.comment.body, '/review'))
 
     steps:
+      - name: Check commenter write access
+        id: check-access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERM=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" -q '.permission')
+          if [[ "$PERM" == "admin" || "$PERM" == "write" ]]; then
+            echo "has_write=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_write=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: ${{ github.event.comment.user.login }} has '$PERM' permission (write required)"
+          fi
+
       - name: Checkout repository
+        if: steps.check-access.outputs.has_write == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Save PR info
+        if: steps.check-access.outputs.has_write == 'true'
         run: |
           mkdir -p pr-info
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -42,6 +57,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload PR info
+        if: steps.check-access.outputs.has_write == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-info


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

Adds a permission gate to the `/review` trigger workflow. A single step runs first, queries the commenter's repo permission via the GitHub API, and exits non-zero if it is not `admin`, `maintain`, or `write`. This fails the trigger workflow, so the downstream `claude-code-review` workflow naturally skips via its existing `conclusion == 'success'` guard.

```yaml
- name: Require maintainer access
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    PERM=$(gh api "repos/.../collaborators/.../permission" -q '.permission')
    echo "... has permission: $PERM"
    [[ "$PERM" =~ ^(admin|maintain|write)$ ]] || exit 1
```

Three lines of bash, no conditional flags on other steps, no artifact changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-009cdbd0-7cb4-4920-9e72-d56f63e24a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-009cdbd0-7cb4-4920-9e72-d56f63e24a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

