### PR TITLE
feat(riker): group alignment table by sample with pair as primary row

### DIFF
--- a/multiqc/modules/riker/alignment.py
+++ b/multiqc/modules/riker/alignment.py
@@ -166,9 +166,12 @@ def parse_reports(module):
         plot=bargraph.plot(bar_data, bar_keys, bar_config),
     )
 
-    # Per-category metrics table, grouped by sample so the `pair` row is the
-    # headline and the `read1` / `read2` rows nest under it, expandable on click.
-    # The first row in each group is the primary row, so `pair` is ordered first.
+    # Per-category metrics table, grouped by sample. For paired data the `pair`
+    # row is ordered first and becomes the headline, with the `read1` / `read2`
+    # rows nesting under it, expandable on click. For single-end data riker emits
+    # only a `read1` row, which then becomes the headline on its own.
+    # The first row of each group is always the primary row, so the headline is
+    # whichever category sorts first, not `pair` specifically.
     category_order = ["pair", "read1", "read2"]
     rows_by_sample: Dict[SampleGroup, List[InputRow]] = {}
     for s_name, by_cat in data_by_sample.items():
@@ -176,7 +179,7 @@ def parse_reports(module):
         ordered += [c for c in by_cat if c not in category_order]
         rows: List[InputRow] = []
         for category in ordered:
-            is_headline = not rows and category == "pair"
+            is_headline = not rows
             label = s_name if is_headline else f"{s_name} ({category})"
             rows.append(InputRow(sample=SampleName(label), data=by_cat[category]))
         rows_by_sample[SampleGroup(s_name)] = rows
@@ -263,8 +266,9 @@ def parse_reports(module):
         description="Per-category alignment metrics from riker's `alignment` tool.",
         helptext="""
             Alignment summary metrics, equivalent to Picard `CollectAlignmentSummaryMetrics`.
-            Each sample's `pair` row is the primary row; click it to expand the per-read
-            `read1` and `read2` rows underneath.
+            For paired data each sample's `pair` row is the primary row; click it to expand
+            the per-read `read1` and `read2` rows underneath. For single-end data riker
+            reports only a `read1` row, which is shown as the primary row on its own.
 
             * `Total reads` / `Aligned reads`: read counts (QC-failed reads are included in the total).
             * `% Aligned`: aligned reads as a fraction of total.

--- a/multiqc/modules/riker/alignment.py
+++ b/multiqc/modules/riker/alignment.py
@@ -1,12 +1,14 @@
 """Parse riker `alignment` (alignment-metrics.txt) outputs."""
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from multiqc import config
 from multiqc.plots import bargraph, table
 from multiqc.plots.bargraph import BarPlotConfig
 from multiqc.plots.table import TableConfig
+from multiqc.plots.table_object import InputRow
+from multiqc.types import SampleGroup, SampleName
 
 from .util import read_tsv, to_float, to_int
 
@@ -164,11 +166,20 @@ def parse_reports(module):
         plot=bargraph.plot(bar_data, bar_keys, bar_config),
     )
 
-    # Per-category metrics table
-    table_data: Dict[str, Dict[str, Optional[float]]] = {}
+    # Per-category metrics table, grouped by sample so the `pair` row is the
+    # headline and the `read1` / `read2` rows nest under it, expandable on click.
+    # The first row in each group is the primary row, so `pair` is ordered first.
+    category_order = ["pair", "read1", "read2"]
+    rows_by_sample: Dict[SampleGroup, List[InputRow]] = {}
     for s_name, by_cat in data_by_sample.items():
-        for category, row in by_cat.items():
-            table_data[f"{s_name} ({category})"] = row
+        ordered = [c for c in category_order if c in by_cat]
+        ordered += [c for c in by_cat if c not in category_order]
+        rows: List[InputRow] = []
+        for category in ordered:
+            is_headline = not rows and category == "pair"
+            label = s_name if is_headline else f"{s_name} ({category})"
+            rows.append(InputRow(sample=SampleName(label), data=by_cat[category]))
+        rows_by_sample[SampleGroup(s_name)] = rows
 
     # Same coloring rationale as the general stats columns above.
     table_headers = {
@@ -252,8 +263,8 @@ def parse_reports(module):
         description="Per-category alignment metrics from riker's `alignment` tool.",
         helptext="""
             Alignment summary metrics, equivalent to Picard `CollectAlignmentSummaryMetrics`.
-            Each sample is split into rows for the `pair`, `first_of_pair`, and `second_of_pair`
-            read categories.
+            Each sample's `pair` row is the primary row; click it to expand the per-read
+            `read1` and `read2` rows underneath.
 
             * `Total reads` / `Aligned reads`: read counts (QC-failed reads are included in the total).
             * `% Aligned`: aligned reads as a fraction of total.
