### PR TITLE
Fix mypy union-attr error in is_running_in_notebook

### DIFF
--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -161,7 +161,8 @@ def is_running_in_notebook() -> bool:
     try:
         from IPython import get_ipython  # type: ignore
 
-        if "IPKernelApp" in get_ipython().config:
+        ip = get_ipython()
+        if ip is not None and "IPKernelApp" in ip.config:
             return True
     except (ImportError, AttributeError):
         pass


### PR DESCRIPTION
## Summary

`main`'s mypy CI has been intermittently failing on `multiqc/utils/util_functions.py:164` (`Item "None" of "InteractiveShell | None" has no attribute "config"`) since at least mid-July, unrelated to any specific PR - it currently blocks the mypy check on every open PR.

`get_ipython()` is typed as returning `InteractiveShell | None`; the code previously relied on the surrounding `except AttributeError` to handle the `None` case implicitly. This narrows explicitly instead.

No behaviour change: outside a notebook (`get_ipython()` returning `None`), `is_running_in_notebook()` still returns `False`, verified manually.

## Test plan

- [x] `mypy multiqc` - clean (was failing before)
- [x] `ruff check`, `prek run`, `python .github/workflows/code_checks.py`
- [x] Manual check: `is_running_in_notebook()` still returns `False` outside a notebook