### PR TITLE
NGSBits: Fix `SampleGender` parsing for unknown gender

### DIFF
--- a/multiqc/modules/ngsbits/samplegender.py
+++ b/multiqc/modules/ngsbits/samplegender.py
@@ -100,12 +100,18 @@ def parse_file(f: str) -> Dict[str, Union[float, str]]:
         return parsed_data
 
     headers = lines[0].strip().split("\t")[1:5]
-    values = lines[1].strip().split("\t")[1:5]
+    values = lines[1].strip().split("\t")[1:]
+
+    if len(headers) > 1 and headers[0] == "gender" and len(values) > len(headers):
+        metric_count = len(headers) - 1
+        values = [" ".join(values[:-metric_count])] + values[-metric_count:]
+    else:
+        values = values[: len(headers)]
 
     for key, value in zip(headers, values):
         try:
             parsed_data[key] = float(value)
         except ValueError:
-            parsed_data[key] = value
+            parsed_data[key] = " ".join(value.split())
 
     return parsed_data

--- a/multiqc/modules/ngsbits/tests/test_samplegender.py
+++ b/multiqc/modules/ngsbits/tests/test_samplegender.py
@@ -1,0 +1,31 @@
+import pytest
+
+from multiqc.modules.ngsbits.samplegender import parse_file
+
+
+def test_parse_samplegender_report():
+    report = """\
+#file\tgender\treads_chry\treads_chrx\tratio_chry_chrx
+SAMPLE1_sorted_md.bam\tmale\t3872086\t14244970\t0.2718
+"""
+
+    assert parse_file(report) == {
+        "gender": "male",
+        "reads_chry": 3872086.0,
+        "reads_chrx": 14244970.0,
+        "ratio_chry_chrx": 0.2718,
+    }
+
+
+def test_parse_samplegender_unknown_gender_with_tabbed_description():
+    report = """\
+#sample\tgender\treads_chry\treads_chrx\tratio_chry_chrx
+XXX\tunknown\t(ratio\tin\tgray\tarea)\t12246\t153042\t0.0800
+"""
+
+    assert parse_file(report) == {
+        "gender": "unknown (ratio in gray area)",
+        "reads_chry": 12246.0,
+        "reads_chrx": 153042.0,
+        "ratio_chry_chrx": pytest.approx(0.08),
+    }


### PR DESCRIPTION
## Summary
- handle SampleGender rows where the `gender` value contains tab-separated text, such as `unknown (ratio in gray area)`
- keep the trailing numeric SampleGender metrics aligned with their headers
- add parser regression tests for the normal and unknown-gender cases

Fixes #3539

## Testing
- `./.venv/bin/pytest multiqc/modules/ngsbits/tests/test_samplegender.py`
- `./.venv/bin/ruff check multiqc/modules/ngsbits/samplegender.py multiqc/modules/ngsbits/tests/test_samplegender.py`
- smoke-tested MultiQC with the issue sample row and checked `multiqc_ngsbits_samplegender.txt` output