### PR TITLE
fix(jcvi): relax genestats header validation for variable table widths (#3614)

### DIFF
--- a/multiqc/modules/jcvi/jcvi.py
+++ b/multiqc/modules/jcvi/jcvi.py
@@ -140,16 +140,20 @@ class MultiqcModule(BaseMultiqcModule):
 
     def parse_jcvi(self, f):
         # Look at the first three lines, they are always the same
-        first_line = f["f"].readline()
-        second_line = f["f"].readline()
-        third_line = f["f"].readline()
+        first_line = f["f"].readline().strip()
+        second_line = f["f"].readline().strip()
+        third_line = f["f"].readline().strip()
 
-        # If any of these fail, it's probably not a jcvi summary file
+        # Validate JCVI genestats table header structure.
+        # The exact width varies across JCVI versions because the upstream
+        # table formatter (jcvi.utils.table.banner) dynamically sizes the
+        # border to match the widest data row. We therefore match the
+        # structural pattern rather than exact character counts.
         if not all(
             (
-                first_line.startswith("==================================================================="),
-                second_line.startswith("                                                   o            all"),
-                third_line.startswith("-------------------------------------------------------------------"),
+                re.fullmatch(r"={50,}", first_line),
+                second_line.split() == ["o", "all"],
+                re.fullmatch(r"-{50,}", third_line),
             )
         ):
             return


### PR DESCRIPTION
Fixes #3614

The upstream JCVI library (`jcvi.utils.table.banner`) dynamically sizes the ASCII table border based on the widest data row. Different input data produces different widths (e.g., 66 vs. 67 `=` characters), but the parser hardcoded exact 67-character strings, silently rejecting valid genestats files.

Replace exact `startswith()` checks with:
* `re.fullmatch(r"={50,}", ...)` and `re.fullmatch(r"-{50,}", ...)` for border lines
* `split()`-based token check for the `o all` header line to remain whitespace-agnostic
* `.strip()` on `readline()` to handle cross-platform line endings (`\r\n`)

- [x] This comment contains a description of changes (with reason)
- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR (MultiQC/test-data#388)
- [x] Code is tested and works locally (including with `--strict` flag)

> **Note:** Developed and verified with assistance from Antigravity. All test fixtures, linting, and parsing logic were manually reviewed and validated locally against `pytest`.