### PR TITLE
fix(riker): tolerate empty metric fields in TSV parsers

### DIFF
--- a/multiqc/modules/riker/alignment.py
+++ b/multiqc/modules/riker/alignment.py
@@ -1,14 +1,14 @@
 """Parse riker `alignment` (alignment-metrics.txt) outputs."""
 
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 from multiqc import config
 from multiqc.plots import bargraph, table
 from multiqc.plots.bargraph import BarPlotConfig
 from multiqc.plots.table import TableConfig
 
-from .util import read_tsv, to_int
+from .util import read_tsv, to_float, to_int
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ _INT_COLS = {
 
 def parse_reports(module):
     # data_by_sample[sample][category] -> dict of metrics
-    data_by_sample: Dict[str, Dict[str, Dict[str, float]]] = {}
+    data_by_sample: Dict[str, Dict[str, Dict[str, Optional[float]]]] = {}
 
     for f in module.find_log_files("riker/alignment", filehandles=True):
         for row in read_tsv(f["f"], source=f["fn"]):
@@ -41,8 +41,8 @@ def parse_reports(module):
             s_name = module.clean_s_name(sample, f)
 
             try:
-                parsed: Dict[str, float] = {
-                    col: (to_int(val) if col in _INT_COLS else float(val)) for col, val in row.items()
+                parsed: Dict[str, Optional[float]] = {
+                    col: (to_int(val) if col in _INT_COLS else to_float(val)) for col, val in row.items()
                 }
             except (TypeError, ValueError) as e:
                 log.warning(f"riker: skipping row in {f['fn']} for sample {sample}: {e}")
@@ -58,7 +58,7 @@ def parse_reports(module):
     module.add_software_version(None)
 
     # Pull the `pair` row (or fall back to the first available category) for general stats.
-    pair_data: Dict[str, Dict[str, float]] = {}
+    pair_data: Dict[str, Dict[str, Optional[float]]] = {}
     for s_name, by_cat in data_by_sample.items():
         pair_data[s_name] = by_cat.get("pair", next(iter(by_cat.values())))
 
@@ -165,7 +165,7 @@ def parse_reports(module):
     )
 
     # Per-category metrics table
-    table_data: Dict[str, Dict[str, float]] = {}
+    table_data: Dict[str, Dict[str, Optional[float]]] = {}
     for s_name, by_cat in data_by_sample.items():
         for category, row in by_cat.items():
             table_data[f"{s_name} ({category})"] = row

--- a/multiqc/modules/riker/gcbias.py
+++ b/multiqc/modules/riker/gcbias.py
@@ -2,11 +2,11 @@
 
 import logging
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
 from multiqc.plots import linegraph
 
-from .util import read_tsv, to_int
+from .util import read_tsv, to_float, to_int
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def parse_reports(module):
 
 
 def _parse_summary(module) -> set:
-    data_by_sample: Dict[str, Dict[str, float]] = {}
+    data_by_sample: Dict[str, Dict[str, Optional[float]]] = {}
 
     for f in module.find_log_files("riker/gcbias_summary", filehandles=True):
         for row in read_tsv(f["f"], source=f["fn"]):
@@ -32,7 +32,7 @@ def _parse_summary(module) -> set:
                 continue
             s_name = module.clean_s_name(sample, f)
             try:
-                data_by_sample[s_name] = {col: float(val) for col, val in row.items()}
+                data_by_sample[s_name] = {col: to_float(val) for col, val in row.items()}
             except (TypeError, ValueError) as e:
                 log.warning(f"riker: skipping row in {f['fn']} for sample {sample}: {e}")
                 continue

--- a/multiqc/modules/riker/hybcap.py
+++ b/multiqc/modules/riker/hybcap.py
@@ -1,13 +1,13 @@
 """Parse riker `hybcap` outputs (hybcap-metrics.txt)."""
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from multiqc import config
 from multiqc.plots import linegraph, table
 from multiqc.plots.table import TableConfig
 
-from .util import read_tsv
+from .util import read_tsv, to_float
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ TARGET_COVERAGE_LEVELS = [1, 10, 20, 30, 50, 100, 250, 500, 1000]
 
 
 def parse_reports(module):
-    data_by_sample: Dict[str, Dict[str, float]] = {}
+    data_by_sample: Dict[str, Dict[str, Optional[float]]] = {}
     panel_by_sample: Dict[str, str] = {}
 
     for f in module.find_log_files("riker/hybcap_metrics", filehandles=True):
@@ -27,7 +27,7 @@ def parse_reports(module):
             s_name = module.clean_s_name(sample, f)
             panel = row.pop("panel_name", "")
             try:
-                parsed = {col: float(val) for col, val in row.items()}
+                parsed = {col: to_float(val) for col, val in row.items()}
             except (TypeError, ValueError) as e:
                 log.warning(f"riker: skipping row in {f['fn']} for sample {sample}: {e}")
                 continue
@@ -138,7 +138,7 @@ def parse_reports(module):
     module.general_stats_addcols(data_by_sample, headers, namespace="hybcap")
 
     # Full metrics table; most columns hidden by default and the user can toggle them.
-    table_data: Dict[str, Dict[str, float]] = {}
+    table_data: Dict[str, Dict[str, object]] = {}
     for s_name, row in data_by_sample.items():
         merged = dict(row)
         merged["panel_name"] = panel_by_sample.get(s_name, "")
@@ -352,8 +352,9 @@ def parse_reports(module):
         curve_data[s_name] = {}
         for cov in TARGET_COVERAGE_LEVELS:
             key = f"frac_target_bases_{cov}x"
-            if key in row:
-                curve_data[s_name][cov] = row[key] * 100.0
+            val = row.get(key)
+            if val is not None:
+                curve_data[s_name][cov] = val * 100.0
 
     if any(curve_data.values()):
         pconfig = {

--- a/multiqc/modules/riker/isize.py
+++ b/multiqc/modules/riker/isize.py
@@ -2,11 +2,11 @@
 
 import logging
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
 from multiqc.plots import linegraph
 
-from .util import read_tsv, to_int
+from .util import read_tsv, to_float, to_int
 
 log = logging.getLogger(__name__)
 
@@ -18,9 +18,9 @@ def parse_reports(module):
     return parsed_samples
 
 
-def _parse_metrics(module) -> Dict[str, Dict[str, Dict[str, float]]]:
+def _parse_metrics(module) -> Dict[str, Dict[str, Dict[str, Optional[float]]]]:
     # data_by_sample[sample][orientation] = {col: value}
-    data_by_sample: Dict[str, Dict[str, Dict[str, float]]] = {}
+    data_by_sample: Dict[str, Dict[str, Dict[str, Optional[float]]]] = {}
 
     for f in module.find_log_files("riker/isize_metrics", filehandles=True):
         for row in read_tsv(f["f"], source=f["fn"]):
@@ -30,7 +30,7 @@ def _parse_metrics(module) -> Dict[str, Dict[str, Dict[str, float]]]:
                 continue
             s_name = module.clean_s_name(sample, f)
             try:
-                parsed = {col: float(val) for col, val in row.items()}
+                parsed = {col: to_float(val) for col, val in row.items()}
             except (TypeError, ValueError) as e:
                 log.warning(f"riker: skipping row in {f['fn']} for sample {sample}: {e}")
                 continue
@@ -45,7 +45,7 @@ def _parse_metrics(module) -> Dict[str, Dict[str, Dict[str, float]]]:
 
     # Pick the FR orientation when present (the typical Illumina library), else the
     # first available orientation; there is always at least one row per sample.
-    primary_data: Dict[str, Dict[str, float]] = {}
+    primary_data: Dict[str, Dict[str, Optional[float]]] = {}
     for s_name, by_orient in data_by_sample.items():
         primary_data[s_name] = by_orient.get("FR", next(iter(by_orient.values())))
 

--- a/multiqc/modules/riker/tests/test_riker.py
+++ b/multiqc/modules/riker/tests/test_riker.py
@@ -181,6 +181,34 @@ def test_hybcap_metrics(run_riker_module):
     _assert_one_sample_for_tool(module, "hybcap", "HG00240")
 
 
+def test_hybcap_metrics_tolerates_empty_field(run_riker_module):
+    """An undefined metric (e.g. hs_library_size) is left blank by riker; the row
+    must be retained with that field missing, not dropped wholesale."""
+    from multiqc import config
+
+    # Blank out the hs_library_size cell, as riker does when the estimate is undefined.
+    assert "\t246041533\t" in HYBCAP_METRICS_TSV
+    content = HYBCAP_METRICS_TSV.replace("\t246041533\t", "\t\t")
+
+    original = config.preserve_module_raw_data
+    config.preserve_module_raw_data = True
+    try:
+        module = run_riker_module("HG00240.hybcap-metrics.txt", content)
+    finally:
+        config.preserve_module_raw_data = original
+
+    _assert_one_sample_for_tool(module, "hybcap", "HG00240")
+
+    saved = module.saved_raw_data
+    assert saved is not None
+    data = saved.get("multiqc_riker_hybcap")
+    assert data and "HG00240" in data, "hybcap row was dropped for the empty cell"
+    row = data["HG00240"]
+    # The empty cell becomes missing; every other numeric field is untouched.
+    assert row["hs_library_size"] is None
+    assert row["mean_target_coverage"] == 83.13
+
+
 def test_isize_metrics(run_riker_module):
     module = run_riker_module("HG00240.isize-metrics.txt", ISIZE_METRICS_TSV)
     _assert_one_sample_for_tool(module, "isize", "HG00240")

--- a/multiqc/modules/riker/util.py
+++ b/multiqc/modules/riker/util.py
@@ -1,7 +1,7 @@
 """Shared helpers for the riker submodules."""
 
 import logging
-from typing import Dict, Iterator, List, TextIO
+from typing import Dict, Iterator, List, Optional, TextIO
 
 log = logging.getLogger(__name__)
 
@@ -42,3 +42,18 @@ def to_int(value: str) -> int:
         return int(value)
     except (TypeError, ValueError):
         return int(float(value))
+
+
+def to_float(value: str) -> Optional[float]:
+    """
+    Parse a float metric column, treating an empty or blank cell as missing.
+
+    Riker leaves an undefined metric (for example Picard's estimated library
+    size when it cannot be computed) as an empty string. Returning ``None`` for
+    such a cell lets the rest of the row survive; MultiQC renders a missing cell
+    as blank. A non-empty, non-numeric value is a genuine parse error and still
+    raises ``ValueError``.
+    """
+    if value is None or value.strip() == "":
+        return None
+    return float(value)

--- a/multiqc/modules/riker/wgs.py
+++ b/multiqc/modules/riker/wgs.py
@@ -2,14 +2,14 @@
 
 import logging
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from multiqc import config
 from multiqc.plots import bargraph, linegraph, table
 from multiqc.plots.bargraph import BarPlotConfig
 from multiqc.plots.table import TableConfig
 
-from .util import read_tsv, to_int
+from .util import read_tsv, to_float, to_int
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ def parse_reports(module):
 
 
 def _parse_metrics(module) -> set:
-    data_by_sample: Dict[str, Dict[str, float]] = {}
+    data_by_sample: Dict[str, Dict[str, Optional[float]]] = {}
 
     for f in module.find_log_files("riker/wgs_metrics", filehandles=True):
         for row in read_tsv(f["f"], source=f["fn"]):
@@ -33,7 +33,7 @@ def _parse_metrics(module) -> set:
                 continue
             s_name = module.clean_s_name(sample, f)
             try:
-                data_by_sample[s_name] = {col: float(val) for col, val in row.items()}
+                data_by_sample[s_name] = {col: to_float(val) for col, val in row.items()}
             except (TypeError, ValueError) as e:
                 log.warning(f"riker: skipping row in {f['fn']} for sample {sample}: {e}")
                 continue
@@ -265,7 +265,10 @@ def _parse_metrics(module) -> set:
     ]
     excl_data: Dict[str, Dict[str, float]] = {}
     for s_name, row in data_by_sample.items():
-        excl_data[s_name] = {col: row.get(col, 0.0) * 100.0 for col, _ in excl_keys}
+        excl_data[s_name] = {}
+        for col, _ in excl_keys:
+            val = row.get(col)
+            excl_data[s_name][col] = val * 100.0 if val is not None else 0.0
     excl_cats = {col: {"name": label} for col, label in excl_keys}
     excl_config = BarPlotConfig(
         id=f"{module.anchor}_wgs_excluded_bases",


### PR DESCRIPTION
Riker leaves an undefined metric (for example Picard's estimated library size, hs_library_size) as an empty string. The hybcap parser, like the wgs, gcbias, isize, and alignment metric parsers, ran float() over every cell and raised on the empty value, so it logged a warning and dropped the entire row; the whole hyb-selection section then went missing.

Add a to_float() helper that maps an empty or blank cell to None (missing) while still raising on genuinely non-numeric values, and use it in the metric-row parsers. Real numbers are unchanged; only empty cells become missing, and MultiQC renders a missing cell as blank. Guard the two spots that multiply a possibly-missing value.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
