### PR TITLE
DRAGEN-FastQC: fix "Per-Position Sequence Content" showing "No samples found"

### DIFF
--- a/multiqc/modules/dragen_fastqc/content_metrics.py
+++ b/multiqc/modules/dragen_fastqc/content_metrics.py
@@ -162,7 +162,7 @@ class DragenContentMetrics(BaseMultiqcModule):
         """.format(
             # Generate unique plot ID, needed in mqc_export_selectplots
             id=report.save_htmlid("dragen_fastqc_per_base_sequence_content_plot"),
-            d=json.dumps([self.anchor.replace("-", "_"), data]),
+            d=json.dumps([self.anchor, data]),
             hand_icon=get_material_icon("mdi:hand-pointing-up", 16),
         )
 


### PR DESCRIPTION
Fixes #3651.

Key the embedded sequence content data by the raw module anchor, as the JavaScript expects, instead of the underscored form.