### PR TITLE
Add native vcf-sv-stats module

### DIFF
--- a/multiqc/modules/vcf_sv_stats/__init__.py
+++ b/multiqc/modules/vcf_sv_stats/__init__.py
@@ -1,0 +1,3 @@
+from .vcf_sv_stats import MultiqcModule
+
+__all__ = ["MultiqcModule"]

--- a/multiqc/modules/vcf_sv_stats/parser.py
+++ b/multiqc/modules/vcf_sv_stats/parser.py
@@ -1,0 +1,258 @@
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import jsonschema
+import rfc8785
+
+SUMMARY_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "urn:vcf-sv-stats:schema:summary:1.0.0",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "schema_name",
+        "schema_version",
+        "content_signature",
+        "producer",
+        "input",
+        "callset",
+        "validation",
+        "statistics",
+        "reports",
+        "payload_sha256",
+    ],
+    "properties": {
+        "schema_name": {"const": "vcf-sv-stats.summary"},
+        "schema_version": {"const": "1.0.0"},
+        "content_signature": {"const": "vcf-sv-stats:summary:1"},
+        "producer": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["name", "version"],
+            "properties": {
+                "name": {"const": "vcf-sv-stats"},
+                "version": {"type": "string", "minLength": 1},
+            },
+        },
+        "input": {"type": "object"},
+        "callset": {"type": "object"},
+        "validation": {"type": "object"},
+        "statistics": {"type": "object"},
+        "reports": {"type": "array", "items": {"type": "object"}},
+        "payload_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "execution": {"type": ["object", "null"]},
+    },
+}
+
+
+class SummaryValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ParsedReport:
+    report_id: str
+    payload_sha256: str
+    producer_version: str
+    callset: dict[str, Any]
+    validation: dict[str, Any]
+    report: dict[str, Any]
+
+
+def mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SummaryValidationError(f"{field} must be an object")
+    return value
+
+
+def non_negative_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SummaryValidationError(f"{field} must be a non-negative integer")
+    return value
+
+
+def non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise SummaryValidationError(f"{field} must be a non-empty string")
+    return value
+
+
+def count_mapping(value: Any, field: str) -> dict[str, int]:
+    raw = mapping(value, field)
+    return {str(key): non_negative_integer(count, f"{field}.{key}") for key, count in raw.items()}
+
+
+def _validate_statistics(statistics: dict[str, Any], prefix: str) -> None:
+    source_records = mapping(statistics["source_records"], f"{prefix}.source_records")
+    non_negative_integer(source_records["total"], f"{prefix}.source_records.total")
+    alleles = mapping(statistics["alleles"], f"{prefix}.alleles")
+    non_negative_integer(alleles["total"], f"{prefix}.alleles.total")
+    count_mapping(alleles["types"], f"{prefix}.alleles.types")
+    events = mapping(statistics["events"], f"{prefix}.events")
+    non_negative_integer(events["resolved"], f"{prefix}.events.resolved")
+    breakends = mapping(statistics["breakends"], f"{prefix}.breakends")
+    for key in (
+        "total",
+        "reciprocal_pairs",
+        "without_declared_mate",
+        "unresolved_mate_references",
+    ):
+        non_negative_integer(breakends[key], f"{prefix}.breakends.{key}")
+    count_mapping(statistics["filters"], f"{prefix}.filters")
+    count_mapping(statistics["genotypes"], f"{prefix}.genotypes")
+    count_mapping(statistics["copy_number"], f"{prefix}.copy_number")
+
+    support = mapping(statistics["merged_support"], f"{prefix}.merged_support")
+    non_empty_string(support["status"], f"{prefix}.merged_support.status")
+    declared_fields = support["declared_fields"]
+    if not isinstance(declared_fields, list) or not all(isinstance(field, str) and field for field in declared_fields):
+        raise SummaryValidationError(f"{prefix}.merged_support.declared_fields must be a string array")
+    records_with_support = non_negative_integer(
+        support["records_with_support"], f"{prefix}.merged_support.records_with_support"
+    )
+    non_negative_integer(support["records_without_support"], f"{prefix}.merged_support.records_without_support")
+    supporting_sources = count_mapping(support["supporting_sources"], f"{prefix}.merged_support.supporting_sources")
+    if sum(supporting_sources.values()) != records_with_support:
+        raise SummaryValidationError(f"{prefix}.merged_support counts do not reconcile")
+    count_mapping(support["source_count_states"], f"{prefix}.merged_support.source_count_states")
+    consistency = count_mapping(
+        support["vector_count_consistency"],
+        f"{prefix}.merged_support.vector_count_consistency",
+    )
+    if sum(consistency.values()) != records_with_support:
+        raise SummaryValidationError(f"{prefix}.merged_support consistency does not reconcile")
+    if support["interpretation"] != "merger_provenance_only":
+        raise SummaryValidationError(f"{prefix}.merged_support interpretation is unsupported")
+
+    length = mapping(statistics["length_bp"], f"{prefix}.length_bp")
+    boundaries = length["boundaries"]
+    counts = length["counts"]
+    if not isinstance(boundaries, list) or not isinstance(counts, list):
+        raise SummaryValidationError(f"{prefix}.length_bp histogram must use arrays")
+    if len(boundaries) != len(counts):
+        raise SummaryValidationError(f"{prefix}.length_bp histogram cardinality differs")
+    total = sum(non_negative_integer(count, f"{prefix}.length_bp.counts") for count in counts)
+    if total != non_negative_integer(length["n"], f"{prefix}.length_bp.n"):
+        raise SummaryValidationError(f"{prefix}.length_bp counts do not reconcile")
+
+    contracts = mapping(statistics["metric_contracts"], f"{prefix}.metric_contracts")
+    for metric in (
+        "alleles",
+        "breakends",
+        "copy_number",
+        "events",
+        "filters",
+        "genotypes",
+        "length_bp",
+        "merged_support",
+        "source_records",
+    ):
+        contract = mapping(contracts[metric], f"{prefix}.metric_contracts.{metric}")
+        for field in ("scope", "denominator", "unit", "comparability"):
+            non_empty_string(contract[field], f"{prefix}.metric_contracts.{metric}.{field}")
+
+
+def _parse_summary(content: str, source_name: str) -> tuple[ParsedReport, ...]:
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise SummaryValidationError(f"Invalid JSON in {source_name}") from exc
+    if not isinstance(payload, dict):
+        raise SummaryValidationError(f"Summary root must be an object in {source_name}")
+
+    version = str(payload.get("schema_version", ""))
+    try:
+        major = int(version.split(".", 1)[0])
+    except ValueError as exc:
+        raise SummaryValidationError(f"Invalid schema version in {source_name}") from exc
+    if major != 1:
+        raise SummaryValidationError(f"Unsupported summary schema major in {source_name}")
+    if version != "1.0.0":
+        raise SummaryValidationError(f"Unsupported summary schema version in {source_name}")
+    try:
+        jsonschema.Draft202012Validator(SUMMARY_SCHEMA).validate(payload)
+    except jsonschema.ValidationError as exc:
+        raise SummaryValidationError(f"Summary schema validation failed in {source_name}") from exc
+
+    expected_digest = payload["payload_sha256"]
+    digest_payload = dict(payload)
+    digest_payload.pop("payload_sha256")
+    digest_payload.pop("execution", None)
+    observed_digest = hashlib.sha256(rfc8785.dumps(digest_payload)).hexdigest()
+    if expected_digest != observed_digest:
+        raise SummaryValidationError(f"Summary payload digest does not match in {source_name}")
+
+    producer = mapping(payload["producer"], "producer")
+    producer_version = non_empty_string(producer["version"], "producer.version")
+    callset = mapping(payload["callset"], "callset")
+    callset_producer = mapping(callset["producer"], "callset.producer")
+    for field in ("adapter_id", "producer", "status"):
+        non_empty_string(callset_producer[field], f"callset.producer.{field}")
+    non_negative_integer(callset["record_count"], "callset.record_count")
+    non_negative_integer(callset["allele_count"], "callset.allele_count")
+
+    validation = mapping(payload["validation"], "validation")
+    count_mapping(validation["diagnostic_counts"], "validation.diagnostic_counts")
+    states = mapping(validation["states"], "validation.states")
+    for field in (
+        "container_state",
+        "parse_state",
+        "vcf_conformance_state",
+        "sv_semantic_state",
+        "operation_safety_state",
+        "statistics_state",
+    ):
+        non_empty_string(states[field], f"validation.states.{field}")
+
+    reports = payload["reports"]
+    if not reports:
+        raise SummaryValidationError(f"Summary contains no reports in {source_name}")
+    parsed: list[ParsedReport] = []
+    seen_ids: set[str] = set()
+    for index, raw_report in enumerate(reports):
+        report = mapping(raw_report, f"reports[{index}]")
+        report_id = non_empty_string(report["report_id"], f"reports[{index}].report_id")
+        if report_id in seen_ids:
+            raise SummaryValidationError(f"Duplicate report identifier in {source_name}")
+        seen_ids.add(report_id)
+        analysis_unit = mapping(report["analysis_unit"], f"reports[{index}].analysis_unit")
+        non_empty_string(analysis_unit["status"], f"reports[{index}].analysis_unit.status")
+        mapped_samples = report["mapped_vcf_sample_ids"]
+        if not isinstance(mapped_samples, list) or not all(
+            isinstance(sample, str) and sample for sample in mapped_samples
+        ):
+            raise SummaryValidationError(f"reports[{index}].mapped_vcf_sample_ids must be a string array")
+        statistics = mapping(report["statistics"], f"reports[{index}].statistics")
+        _validate_statistics(statistics, f"reports[{index}].statistics")
+        report_digest = hashlib.sha256(rfc8785.dumps(report)).hexdigest()
+        parsed.append(
+            ParsedReport(
+                report_id=report_id,
+                payload_sha256=report_digest,
+                producer_version=producer_version,
+                callset=callset,
+                validation=validation,
+                report=report,
+            )
+        )
+    return tuple(parsed)
+
+
+def parse_summary(content: str, source_name: str = "summary") -> tuple[ParsedReport, ...]:
+    try:
+        return _parse_summary(content, source_name)
+    except SummaryValidationError:
+        raise
+    except (KeyError, TypeError) as exc:
+        raise SummaryValidationError(f"Summary is missing a required nested field in {source_name}") from exc
+
+
+def length_label(boundary: Any) -> str:
+    if not isinstance(boundary, list) or len(boundary) != 2:
+        raise SummaryValidationError("Length boundary must contain lower and upper values")
+    lower, upper = boundary
+    if not isinstance(lower, int) or (upper is not None and not isinstance(upper, int)):
+        raise SummaryValidationError("Length boundary values must be integers or null")
+    return f"{lower:,}+ bp" if upper is None else f"{lower:,}-{upper - 1:,} bp"