@@ -265,7 +276,7 @@ def parse_reports(module):
             * `Strand balance`: fraction of aligned reads on the forward strand. 0.5 is unbiased.
             * `Bad cycles`: sequencing cycles where at least 80% of reads called N.
         """,
-        plot=table.plot(table_data, table_headers, table_config),
+        plot=table.plot(rows_by_sample, table_headers, table_config),
     )
 
     module.write_data_file(pair_data, f"multiqc_{module.anchor}_alignment")

--- a/multiqc/modules/riker/tests/test_riker.py
+++ b/multiqc/modules/riker/tests/test_riker.py
@@ -29,6 +29,9 @@ ALIGNMENT_TSV = (
     "\t0.02466\t0\t0.49993\t0.01793\t0.01464\t0.00000\t21.69\n"
 )
 
+# Single-end riker output: the header plus only the `read1` row (no `read2`, no `pair`).
+ALIGNMENT_SE_TSV = "\n".join(ALIGNMENT_TSV.split("\n")[:2]) + "\n"
+
 BASE_DIST_TSV = (
     "sample\tread_end\tcycle\tfrac_a\tfrac_c\tfrac_g\tfrac_t\tfrac_n\n"
     "HG00240\t1\t1\t0.28942\t0.20943\t0.20676\t0.29184\t0.00255\n"
@@ -179,6 +182,16 @@ def test_alignment_table_groups_pair_as_primary(run_riker_module):
     assert rows[0].data[ColumnKey("total_reads")].raw == 98580386
     assert rows[1].data[ColumnKey("total_reads")].raw == 49290193
     assert rows[2].data[ColumnKey("total_reads")].raw == 49290193
+
+
+def test_alignment_table_single_end_has_no_expandable_group(run_riker_module):
+    """Single-end riker emits only a `read1` row. It is shown as a bare primary row
+    (no `(read1)` suffix and nothing to expand), so the group degrades to one row."""
+    run_riker_module("HG00240.alignment-metrics.txt", ALIGNMENT_SE_TSV)
+
+    rows = _alignment_group_rows("HG00240")
+    assert rows is not None, "alignment table did not produce a HG00240 sample group"
+    assert [str(r.sample) for r in rows] == ["HG00240"]
 
 
 def test_basic_base_distribution(run_riker_module):

--- a/multiqc/modules/riker/tests/test_riker.py
+++ b/multiqc/modules/riker/tests/test_riker.py
@@ -149,6 +149,38 @@ def test_alignment_metrics(run_riker_module):
     _assert_one_sample_for_tool(module, "alignment", "HG00240")
 
 
+def _alignment_group_rows(sample):
+    """Return the grouped table rows for a sample from the alignment metrics table."""
+    from multiqc.types import SampleGroup
+
+    for plot in report.plot_by_id.values():
+        for dataset in getattr(plot, "datasets", []):
+            dt = getattr(dataset, "dt", None)
+            if dt is None:
+                continue
+            for section in dt.section_by_id.values():
+                if SampleGroup(sample) in section.rows_by_sgroup:
+                    return section.rows_by_sgroup[SampleGroup(sample)]
+    return None
+
+
+def test_alignment_table_groups_pair_as_primary(run_riker_module):
+    """The alignment metrics table groups each sample so the `pair` row is the primary
+    (headline) row and `read1` / `read2` nest under it as expandable children."""
+    from multiqc.types import ColumnKey
+
+    run_riker_module("HG00240.alignment-metrics.txt", ALIGNMENT_TSV)
+
+    rows = _alignment_group_rows("HG00240")
+    assert rows is not None, "alignment table did not produce a HG00240 sample group"
+    assert [str(r.sample) for r in rows] == ["HG00240", "HG00240 (read1)", "HG00240 (read2)"]
+
+    # The primary row carries the `pair` metrics (total_reads is the sum of both reads).
+    assert rows[0].data[ColumnKey("total_reads")].raw == 98580386
+    assert rows[1].data[ColumnKey("total_reads")].raw == 49290193
+    assert rows[2].data[ColumnKey("total_reads")].raw == 49290193
+
+
 def test_basic_base_distribution(run_riker_module):
     module = run_riker_module("HG00240.base-distribution-by-cycle.txt", BASE_DIST_TSV)
     # When read_end=2 is present we split into _R1 / _R2; the per-tool sample set


### PR DESCRIPTION
Render the Alignment metrics table with MultiQC sample grouping so each sample's pair row is the headline and the read1 / read2 rows nest under it, expandable on click. Previously the three categories were flat siblings, which made the bar shading and sorting misleading because pair values are a different scale than the per-read values.

Here's what it looked like **_before_**:

<img width="616" height="432" alt="Screenshot 2026-09-04 at 11 33 40 AM" src="https://github.com/user-attachments/assets/cb0050cb-945a-4dbd-8e14-2d70a6e2686d" />

Here's what it looks like _**now**_:

<img width="658" height="375" alt="Screenshot 2026-09-05 at 9 31 08 AM" src="https://github.com/user-attachments/assets/ccc1d5ff-bdc5-40b7-961f-52714661a0b5" />

My PR here is also supportive of single-end data if/when someone runs riker on single-end data.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Before merge, I'd like to get @tfenne's blessing on this aesthetic change!