### PR TITLE
Replace rstrip with removesuffix in custom content module

### DIFF
--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -146,8 +146,8 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                     "id": f["s_name"],
                     "plot_type": "image",
                     "section_name": f["s_name"]
-                    .rstrip(f_extension)
-                    .rstrip("_mqc")
+                    .removesuffix(f_extension)
+                    .removesuffix("_mqc")
                     .replace("_", " ")
                     .replace("-", " ")
                     .replace(".", " "),
@@ -179,8 +179,8 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                     "id": f["s_name"],
                     "plot_type": "html",
                     "section_name": f["s_name"]
-                    .rstrip(f_extension)
-                    .rstrip("_mqc")
+                    .removesuffix(f_extension)
+                    .removesuffix("_mqc")
                     .replace("_", " ")
                     .replace("-", " ")
                     .replace(".", " "),


### PR DESCRIPTION
The custom content module sometimes removes the last letter when determining the section title. I suspect it is this use of `.rstrip`. 

`.rstrip` does not remove a substring, but removes all matching letters at the end of the string. Python 3.9 (which is the minium supporting version for Multiqc introduced `.removesuffix` to have this addressed. 

Compare: 

```
>>> f = "Organism_mqc.png"
>>> f.rstrip(".png").rstrip("_mqc")
'Organis'
>>> f.removesuffix(".png").removesuffix("_mqc")
'Organism'
``` 
