### PR TITLE
Correct samtools markdup search pattern

### DIFF
--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -1042,10 +1042,7 @@ samtools/coverage:
   contents: "#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq"
   num_lines: 10
 samtools/markdup_txt:
-  contents_re:
-    - "^COMMAND:"
-  contents:
-    - "samtools markdup"
+  contents: "COMMAND: samtools markdup"
   num_lines: 2
 samtools/markdup_json:
   contents:

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -1042,8 +1042,9 @@ samtools/coverage:
   contents: "#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq"
   num_lines: 10
 samtools/markdup_txt:
-  contents:
+  contents_re:
     - "^COMMAND:"
+  contents:
     - "samtools markdup"
   num_lines: 2
 samtools/markdup_json:

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -1042,7 +1042,9 @@ samtools/coverage:
   contents: "#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq"
   num_lines: 10
 samtools/markdup_txt:
-  contents: "COMMAND: samtools markdup"
+  contents:
+    - "COMMAND:"
+    - "samtools markdup"
   num_lines: 2
 samtools/markdup_json:
   contents:


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

Fixes a bug in the `samtools` MultiQC module for `samtools markdup` output.

The issue is in the `samtools/markdup_txt` search pattern: it currently looks for the literal string `^COMMAND:`, which never matches valid output because the file begins with `COMMAND:` and does not include a literal caret. As a result, valid `samtools markdup` metrics files are silently skipped and never appear in the report.

The fix is to search for `COMMAND:` and `samtools markdup` rather than the literal `^COMMAND:` so the file is detected correctly.