### PR TITLE
Guard notebook detection when IPython is unavailable

### DIFF
--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -161,7 +161,8 @@ def is_running_in_notebook() -> bool:
     try:
         from IPython import get_ipython  # type: ignore
 
-        if "IPKernelApp" in get_ipython().config:
+        ipython = get_ipython()
+        if ipython is not None and "IPKernelApp" in ipython.config:
             return True
     except (ImportError, AttributeError):
         pass


### PR DESCRIPTION
## Summary

`is_running_in_notebook()` currently calls `.config` on the value returned by `IPython.get_ipython()`. That function is typed as nullable and can return `None` outside an active shell. Add an explicit `None` guard.

## Validation

- `mypy multiqc/utils/util_functions.py`
- `pytest -q tests/test_interactive.py` with the public test-data checkout: 11 passed
- Runtime smoke test outside a notebook returns `False`

This is a small independent fix surfaced by the Python 3.14 mypy job on DotMatch MultiQC PR #3629; it is not mixed into that module PR.