--- a/multiqc/modules/vcf_sv_stats/tests/test_vcf_sv_stats.py
+++ b/multiqc/modules/vcf_sv_stats/tests/test_vcf_sv_stats.py
@@ -1,0 +1,284 @@
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import rfc8785
+
+from multiqc import config, report, validation
+from multiqc.modules.vcf_sv_stats import MultiqcModule
+from multiqc.modules.vcf_sv_stats.parser import SummaryValidationError, parse_summary
+
+
+@pytest.fixture(autouse=True)
+def reset_multiqc_state():
+    yield
+    report.reset()
+    config.reset()
+    validation.reset()
+
+
+def _metric_contract(scope: str, unit: str, comparability: str) -> dict[str, str]:
+    return {
+        "scope": scope,
+        "denominator": f"all_{scope}",
+        "unit": unit,
+        "comparability": comparability,
+    }
+
+
+def _statistics() -> dict[str, Any]:
+    return {
+        "source_records": {"total": 12},
+        "alleles": {"total": 14, "types": {"BND": 2, "DEL": 7, "DUP": 5}},
+        "events": {"resolved": 13},
+        "breakends": {
+            "total": 2,
+            "reciprocal_pairs": 1,
+            "without_declared_mate": 0,
+            "unresolved_mate_references": 0,
+        },
+        "filters": {"PASS": 10, "filtered_any": 2, "LowQuality": 2},
+        "genotypes": {
+            "heterozygous_or_other_alt": 8,
+            "homozygous_alt": 2,
+            "no_call": 2,
+        },
+        "copy_number": {"1": 7, "2": 3, "missing": 2},
+        "merged_support": {
+            "status": "not_declared",
+            "declared_fields": [],
+            "records_with_support": 0,
+            "records_without_support": 0,
+            "supporting_sources": {},
+            "source_count_states": {},
+            "vector_count_consistency": {},
+            "interpretation": "merger_provenance_only",
+        },
+        "length_bp": {
+            "boundaries": [[0, 50], [50, 100], [100, None]],
+            "counts": [2, 5, 5],
+            "n": 12,
+            "missing": 0,
+            "invalid": 0,
+            "not_applicable": 2,
+            "policy_id": "vss-bins/1",
+        },
+        "metric_contracts": {
+            "source_records": _metric_contract("source_records", "records", "canonical-observation/1"),
+            "alleles": _metric_contract("alternate_alleles", "alleles", "canonical-observation/1"),
+            "events": _metric_contract("resolved_events", "events", "event-resolution/1"),
+            "breakends": _metric_contract("breakend_observations", "breakends", "event-resolution/1"),
+            "filters": _metric_contract("source_records", "records", "vcf-filter-state/1"),
+            "genotypes": _metric_contract("sample_calls", "sample_calls", "vcf-genotype-state/1"),
+            "copy_number": _metric_contract("sample_calls", "declared_copy_number", "declared-cn/1"),
+            "length_bp": _metric_contract("alternate_alleles", "base_pairs", "vss-bins/1"),
+            "merged_support": _metric_contract("source_records", "records", "merger-support-provenance/1"),
+        },
+    }
+
+
+def make_summary(report_count: int = 1) -> dict[str, Any]:
+    statistics = _statistics()
+    value: dict[str, Any] = {
+        "schema_name": "vcf-sv-stats.summary",
+        "schema_version": "1.0.0",
+        "content_signature": "vcf-sv-stats:summary:1",
+        "producer": {"name": "vcf-sv-stats", "version": "0.8.0"},
+        "input": {
+            "display_name": "neutral.hg002.vcf.gz",
+            "complete": True,
+            "sha256": "a" * 64,
+        },
+        "callset": {
+            "record_count": 12,
+            "allele_count": 14,
+            "producer_kind": "caller",
+            "producer": {
+                "adapter_id": "urn:vcf-sv-stats:adapter:generic:1",
+                "producer": "unknown",
+                "version": None,
+                "status": "supported",
+            },
+        },
+        "validation": {
+            "diagnostic_counts": {},
+            "states": {
+                "container_state": "accepted",
+                "parse_state": "accepted",
+                "vcf_conformance_state": "conformant",
+                "sv_semantic_state": "consistent",
+                "operation_safety_state": "safe",
+                "statistics_state": "complete",
+            },
+        },
+        "statistics": statistics,
+        "reports": [
+            {
+                "report_id": f"vss1-test-{index:04d}",
+                "analysis_unit": {"status": "unresolved"},
+                "mapped_vcf_sample_ids": [],
+                "statistics": copy.deepcopy(statistics),
+            }
+            for index in range(report_count)
+        ],
+    }
+    value["payload_sha256"] = hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+    return value
+
+
+def render(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def resign(value: dict[str, Any]) -> dict[str, Any]:
+    value.pop("payload_sha256", None)
+    value["payload_sha256"] = hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+    return value
+
+
+def test_parser_validates_digest_schema_and_nested_contract() -> None:
+    value = make_summary()
+    parsed = parse_summary(render(value), "valid.vcf-sv-stats.json")
+    assert len(parsed) == 1
+    assert parsed[0].report_id == "vss1-test-0000"
+    assert parsed[0].report["statistics"]["events"]["resolved"] == 13
+
+    tampered = copy.deepcopy(value)
+    tampered["reports"][0]["statistics"]["events"]["resolved"] = 99
+    with pytest.raises(SummaryValidationError, match="digest does not match"):
+        parse_summary(render(tampered), "tampered.vcf-sv-stats.json")
+
+    future = copy.deepcopy(value)
+    future["schema_version"] = "2.0.0"
+    with pytest.raises(SummaryValidationError, match="schema major"):
+        parse_summary(render(future), "future.vcf-sv-stats.json")
+
+    malformed = copy.deepcopy(value)
+    malformed["reports"][0]["statistics"]["length_bp"]["n"] = 11
+    resign(malformed)
+    with pytest.raises(SummaryValidationError, match="counts do not reconcile"):
+        parse_summary(render(malformed), "malformed.vcf-sv-stats.json")
+
+    missing = copy.deepcopy(value)
+    del missing["reports"][0]["statistics"]["events"]
+    resign(missing)
+    with pytest.raises(SummaryValidationError, match="required nested field"):
+        parse_summary(render(missing), "missing.vcf-sv-stats.json")
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "unknown-producer",
+        "cnv",
+        "merged",
+        "multi-unit",
+        "unresolved",
+        "invalid",
+        "normalized-name",
+        "missing-optional-context",
+    ],
+)
+def test_parser_golden_context_matrix(case: str) -> None:
+    value = make_summary(report_count=2 if case == "multi-unit" else 1)
+    if case == "unknown-producer":
+        value["callset"]["producer"]["status"] = "provisional"
+    elif case == "cnv":
+        value["reports"][0]["statistics"]["alleles"]["types"] = {"CNV": 14}
+    elif case == "merged":
+        value["callset"]["producer_kind"] = "merger"
+        value["reports"][0]["statistics"]["merged_support"] = {
+            "status": "present",
+            "declared_fields": ["SUPP", "SUPP_VEC"],
+            "records_with_support": 12,
+            "records_without_support": 0,
+            "supporting_sources": {"1": 7, "2": 5},
+            "source_count_states": {"6": 12},
+            "vector_count_consistency": {"consistent": 12},
+            "interpretation": "merger_provenance_only",
+        }
+    elif case == "invalid":
+        value["validation"]["diagnostic_counts"] = {"error": 2, "warning": 1}
+        value["validation"]["states"]["vcf_conformance_state"] = "nonconformant"
+    elif case == "normalized-name":
+        value["input"]["display_name"] = "neutral.normalized.vcf.gz"
+    elif case == "missing-optional-context":
+        assert value["reports"][0]["analysis_unit"] == {"status": "unresolved"}
+    resign(value)
+    parsed = parse_summary(render(value), f"{case}.vcf-sv-stats.json")
+    assert len(parsed) == (2 if case == "multi-unit" else 1)
+
+
+def test_parser_handles_one_thousand_reports_deterministically() -> None:
+    value = make_summary(report_count=1000)
+    first = parse_summary(render(value), "scale.vcf-sv-stats.json")
+    second = parse_summary(render(value), "scale.vcf-sv-stats.json")
+    assert first == second
+    assert len(first) == 1000
+    assert first[0].report_id == "vss1-test-0000"
+    assert first[-1].report_id == "vss1-test-0999"
+
+
+def _write_summary(path: Path, value: dict[str, Any]) -> Path:
+    path.write_text(render(value), encoding="utf-8")
+    return path
+
+
+def test_module_renders_all_sections_and_preserves_report_identity(tmp_path: Path) -> None:
+    summary = make_summary()
+    summary["reports"][0]["analysis_unit"] = {
+        "status": "resolved",
+        "analysis_unit_id": "analysis-001",
+        "display_id": "Demonstration",
+        "algorithm_id": "generic-sv-1",
+    }
+    summary["reports"][0]["mapped_vcf_sample_ids"] = ["HG002"]
+    resign(summary)
+    source = _write_summary(tmp_path / "valid.vcf-sv-stats.json", summary)
+
+    report.analysis_files = [str(source)]
+    report.search_files(["vcf_sv_stats"])
+    module = MultiqcModule()
+
+    assert list(module.vcf_sv_stats_data) == ["vss1-test-0000"]
+    assert len(module.sections) == 11
+    assert {section.id for section in module.sections} == {
+        "vcf-sv-stats-overview",
+        "vcf-sv-stats-types",
+        "vcf-sv-stats-length",
+        "vcf-sv-stats-filters",
+        "vcf-sv-stats-breakends",
+        "vcf-sv-stats-merged-support",
+        "vcf-sv-stats-genotypes",
+        "vcf-sv-stats-copy-number",
+        "vcf-sv-stats-validation",
+        "vcf-sv-stats-normalization",
+        "vcf-sv-stats-provenance",
+    }
+    assert module.vcf_sv_stats_data["vss1-test-0000"]["report"]["mapped_vcf_sample_ids"] == ["HG002"]
+
+
+def test_module_deduplicates_identical_and_rejects_conflicting_reports(
+    tmp_path: Path,
+) -> None:
+    first = make_summary()
+    _write_summary(tmp_path / "first.vcf-sv-stats.json", first)
+    _write_summary(tmp_path / "second.vcf-sv-stats.json", first)
+    report.analysis_files = [str(tmp_path)]
+    report.search_files(["vcf_sv_stats"])
+    module = MultiqcModule()
+    assert len(module.vcf_sv_stats_data) == 1
+    assert module.duplicate_sources == ["second.vcf-sv-stats.json"]
+
+    conflict = make_summary()
+    conflict["reports"][0]["statistics"]["events"]["resolved"] = 12
+    resign(conflict)
+    _write_summary(tmp_path / "third.vcf-sv-stats.json", conflict)
+    report.reset()
+    report.analysis_files = [str(tmp_path)]
+    report.search_files(["vcf_sv_stats"])
+    with pytest.raises(SummaryValidationError, match="Conflicting"):
+        MultiqcModule()

