### PR TITLE
mosdepth: fix pre-existing mypy errors

### DIFF
--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -305,7 +305,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.write_data_file(perchrom_avg_by_sample, "mosdepth_perchrom")
 
                 num_contigs = max([len(x.keys()) for x in perchrom_avg_by_sample.values()])
-                perchrom_plot: Union[Plot, str]
+                perchrom_plot: Optional[Union[Plot, str]]
                 if num_contigs > 1:
                     perchrom_plot = linegraph.plot(
                         perchrom_avg_by_sample,

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -207,10 +207,10 @@ class MultiqcModule(BaseMultiqcModule):
         genstats_by_sample = defaultdict(dict, self.ignore_samples(genstats_by_sample))
         samples_in_summary = set(genstats_by_sample.keys())
 
-        data_dicts_global = self.parse_cov_dist("global")
-        data_dicts_region = self.parse_cov_dist("region")
-        data_dicts_global = [self.ignore_samples(d) for d in data_dicts_global]
-        data_dicts_region = [self.ignore_samples(d) for d in data_dicts_region]
+        raw_cov_dist_global = self.parse_cov_dist("global")
+        raw_cov_dist_region = self.parse_cov_dist("region")
+        data_dicts_global = [self.ignore_samples(d) for d in raw_cov_dist_global]
+        data_dicts_region = [self.ignore_samples(d) for d in raw_cov_dist_region]
 
         samples_global = set.union(*(set(d.keys()) for d in data_dicts_global))
         samples_region = set.union(*(set(d.keys()) for d in data_dicts_region))

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -1,13 +1,14 @@
 import fnmatch
 import logging
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 from multiqc import Plot, config
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 from multiqc.modules.qualimap.QM_BamQC import genome_fraction_helptext
 from multiqc.plots import bargraph, linegraph
 from multiqc.plots.linegraph import smooth_array
+from multiqc.plots.table_object import ValueT
 from multiqc.utils.util_functions import update_dict
 
 log = logging.getLogger(__name__)
@@ -430,7 +431,7 @@ class MultiqcModule(BaseMultiqcModule):
                 },
             },
         )
-        self.general_stats_addcols(genstats_by_sample, genstats_headers)
+        self.general_stats_addcols(cast(Dict[str, Dict[str, ValueT]], genstats_by_sample), genstats_headers)
 
     def parse_cov_dist(
         self, scope: str


### PR DESCRIPTION
## Summary

Small type-only maintenance PR, no behaviour change. Fixes the 6 pre-existing `mypy` errors in `multiqc/modules/mosdepth/mosdepth.py` (noticed while working on #3612, split out separately since it's unrelated cleanup):

- Renaming the `parse_cov_dist()` tuple result before reassigning it to a list comprehension, so mypy doesn't try to narrow the same variable to two incompatible types (also fixed a follow-on `"object" has no attribute "update"` error caused by the same narrowing issue).
- Widening `perchrom_plot`'s declared type to `Optional[Union[Plot, str]]`, since `linegraph.plot()`/`bargraph.plot()` can return `None` for all-zero data.
- Casting the `general_stats_addcols()` argument to match its invariant `Dict[..., ValueT]` parameter, since `genstats_by_sample`'s `int | float` value type doesn't satisfy `ValueT = Union[int, float, str, bool]` under Dict's invariance rules.

## Test plan

- [x] `mypy multiqc/modules/mosdepth/mosdepth.py` - 0 errors (down from 6)
- [x] `ruff check`, `python .github/workflows/code_checks.py`
- [x] `pytest tests/test_modules_run.py -k mosdepth` and `pytest multiqc/modules/mosdepth/tests/`
- [x] `multiqc test-data/data/modules/mosdepth -m mosdepth --strict`