### PR TITLE
Fix link that errors in docs build

### DIFF
--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -387,6 +387,23 @@ fn_clean_exts:
     )
 
     render_special_type(
+        GeneralStatsModuleConfig,
+        """Per-module wrapper for General Stats column overrides.
+
+The `GeneralStatsModuleConfig` type is the value of each module entry in the `general_stats_columns` configuration option. It has a single `columns` key mapping column IDs to `GeneralStatsColumnConfig` settings.
+
+Example:
+
+```yaml
+general_stats_columns:
+  fastqc:
+    columns:
+      percent_duplicates:
+        title: "% Dups"
+```""",
+    )
+
+    render_special_type(
         GeneralStatsColumnConfig,
         """Configuration for columns in the general statistics table.
 


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

Fix for check-internal-links CI in docs repo:

```
  Exhaustive list of all broken anchors found:
  - Broken anchor on source page path = /multiqc/config_schema:
     -> linking to #generalstatsmoduleconfig (resolved as: /multiqc/config_schema#generalstatsmoduleconfig)
  - Broken anchor on source page path = /platform-cloud/git/overview:
     -> linking to #seqera-ai (resolved as: /platform-cloud/git/overview#seqera-ai)
```

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