--- a/multiqc/modules/vcf_sv_stats/vcf_sv_stats.py
+++ b/multiqc/modules/vcf_sv_stats/vcf_sv_stats.py
@@ -1,0 +1,508 @@
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.plots import bargraph, table
+from multiqc.plots.table_object import ColumnDict
+
+from .parser import (
+    ParsedReport,
+    SummaryValidationError,
+    count_mapping,
+    length_label,
+    mapping,
+    non_negative_integer,
+    parse_summary,
+)
+
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    """
+    `vcf-sv-stats` calculates standards-aware descriptive statistics for structural-variant
+    and copy-number VCF or BCF callsets.
+
+    The module discovers `*.vcf-sv-stats.json` summaries written by `vcf-sv-stats stats`
+    or `vcf-sv-stats run`. It validates the schema, content signature, and RFC 8785 payload
+    digest before displaying any value. The digest is an integrity check, not proof of
+    authorship.
+
+    Report identifiers remain separate from analysis-unit context and VCF sample columns.
+    Counts are descriptive callset statistics. They are not precision, recall, concordance,
+    or truth-set accuracy measurements.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="vcf-sv-stats",
+            anchor="vcf-sv-stats",
+            href="https://pypi.org/project/vcf-sv-stats/",
+            info="Summarizes structural-variant and copy-number VCF or BCF callsets.",
+            doi="",
+        )
+
+        records: dict[str, ParsedReport] = {}
+        self.duplicate_sources: list[str] = []
+        for f in self.find_log_files("vcf_sv_stats"):
+            for parsed in parse_summary(f["f"], f["fn"]):
+                previous = records.get(parsed.report_id)
+                if previous is not None:
+                    if previous.payload_sha256 != parsed.payload_sha256:
+                        raise SummaryValidationError(f"Conflicting vcf-sv-stats report identifier: {parsed.report_id}")
+                    self.duplicate_sources.append(f["fn"])
+                    continue
+                records[parsed.report_id] = parsed
+                self.add_data_source(f, s_name=parsed.report_id)
+                self.add_software_version(parsed.producer_version, sample=parsed.report_id)
+
+        self.vcf_sv_stats_data: dict[str, dict[str, Any]] = {
+            report_id: {
+                "callset": parsed.callset,
+                "validation": parsed.validation,
+                "report": parsed.report,
+                "report_payload_sha256": parsed.payload_sha256,
+            }
+            for report_id, parsed in records.items()
+        }
+        self.vcf_sv_stats_data = self.ignore_samples(self.vcf_sv_stats_data)
+        if not self.vcf_sv_stats_data:
+            raise ModuleNoSamplesFound
+        records = {key: records[key] for key in self.vcf_sv_stats_data}
+        log.info(f"Found {len(records)} vcf-sv-stats reports")
+
+        self._add_general_stats(records)
+        self._add_overview(records)
+        self._add_sv_types(records)
+        self._add_length_section(records)
+        self._add_flat_count_section(records, "filters", "Record filter states")
+        self._add_breakend_section(records)
+        self._add_merged_support_section(records)
+        self._add_flat_count_section(records, "genotypes", "Genotype states")
+        self._add_flat_count_section(records, "copy_number", "Declared copy number")
+        self._add_validation_section(records)
+        self._add_normalization_section(records)
+        self._add_provenance_section(records)
+
+        self.write_data_file(self.vcf_sv_stats_data, "multiqc_vcf_sv_stats")
+
+    @staticmethod
+    def _statistics(parsed: ParsedReport) -> dict[str, Any]:
+        return mapping(parsed.report["statistics"], "report.statistics")
+
+    def _add_general_stats(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, Any]] = {}
+        for report_id, parsed in records.items():
+            statistics = self._statistics(parsed)
+            breakends = mapping(statistics["breakends"], "report.statistics.breakends")
+            diagnostic_counts = count_mapping(parsed.validation["diagnostic_counts"], "validation.diagnostic_counts")
+            bnd_total = non_negative_integer(breakends["total"], "breakends.total")
+            unresolved = non_negative_integer(
+                breakends["without_declared_mate"], "breakends.without_declared_mate"
+            ) + non_negative_integer(
+                breakends["unresolved_mate_references"],
+                "breakends.unresolved_mate_references",
+            )
+            data[report_id] = {
+                "events": non_negative_integer(statistics["events"]["resolved"], "events.resolved"),
+                "alleles": non_negative_integer(statistics["alleles"]["total"], "alleles.total"),
+                "records": non_negative_integer(statistics["source_records"]["total"], "source_records.total"),
+                "errors": diagnostic_counts.get("error", 0) + diagnostic_counts.get("fatal", 0),
+                "unresolved_bnd_pct": (0 if bnd_total == 0 else unresolved * 100 / bnd_total),
+            }
+        all_headers: dict[str, ColumnDict] = {
+            "events": {
+                "title": "SV events",
+                "description": "Resolved structural-variant events",
+                "scale": "Blues",
+                "format": "{:,.0f}",
+            },
+            "alleles": {
+                "title": "SV alleles",
+                "description": ("Parsed alternate alleles; this is not a source-record count"),
+                "scale": "Purples",
+                "format": "{:,.0f}",
+            },
+            "records": {
+                "title": "VCF records",
+                "description": "Parsed source VCF or BCF records",
+                "scale": "Greens",
+                "format": "{:,.0f}",
+                "hidden": True,
+            },
+            "errors": {
+                "title": "Validation errors",
+                "description": ("Error and fatal diagnostics from vcf-sv-stats validation"),
+                "scale": "Reds",
+                "format": "{:,.0f}",
+            },
+            "unresolved_bnd_pct": {
+                "title": "Unresolved BND",
+                "description": "Breakends without a declared or resolvable mate",
+                "scale": "OrRd",
+                "suffix": "%",
+                "min": 0,
+                "max": 100,
+                "hidden": True,
+            },
+        }
+        headers = self.get_general_stats_headers(all_headers=all_headers)
+        if headers:
+            self.general_stats_addcols(data, headers, namespace="vcf-sv-stats")
+
+    def _add_overview(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, Any]] = {}
+        for report_id, parsed in records.items():
+            statistics = self._statistics(parsed)
+            data[report_id] = {
+                "records": statistics["source_records"]["total"],
+                "alleles": statistics["alleles"]["total"],
+                "events": statistics["events"]["resolved"],
+                "producer": parsed.callset["producer"]["producer"],
+                "adapter_status": parsed.callset["producer"]["status"],
+                "analysis_unit": parsed.report["analysis_unit"]["status"],
+                "vcf_samples": (", ".join(parsed.report["mapped_vcf_sample_ids"]) or "Unmapped"),
+            }
+        self.add_section(
+            name="Callset overview",
+            anchor="vcf-sv-stats-overview",
+            description=(
+                "Records, alternate alleles, and resolved events are distinct statistical "
+                "grains. The report identifier is a compatibility key, not a biological "
+                "sample identity."
+            ),
+            plot=table.plot(
+                data,
+                {
+                    "records": {
+                        "title": "VCF records",
+                        "format": "{:,.0f}",
+                        "scale": "Greens",
+                    },
+                    "alleles": {
+                        "title": "ALT alleles",
+                        "format": "{:,.0f}",
+                        "scale": "Purples",
+                    },
+                    "events": {
+                        "title": "Resolved events",
+                        "format": "{:,.0f}",
+                        "scale": "Blues",
+                    },
+                    "producer": {"title": "Producer"},
+                    "adapter_status": {"title": "Adapter status"},
+                    "analysis_unit": {"title": "Analysis-unit status"},
+                    "vcf_samples": {"title": "Mapped VCF samples"},
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-overview-table",
+                    "title": "vcf-sv-stats: callset overview",
+                },
+            ),
+        )
+
+    def _add_sv_types(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, int]] = {}
+        keys: set[str] = set()
+        for report_id, parsed in records.items():
+            alleles = mapping(self._statistics(parsed)["alleles"], "statistics.alleles")
+            counts = count_mapping(alleles["types"], "statistics.alleles.types")
+            data[report_id] = counts
+            keys.update(counts)
+        self._add_bargraph(
+            data,
+            keys,
+            title="SV type spectrum",
+            anchor="vcf-sv-stats-types",
+            plot_id="vcf-sv-stats-types-plot",
+            ylab="Alleles",
+        )
+
+    def _add_flat_count_section(
+        self,
+        records: Mapping[str, ParsedReport],
+        key: str,
+        title: str,
+    ) -> None:
+        data: dict[str, dict[str, int]] = {}
+        keys: set[str] = set()
+        for report_id, parsed in records.items():
+            counts = count_mapping(self._statistics(parsed)[key], f"statistics.{key}")
+            data[report_id] = counts
+            keys.update(counts)
+        anchor_key = key.replace("_", "-")
+        self._add_bargraph(
+            data,
+            keys,
+            title=title,
+            anchor=f"vcf-sv-stats-{anchor_key}",
+            plot_id=f"vcf-sv-stats-{anchor_key}-plot",
+            ylab="Count",
+        )
+
+    def _add_bargraph(
+        self,
+        data: dict[str, dict[str, int]],
+        keys: set[str],
+        *,
+        title: str,
+        anchor: str,
+        plot_id: str,
+        ylab: str,
+    ) -> None:
+        categories = {key: {"name": str(key).replace("_", " ")} for key in sorted(keys)}
+        self.add_section(
+            name=title,
+            anchor=anchor,
+            description=(
+                "Counts retain the metric scope and denominator declared in the producer "
+                "summary. They are descriptive statistics, not truth-set accuracy measures."
+            ),
+            plot=bargraph.plot(
+                data,
+                categories,
+                pconfig={
+                    "id": plot_id,
+                    "title": f"vcf-sv-stats: {title}",
+                    "ylab": ylab,
+                    "cpswitch": False,
+                },
+            ),
+        )
+
+    def _add_length_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, int]] = {}
+        expected_labels: tuple[str, ...] | None = None
+        for report_id, parsed in records.items():
+            length = mapping(self._statistics(parsed)["length_bp"], "statistics.length_bp")
+            labels = tuple(length_label(boundary) for boundary in length["boundaries"])
+            if expected_labels is not None and labels != expected_labels:
+                raise SummaryValidationError("Conflicting length histogram boundaries")
+            expected_labels = labels
+            data[report_id] = dict(zip(labels, length["counts"]))
+        categories = {label: {"name": label} for label in expected_labels or ()}
+        self.add_section(
+            name="Structural-variant length",
+            anchor="vcf-sv-stats-length",
+            description=(
+                "Alleles with an applicable length, grouped using the producer's fixed "
+                "histogram policy. Missing, invalid, and not-applicable values are not zero."
+            ),
+            plot=bargraph.plot(
+                data,
+                categories,
+                pconfig={
+                    "id": "vcf-sv-stats-length-plot",
+                    "title": "vcf-sv-stats: structural-variant length",
+                    "ylab": "Alleles",
+                    "cpswitch": False,
+                },
+            ),
+        )
+
+    def _add_breakend_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data = {report_id: self._statistics(parsed)["breakends"] for report_id, parsed in records.items()}
+        self.add_section(
+            name="Breakend relationships",
+            anchor="vcf-sv-stats-breakends",
+            description=("Pair resolution follows explicit record and relationship evidence only."),
+            plot=table.plot(
+                data,
+                {
+                    "total": {
+                        "title": "Breakends",
+                        "format": "{:,.0f}",
+                        "scale": "Blues",
+                    },
+                    "reciprocal_pairs": {
+                        "title": "Reciprocal pairs",
+                        "format": "{:,.0f}",
+                    },
+                    "without_declared_mate": {
+                        "title": "No declared mate",
+                        "format": "{:,.0f}",
+                        "scale": "OrRd",
+                    },
+                    "unresolved_mate_references": {
+                        "title": "Unresolved mate",
+                        "format": "{:,.0f}",
+                        "scale": "Reds",
+                    },
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-breakends-table",
+                    "title": "vcf-sv-stats: breakends",
+                },
+            ),
+        )
+
+    def _add_merged_support_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, Any]] = {}
+        for report_id, parsed in records.items():
+            support = mapping(self._statistics(parsed)["merged_support"], "statistics.merged_support")
+            source_counts = count_mapping(
+                support["source_count_states"], "statistics.merged_support.source_count_states"
+            )
+            consistency = count_mapping(
+                support["vector_count_consistency"],
+                "statistics.merged_support.vector_count_consistency",
+            )
+            data[report_id] = {
+                "producer_kind": parsed.callset["producer_kind"],
+                "status": support["status"],
+                "records_with_support": support["records_with_support"],
+                "records_without_support": support["records_without_support"],
+                "declared_source_counts": ", ".join(sorted(source_counts)) or "Not reported",
+                "inconsistent_vectors": consistency.get("inconsistent", 0),
+            }
+        self.add_section(
+            name="Merged support provenance",
+            anchor="vcf-sv-stats-merged-support",
+            description=(
+                "Merger support fields describe source provenance. They are not biological "
+                "replication, precision, recall, concordance, or truth evidence."
+            ),
+            plot=table.plot(
+                data,
+                {
+                    "producer_kind": {"title": "Producer kind"},
+                    "status": {"title": "Support status"},
+                    "records_with_support": {
+                        "title": "Records with support",
+                        "format": "{:,.0f}",
+                        "scale": "Blues",
+                    },
+                    "records_without_support": {
+                        "title": "Records without support",
+                        "format": "{:,.0f}",
+                        "scale": "Oranges",
+                    },
+                    "declared_source_counts": {"title": "Declared source-count states"},
+                    "inconsistent_vectors": {
+                        "title": "Count/vector conflicts",
+                        "format": "{:,.0f}",
+                        "scale": "Reds",
+                    },
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-merged-support-table",
+                    "title": "vcf-sv-stats: merger support provenance",
+                },
+            ),
+        )
+
+    def _add_validation_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, Any]] = {}
+        for report_id, parsed in records.items():
+            states = parsed.validation["states"]
+            counts = count_mapping(parsed.validation["diagnostic_counts"], "validation.diagnostic_counts")
+            data[report_id] = {
+                "container": states["container_state"],
+                "parse": states["parse_state"],
+                "conformance": states["vcf_conformance_state"],
+                "sv_semantics": states["sv_semantic_state"],
+                "statistics": states["statistics_state"],
+                "warnings": counts.get("warning", 0),
+                "errors": counts.get("error", 0) + counts.get("fatal", 0),
+            }
+        self.add_section(
+            name="Validation states",
+            anchor="vcf-sv-stats-validation",
+            description=(
+                "Container, parse, conformance, structural-variant semantics, and statistics states remain independent."
+            ),
+            plot=table.plot(
+                data,
+                {
+                    "container": {"title": "Container"},
+                    "parse": {"title": "Parse"},
+                    "conformance": {"title": "VCF conformance"},
+                    "sv_semantics": {"title": "SV semantics"},
+                    "statistics": {"title": "Statistics"},
+                    "warnings": {
+                        "title": "Warnings",
+                        "format": "{:,.0f}",
+                        "scale": "Oranges",
+                    },
+                    "errors": {
+                        "title": "Errors",
+                        "format": "{:,.0f}",
+                        "scale": "Reds",
+                    },
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-validation-table",
+                    "title": "vcf-sv-stats: validation states",
+                },
+            ),
+        )
+
+    def _add_normalization_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data = {
+            report_id: {
+                "operation_safety": parsed.validation["states"]["operation_safety_state"],
+                "adapter_status": parsed.callset["producer"]["status"],
+            }
+            for report_id, parsed in records.items()
+        }
+        self.add_section(
+            name="Normalization safety",
+            anchor="vcf-sv-stats-normalization",
+            description=(
+                "Operation safety reports whether rewriting is supported by the observed "
+                "evidence. It does not imply that normalization occurred."
+            ),
+            plot=table.plot(
+                data,
+                {
+                    "operation_safety": {"title": "Operation safety"},
+                    "adapter_status": {"title": "Adapter status"},
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-normalization-table",
+                    "title": "vcf-sv-stats: normalization safety",
+                },
+            ),
+        )
+
+    def _add_provenance_section(self, records: Mapping[str, ParsedReport]) -> None:
+        data: dict[str, dict[str, Any]] = {}
+        for report_id, parsed in records.items():
+            producer = parsed.callset["producer"]
+            analysis = parsed.report["analysis_unit"]
+            data[report_id] = {
+                "producer": producer["producer"],
+                "version": producer.get("version") or "Unknown",
+                "adapter": producer["adapter_id"],
+                "adapter_status": producer["status"],
+                "analysis_unit_id": analysis.get("analysis_unit_id") or "Unresolved",
+                "display_id": analysis.get("display_id") or "Unresolved",
+                "algorithm_id": analysis.get("algorithm_id") or "Unresolved",
+                "vcf_samples": (", ".join(parsed.report["mapped_vcf_sample_ids"]) or "Unmapped"),
+            }
+        self.add_section(
+            name="Provenance and analysis context",
+            anchor="vcf-sv-stats-provenance",
+            description=(
+                "Producer support is provenance, not accuracy evidence. Analysis-unit "
+                "identifiers and mapped VCF sample columns remain separate."
+            ),
+            plot=table.plot(
+                data,
+                {
+                    "producer": {"title": "Producer"},
+                    "version": {"title": "Producer version"},
+                    "adapter": {"title": "Adapter"},
+                    "adapter_status": {"title": "Adapter status"},
+                    "analysis_unit_id": {"title": "Analysis unit"},
+                    "display_id": {"title": "Display ID"},
+                    "algorithm_id": {"title": "Algorithm"},
+                    "vcf_samples": {"title": "Mapped VCF samples"},
+                },
+                pconfig={
+                    "id": "vcf-sv-stats-provenance-table",
+                    "title": "vcf-sv-stats: provenance",
+                },
+            ),
+        )

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -1190,6 +1190,8 @@ varscan2/mpileup2indel:
 varscan2/mpileup2cns:
   contents: "Only variants will be reported"
   num_lines: 10
+vcf_sv_stats:
+  fn: "*.vcf-sv-stats.json"
 vcftools/relatedness2:
   fn: "*.relatedness2"
 vcftools/tstv_by_count:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "natsort",
     "tiktoken",
     "jsonschema",
+    "rfc8785>=0.1.4",
     # Pyodide currently publishes Polars 1.33.1; `rtcompat` is available from 1.34.0 for native installs.
     "polars>=1.33.1; sys_platform == 'emscripten'",
     "polars[rtcompat]>=1.34.0; sys_platform != 'emscripten'",
@@ -278,6 +279,7 @@ truvari = "multiqc.modules.truvari:MultiqcModule"
 umicollapse = "multiqc.modules.umicollapse:MultiqcModule"
 umitools = "multiqc.modules.umitools:MultiqcModule"
 varscan2 = "multiqc.modules.varscan2:MultiqcModule"
+vcf_sv_stats = "multiqc.modules.vcf_sv_stats:MultiqcModule"
 vcftools = "multiqc.modules.vcftools:MultiqcModule"
 vep = "multiqc.modules.vep:MultiqcModule"
 verifybamid = "multiqc.modules.verifybamid:MultiqcModule"


### PR DESCRIPTION
## Summary

Adds a native `vcf-sv-stats` module for standards-aware descriptive SV/CNV callset summaries. The module discovers only `*.vcf-sv-stats.json`, validates schema version and the RFC 8785 payload digest, keeps report, analysis-unit, and VCF-sample identities separate, and rejects conflicting duplicate report IDs.

It renders overview, type, length, filter, breakend, merger-support provenance, genotype, copy-number, validation, normalization-safety, and provenance/context sections. All counts remain explicitly descriptive, never truth-set accuracy metrics.

Companion test-data PR: https://github.com/MultiQC/test-data/pull/385

## Validation

- 12 focused parser/module tests
- strict module integration and ignore-samples tests against producer-generated sanitized HG002 data
- `ruff`, focused `mypy`, `code_checks.py`, and all changed-file `prek` hooks
- strict end-to-end HTML report generation
- 1,000-report deterministic aggregate case

## Compatibility and maintenance

The consumer accepts exact summary schema `1.0.0` and fails closed on unknown majors or unapproved minors. The contributor intends to maintain this module as the producer contract evolves and will coordinate any schema-major change through a separate reviewed update. The producer remains an external tool; MultiQC does not import it or parse VCF/BCF input directly.