### PR TITLE
Handle new bedrock models with thinking responses, and handle refusals

### DIFF
--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -41,6 +41,11 @@ REASONING_MODELS = {
 }
 
 
+REFURSAL_STUB_CONTENT = """\
+AI summary could not be generated as the request was refused by the model
+"""
+
+
 def is_reasoning_model(model_name: str) -> bool:
     """Check if a model is a reasoning model based on its name."""
     if not model_name:
@@ -517,7 +522,9 @@ class AWSBedrockClient(Client):
         )
 
         response_body = json.loads(response["body"].read())
-        if "content" not in response_body:
+        if response_body["stop_reason"] == "refusal":
+            return AWSBedrockClient.ApiResponse(content=REFURSAL_STUB_CONTENT, model=self.model)
+        if not response_body.get("content", []):
             logger.error(f"bedrock response does not have 'content': {response_body}")
             raise ValueError("Unexpected bedrock response body")
         text_blocks = [b for b in response_body["content"] if b["type"] == "text"]

--- a/multiqc/core/ai.py
+++ b/multiqc/core/ai.py
@@ -517,14 +517,14 @@ class AWSBedrockClient(Client):
         )
 
         response_body = json.loads(response["body"].read())
-        if (
-            "content" not in response_body
-            or len(response_body["content"]) != 1
-            or "text" not in response_body["content"][0]
-        ):
-            logger.error(f"bedrock response content: {response_body}")
+        if "content" not in response_body:
+            logger.error(f"bedrock response does not have 'content': {response_body}")
             raise ValueError("Unexpected bedrock response body")
-        content = response_body["content"][0]["text"]  # Extract the assistant's response
+        text_blocks = [b for b in response_body["content"] if b["type"] == "text"]
+        if len(text_blocks) != 1:
+            logger.error(f"bedrock response does not contain 1 text block: {response_body}")
+            raise ValueError("Unexpected bedrock response body")
+        content = text_blocks[0]["text"]  # Extract the assistant's response
         return AWSBedrockClient.ApiResponse(content=content, model=self.model)
 
 


### PR DESCRIPTION
Two issues observed with current implementation:

1. We'll get responses like:

	```
	{'model': 'claude-sonnet-5',
	 'id': '<redacted>',
	 'type': 'message',
	 'role': 'assistant',
	 'content': [{'type': 'thinking',
	              'thinking': '',
	              'signature': '<redacted>'},
	             {'type': 'text',
	              'text': '# Genome Abundance Analysis\n'
	             }],
	}
	```
2. Models refuse requests (e.g. try putting `Burkholderia pseudomallei` in a prompt)

This PR handles both cases.

<img width="1618" height="361" alt="2026-07-01_20-32" src="https://github.com/user-attachments/assets/f7062439-679c-4723-8166-2467dd061dc3" />
