### PR TITLE
 feat(fgbio): parse ClipBam clipping metrics

### DIFF
--- a/docs/markdown/modules/fgbio.md
+++ b/docs/markdown/modules/fgbio.md
@@ -25,10 +25,19 @@ The module currently supports tool the following outputs:
 
 - [GroupReadsByUmi](http://fulcrumgenomics.github.io/fgbio/tools/latest/GroupReadsByUmi.html)
 - [ErrorRateByReadPosition](http://fulcrumgenomics.github.io/fgbio/tools/latest/ErrorRateByReadPosition.html)
+- [ClipBam](http://fulcrumgenomics.github.io/fgbio/tools/latest/ClipBam.html)
+
+For `ClipBam`, the module reads the metrics file written with `--metrics` and reports, per
+read type, how many reads and bases were clipped and for which reason. Note that `bases` in
+that file counts the aligned bases left after clipping, so the percentages of bases clipped
+are computed against `bases + bases_clipped_post`, the bases present before ClipBam ran.
 
 ### File search patterns
 
 ```yaml
+fgbio/clipbam:
+  contents: "read_type\treads\treads_unmapped\treads_clipped_pre\treads_clipped_post"
+  num_lines: 3
 fgbio/errorratebyreadposition:
   contents: "read_number\tposition\tbases_total\terrors\terror_rate\ta_to_c_error_rate\t\
     a_to_g_error_rate\ta_to_t_error_rate\tc_to_a_error_rate\tc_to_g_error_rate\tc_to_t_error_rate"

--- a/multiqc/modules/fgbio/clip_bam.py
+++ b/multiqc/modules/fgbio/clip_bam.py
@@ -1,0 +1,401 @@
+"""Parse the clipping metrics that fgbio ClipBam writes with `--metrics`."""
+
+import logging
+from typing import Dict, List, Union
+
+from multiqc import config
+from multiqc.base_module import BaseMultiqcModule
+from multiqc.plots import bargraph, table
+from multiqc.plots.bargraph import BarPlotConfig
+from multiqc.plots.table import TableConfig
+from multiqc.plots.table_object import ColumnDict, InputRow, ValueT
+from multiqc.types import ColumnKey, SampleGroup, SampleName
+
+log = logging.getLogger(__name__)
+
+# Every column after `read_type` is an integer count.
+COUNT_COLUMNS = (
+    "reads",
+    "reads_unmapped",
+    "reads_clipped_pre",
+    "reads_clipped_post",
+    "reads_clipped_five_prime",
+    "reads_clipped_three_prime",
+    "reads_clipped_overlapping",
+    "reads_clipped_extending",
+    "bases",
+    "bases_clipped_pre",
+    "bases_clipped_post",
+    "bases_clipped_five_prime",
+    "bases_clipped_three_prime",
+    "bases_clipped_overlapping",
+    "bases_clipped_extending",
+)
+
+# `Pair` sums `ReadOne` and `ReadTwo`, and `All` sums `Fragment` and `Pair`, so `All`
+# heads each sample's table group and the other read types nest under it in this order.
+HEADLINE_READ_TYPE = "All"
+NESTED_READ_TYPES = ("Pair", "ReadOne", "ReadTwo", "Fragment")
+
+# The clipping reasons whose base counts add up to `bases_clipped_post`.
+CLIPPED_BASES_BY_REASON = (
+    "bases_clipped_pre",
+    "bases_clipped_five_prime",
+    "bases_clipped_three_prime",
+    "bases_clipped_overlapping",
+    "bases_clipped_extending",
+)
+
+BASES_DENOMINATOR_NOTE = (
+    "`bases` in the metrics file counts the aligned bases that remain after clipping, so the "
+    "bases present before ClipBam ran are `bases + bases_clipped_post`, which is the denominator "
+    "of every base percentage here."
+)
+
+ClipBamRow = Dict[str, Union[int, float]]
+
+
+def run_clip_bam(module: BaseMultiqcModule) -> int:
+    """
+    Parse fgbio ClipBam metrics files, then add general stats columns, a bar plot of
+    clipped bases by reason, and a per-read-type table grouped by sample.
+    """
+    data_by_sample = parse_clip_bam_metrics(module)
+    if not data_by_sample:
+        return 0
+
+    module.write_data_file(flatten_by_read_type(data_by_sample), "multiqc_fgbio_clipbam")
+    add_general_stats(module, data_by_sample)
+    add_clipped_bases_plot(module, data_by_sample)
+    add_read_type_table(module, data_by_sample)
+
+    return len(data_by_sample)
+
+
+def parse_clip_bam_metrics(module: BaseMultiqcModule) -> Dict[str, Dict[str, ClipBamRow]]:
+    """Return `{sample: {read_type: metrics}}` for every ClipBam metrics file found."""
+    data_by_sample: Dict[str, Dict[str, ClipBamRow]] = {}
+
+    for f in module.find_log_files("fgbio/clipbam"):
+        lines = [line for line in f["f"].splitlines() if line.strip()]
+        if not lines:
+            continue
+        header = lines[0].split("\t")
+        if header[0] != "read_type" or any(col not in header for col in COUNT_COLUMNS):
+            log.debug(f"Skipping {f['fn']}: not a ClipBam metrics header")
+            continue
+
+        rows_by_read_type: Dict[str, ClipBamRow] = {}
+        for line_num, line in enumerate(lines[1:], start=2):
+            fields = line.split("\t")
+            if len(fields) != len(header):
+                log.warning(
+                    f"fgbio ClipBam: skipping line {line_num} of {f['fn']}: "
+                    f"got {len(fields)} fields, expected {len(header)}"
+                )
+                continue
+            record = dict(zip(header, fields))
+            try:
+                counts = {col: int(record[col]) for col in COUNT_COLUMNS}
+            except ValueError:
+                log.warning(f"fgbio ClipBam: skipping line {line_num} of {f['fn']}: non-integer count")
+                continue
+            rows_by_read_type[record["read_type"]] = with_derived_metrics(counts)
+
+        if not rows_by_read_type:
+            continue
+        if f["s_name"] in data_by_sample:
+            log.debug(f"Duplicate sample name found! Overwriting: {f['s_name']}")
+        data_by_sample[f["s_name"]] = rows_by_read_type
+        module.add_data_source(f, section="ClipBam")
+
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        module.add_software_version(None, f["s_name"])
+
+    return module.ignore_samples(data_by_sample)
+
+
+def with_derived_metrics(counts: Dict[str, int]) -> ClipBamRow:
+    """
+    Add the percentages the report shows to a row of raw counts.
+
+    `bases` is the number of aligned bases left after clipping, not the read length, so the
+    bases present before ClipBam ran are `bases + bases_clipped_post` and every base
+    percentage divides by that sum. Read percentages divide by `reads`. A percentage whose
+    denominator is zero is left out of the row instead of being reported as zero.
+    """
+    row: ClipBamRow = dict(counts)
+    bases_pre_clip = counts["bases"] + counts["bases_clipped_post"]
+    row["bases_pre_clip"] = bases_pre_clip
+    if counts["reads"] > 0:
+        row["pct_reads_clipped"] = 100.0 * counts["reads_clipped_post"] / counts["reads"]
+    if bases_pre_clip > 0:
+        row["pct_bases_clipped"] = 100.0 * counts["bases_clipped_post"] / bases_pre_clip
+        row["pct_bases_clipped_overlapping"] = 100.0 * counts["bases_clipped_overlapping"] / bases_pre_clip
+    return row
+
+
+def flatten_by_read_type(data_by_sample: Dict[str, Dict[str, ClipBamRow]]) -> Dict[str, ClipBamRow]:
+    """One row per sample for the data file, with columns named `<read_type>_<metric>`."""
+    return {
+        s_name: {
+            f"{read_type}_{metric}": value for read_type, row in by_read_type.items() for metric, value in row.items()
+        }
+        for s_name, by_read_type in data_by_sample.items()
+    }
+
+
+def add_general_stats(module: BaseMultiqcModule, data_by_sample: Dict[str, Dict[str, ClipBamRow]]) -> None:
+    gs_keys = ("pct_bases_clipped", "pct_reads_clipped")
+    gs_data: Dict[Union[SampleName, str], Dict[Union[ColumnKey, str], ValueT]] = {}
+    for s_name, by_read_type in data_by_sample.items():
+        all_row = by_read_type.get(HEADLINE_READ_TYPE, {})
+        values: Dict[Union[ColumnKey, str], ValueT] = {key: all_row[key] for key in gs_keys if key in all_row}
+        if values:
+            gs_data[s_name] = values
+    if not gs_data:
+        return
+
+    headers: Dict[str, ColumnDict] = {
+        "pct_bases_clipped": {
+            "title": "% Bases clipped",
+            "description": (
+                "Percentage of bases clipped after ClipBam ran, including clipping already present in the "
+                "input: bases_clipped_post / (bases + bases_clipped_post), where bases counts only the aligned "
+                "bases left after clipping (All reads)"
+            ),
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
+            "scale": "OrRd",
+            "format": "{:,.1f}",
+        },
+        "pct_reads_clipped": {
+            "title": "% Reads clipped",
+            "description": (
+                "Percentage of reads with any clipping after ClipBam ran, including clipping already present "
+                "in the input: reads_clipped_post / reads (All reads)"
+            ),
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
+            "scale": "YlOrBr",
+            "format": "{:,.1f}",
+            "hidden": True,
+        },
+    }
+    module.general_stats_addcols(gs_data, headers, namespace="ClipBam")
+
+
+def add_clipped_bases_plot(module: BaseMultiqcModule, data_by_sample: Dict[str, Dict[str, ClipBamRow]]) -> None:
+    categories = {
+        "bases": {"name": "Aligned, not clipped"},
+        "bases_clipped_pre": {"name": "Clipped before ClipBam"},
+        "bases_clipped_five_prime": {"name": "Clipped at 5' end"},
+        "bases_clipped_three_prime": {"name": "Clipped at 3' end"},
+        "bases_clipped_overlapping": {"name": "Clipped for mate overlap"},
+        "bases_clipped_extending": {"name": "Clipped past mate end"},
+    }
+    plot_data: Dict[str, Dict[str, Union[int, float]]] = {}
+    for s_name, by_read_type in data_by_sample.items():
+        all_row = by_read_type.get(HEADLINE_READ_TYPE)
+        if all_row is None or all_row["bases_pre_clip"] == 0:
+            continue
+        plot_data[s_name] = {key: all_row[key] for key in categories}
+    if not plot_data:
+        return
+
+    module.add_section(
+        name="ClipBam clipped bases",
+        anchor="fgbio-clipbam-bases",
+        description=(
+            "Bases in each sample's `All` reads, split into the aligned bases ClipBam left in place and the "
+            "bases clipped for each reason."
+        ),
+        helptext=f"""
+        Each bar totals the bases present before ClipBam ran ({BASES_DENOMINATOR_NOTE}).
+        The clipped segments are the reasons ClipBam records for a clipped base: clipping that was
+        already in the input, the fixed number of bases requested from the 5' or 3' end of a read,
+        the bases of a read that overlap its mate, and the bases that extend past the far end of the
+        mate. These five counts add up to `bases_clipped_post`.
+        """,
+        plot=bargraph.plot(
+            plot_data,
+            categories,
+            BarPlotConfig(
+                id="fgbio-clipbam-bases-plot",
+                title="fgbio: ClipBam bases by clipping reason",
+                ylab="# Bases",
+                cpswitch_counts_label="Number of bases",
+                cpswitch_percent_label="Percentage of bases",
+            ),
+        ),
+    )
+
+
+def add_read_type_table(module: BaseMultiqcModule, data_by_sample: Dict[str, Dict[str, ClipBamRow]]) -> None:
+    # The first row of each group is the headline: `All`, labelled with the bare sample name.
+    # The other read types nest under it and expand on click. Read types with no reads are
+    # dropped, and a single remaining nested read type is dropped too, since fragment-only
+    # data has `Fragment` equal to `All` and the row would only repeat the headline.
+    rows_by_sample: Dict[Union[str, SampleGroup], List[InputRow]] = {}
+    for s_name, by_read_type in data_by_sample.items():
+        headline = by_read_type.get(HEADLINE_READ_TYPE)
+        if headline is None or headline["reads"] == 0:
+            continue
+        nested = [rt for rt in NESTED_READ_TYPES if by_read_type.get(rt, {}).get("reads", 0) > 0]
+        if len(nested) == 1:
+            nested = []
+        rows = [InputRow(sample=SampleName(s_name), data=headline)]
+        rows += [InputRow(sample=SampleName(f"{s_name} ({rt})"), data=by_read_type[rt]) for rt in nested]
+        rows_by_sample[SampleGroup(s_name)] = rows
+    if not rows_by_sample:
+        return
+
+    headers: Dict[Union[str, ColumnKey], ColumnDict] = {
+        "reads": {
+            "title": f"{config.read_count_prefix} Reads",
+            "description": f"Reads examined by ClipBam ({config.read_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "GnBu",
+            "shared_key": "read_count",
+            "modify": lambda x: float(x) * config.read_count_multiplier,
+            "hidden": True,
+        },
+        "pct_reads_clipped": {
+            "title": "% Reads clipped",
+            "description": (
+                "Reads with any clipping after ClipBam ran, including clipping already present in the input: "
+                "reads_clipped_post / reads"
+            ),
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
+            "format": "{:,.1f}",
+            "scale": "YlOrBr",
+        },
+        "bases_pre_clip": {
+            "title": f"{config.base_count_prefix} Bases pre-clip",
+            "description": (
+                f"Bases present before ClipBam ran: bases + bases_clipped_post, where bases counts only the "
+                f"aligned bases left after clipping ({config.base_count_desc})"
+            ),
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "Blues",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+            "hidden": True,
+        },
+        "pct_bases_clipped": {
+            "title": "% Bases clipped",
+            "description": (
+                "Bases clipped after ClipBam ran, including clipping already present in the input: "
+                "bases_clipped_post / (bases + bases_clipped_post)"
+            ),
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
+            "format": "{:,.1f}",
+            "scale": "OrRd",
+        },
+        "pct_bases_clipped_overlapping": {
+            "title": "% Bases clipped (overlap)",
+            "description": (
+                "Bases clipped because the read overlapped its mate: "
+                "bases_clipped_overlapping / (bases + bases_clipped_post)"
+            ),
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
+            "format": "{:,.1f}",
+            "scale": "PuRd",
+        },
+        "bases_clipped_overlapping": {
+            "title": f"{config.base_count_prefix} Clipped (overlap)",
+            "description": f"Bases clipped because the read overlapped its mate ({config.base_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "Purples",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+        },
+        "bases_clipped_pre": {
+            "title": f"{config.base_count_prefix} Clipped (pre-existing)",
+            "description": f"Bases already clipped in the input before ClipBam ran ({config.base_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "Greys",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+            "hidden": True,
+        },
+        "bases_clipped_five_prime": {
+            "title": f"{config.base_count_prefix} Clipped (5')",
+            "description": f"Bases clipped from the 5' end of reads ({config.base_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "Greens",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+            "hidden": True,
+        },
+        "bases_clipped_three_prime": {
+            "title": f"{config.base_count_prefix} Clipped (3')",
+            "description": f"Bases clipped from the 3' end of reads ({config.base_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "YlGn",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+            "hidden": True,
+        },
+        "bases_clipped_extending": {
+            "title": f"{config.base_count_prefix} Clipped (past mate)",
+            "description": f"Bases clipped because the read extended past the far end of its mate ({config.base_count_desc})",
+            "min": 0,
+            "format": "{:,.2f}",
+            "scale": "Oranges",
+            "shared_key": "base_count",
+            "modify": lambda x: float(x) * config.base_count_multiplier,
+            "hidden": True,
+        },
+    }
+
+    module.add_section(
+        name="ClipBam clipping metrics",
+        anchor="fgbio-clipbam",
+        description=(
+            "Reads and bases clipped by `ClipBam`, per sample and read type. Each sample's headline row "
+            "holds the `All` metrics; expand it for the `Pair`, `ReadOne`, `ReadTwo` and `Fragment` rows."
+        ),
+        helptext=f"""
+        `ClipBam` clips reads in an aligned BAM: a fixed number of bases from the 5' or 3' end,
+        the bases of a read that overlap its mate, or the bases that extend past the far end of
+        the mate. Its metrics file counts, for each read type, how many reads and bases ended up
+        clipped and for which reason.
+
+        Read types: `ReadOne` and `ReadTwo` are the two reads of a pair, `Pair` is their sum,
+        `Fragment` is unpaired reads, and `All` is `Pair` plus `Fragment`. The `All` row is each
+        sample's headline row; the other read types nest under it and can be shown by clicking
+        the row. Read types with no reads are not shown, so paired-end data has no `Fragment` row
+        and fragment-only data collapses to the headline row alone.
+
+        Denominators: {BASES_DENOMINATOR_NOTE}
+        `% Bases clipped` is `bases_clipped_post / (bases + bases_clipped_post)` and
+        `% Bases clipped (overlap)` is `bases_clipped_overlapping / (bases + bases_clipped_post)`.
+        `% Reads clipped` is `reads_clipped_post / reads`. The `_post` counts include clipping
+        that was already present in the input (the `_pre` counts), and the per-reason base
+        counts (pre-existing, 5', 3', overlap, past mate) add up to `bases_clipped_post`.
+        """,
+        plot=table.plot(
+            rows_by_sample,
+            headers,
+            TableConfig(
+                id="fgbio-clipbam-table",
+                title="fgbio: ClipBam clipping metrics by read type",
+            ),
+        ),
+    )

--- a/multiqc/modules/fgbio/fgbio.py
+++ b/multiqc/modules/fgbio/fgbio.py
@@ -2,6 +2,7 @@ import logging
 
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 
+from multiqc.modules.fgbio.clip_bam import run_clip_bam
 from multiqc.modules.fgbio.error_rate_by_read_position import error_rate_by_read_position
 from multiqc.modules.fgbio.group_reads_by_umi import run_group_reads_by_umi
 
@@ -14,6 +15,12 @@ class MultiqcModule(BaseMultiqcModule):
 
     - [GroupReadsByUmi](http://fulcrumgenomics.github.io/fgbio/tools/latest/GroupReadsByUmi.html)
     - [ErrorRateByReadPosition](http://fulcrumgenomics.github.io/fgbio/tools/latest/ErrorRateByReadPosition.html)
+    - [ClipBam](http://fulcrumgenomics.github.io/fgbio/tools/latest/ClipBam.html)
+
+    For `ClipBam`, the module reads the metrics file written with `--metrics` and reports, per
+    read type, how many reads and bases were clipped and for which reason. Note that `bases` in
+    that file counts the aligned bases left after clipping, so the percentages of bases clipped
+    are computed against `bases + bases_clipped_post`, the bases present before ClipBam ran.
     """
 
     def __init__(self):
@@ -38,6 +45,11 @@ class MultiqcModule(BaseMultiqcModule):
         n["errorratebyreadposition"] = error_rate_by_read_position(self)
         if n["errorratebyreadposition"] > 0:
             log.info(f"Found {n['errorratebyreadposition']} errorratebyreadposition reports")
+
+        # ClipBam
+        n["clipbam"] = run_clip_bam(self)
+        if n["clipbam"] > 0:
+            log.info(f"Found {n['clipbam']} clipbam reports")
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/modules/fgbio/tests/test_fgbio.py
+++ b/multiqc/modules/fgbio/tests/test_fgbio.py
@@ -1,0 +1,201 @@
+"""Inline-fixture unit tests for the fgbio module's ClipBam parser.
+
+The count fixtures are hand-built rather than copied from a run so that every derived
+percentage can be checked against arithmetic done by hand in the test. They keep the
+identities fgbio guarantees: `Pair` is the sum of `ReadOne` and `ReadTwo`, `All` is the
+sum of `Fragment` and `Pair`, and the per-reason clipped-base counts add up to
+`bases_clipped_post`.
+"""
+
+import pytest
+
+from multiqc import config, report
+from multiqc.modules.fgbio import MultiqcModule
+from multiqc.types import ColumnKey, SampleGroup
+
+CLIPBAM_HEADER = (
+    "read_type\treads\treads_unmapped\treads_clipped_pre\treads_clipped_post\treads_clipped_five_prime"
+    "\treads_clipped_three_prime\treads_clipped_overlapping\treads_clipped_extending\tbases\tbases_clipped_pre"
+    "\tbases_clipped_post\tbases_clipped_five_prime\tbases_clipped_three_prime\tbases_clipped_overlapping"
+    "\tbases_clipped_extending\n"
+)
+
+# Paired-end data: every read is paired, so the Fragment row is all zeros and All equals Pair.
+# All: 2000 reads, 1220 clipped; 178000 aligned bases remain, 25000 were clipped (22000 for overlap).
+CLIPBAM_PAIRED_TSV = (
+    CLIPBAM_HEADER + "Fragment\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n"
+    "ReadOne\t1000\t0\t100\t600\t0\t0\t550\t0\t90000\t2000\t12000\t0\t0\t10000\t0\n"
+    "ReadTwo\t1000\t0\t50\t620\t0\t0\t600\t0\t88000\t1000\t13000\t0\t0\t12000\t0\n"
+    "Pair\t2000\t0\t150\t1220\t0\t0\t1150\t0\t178000\t3000\t25000\t0\t0\t22000\t0\n"
+    "All\t2000\t0\t150\t1220\t0\t0\t1150\t0\t178000\t3000\t25000\t0\t0\t22000\t0\n"
+)
+
+# Fragment-only data: the paired rows are all zeros and All equals Fragment.
+# All: 500 reads, 200 clipped; 40000 aligned bases remain, 1300 were clipped (1000 at the 5' end).
+CLIPBAM_FRAGMENT_TSV = (
+    CLIPBAM_HEADER + "Fragment\t500\t0\t20\t200\t200\t0\t0\t0\t40000\t300\t1300\t1000\t0\t0\t0\n"
+    "ReadOne\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n"
+    "ReadTwo\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n"
+    "Pair\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n"
+    "All\t500\t0\t20\t200\t200\t0\t0\t0\t40000\t300\t1300\t1000\t0\t0\t0\n"
+)
+
+# An empty input BAM: every count is zero, so no percentage can be computed.
+CLIPBAM_EMPTY_TSV = CLIPBAM_HEADER + "".join(
+    f"{read_type}\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n"
+    for read_type in ("Fragment", "ReadOne", "ReadTwo", "Pair", "All")
+)
+
+GROUPREADSBYUMI_TSV = (
+    "family_size\tcount\tfraction\tfraction_gt_or_eq_family_size\n"
+    "1\t7092682\t0.56602\t1\n"
+    "2\t2005532\t0.16005\t0.43398\n"
+    "3\t1039240\t0.08294\t0.27393\n"
+)
+
+ERRORRATEBYREADPOSITION_TSV = (
+    "read_number\tposition\tbases_total\terrors\terror_rate\ta_to_c_error_rate\ta_to_g_error_rate"
+    "\ta_to_t_error_rate\tc_to_a_error_rate\tc_to_g_error_rate\tc_to_t_error_rate\n"
+    "1\t1\t1000\t10\t0.01\t0.001\t0.002\t0.001\t0.002\t0.002\t0.002\n"
+    "1\t2\t1000\t20\t0.02\t0.002\t0.004\t0.002\t0.004\t0.004\t0.004\n"
+)
+
+
+@pytest.fixture
+def run_fgbio_module(tmp_path):
+    """Factory: write each `filename: content` pair to a temp dir and run the fgbio module on it."""
+
+    def _run(files: dict):
+        for filename, content in files.items():
+            (tmp_path / filename).write_text(content)
+        report.reset()
+        report.analysis_files = [tmp_path]
+        report.search_files(["fgbio"])
+        return MultiqcModule()
+
+    return _run
+
+
+def _clipbam_table_rows(sample: str):
+    """Return the grouped rows for `sample` from the ClipBam table, or None if absent."""
+    for plot in report.plot_by_id.values():
+        for dataset in getattr(plot, "datasets", []):
+            dt = getattr(dataset, "dt", None)
+            if dt is None or dt.id != "fgbio-clipbam-table":
+                continue
+            for section in dt.section_by_id.values():
+                if SampleGroup(sample) in section.rows_by_sgroup:
+                    return section.rows_by_sgroup[SampleGroup(sample)]
+    return None
+
+
+def _general_stats_for(sample: str):
+    """Return (headers, row data) for `sample` from whichever general stats section holds it."""
+    for section_key, rows_by_group in report.general_stats_data.items():
+        if SampleGroup(sample) in rows_by_group:
+            rows = rows_by_group[SampleGroup(sample)]
+            assert len(rows) == 1
+            return report.general_stats_headers[section_key], rows[0].data
+    raise AssertionError(f"{sample!r} not found in general stats")
+
+
+def test_general_stats_use_pre_clip_bases_as_denominator(run_fgbio_module):
+    """`bases` counts only the aligned bases left after clipping, so the base percentage
+    must divide by `bases + bases_clipped_post` (203000 here), not by `bases` alone."""
+    run_fgbio_module({"sampleA.txt": CLIPBAM_PAIRED_TSV})
+
+    headers, data = _general_stats_for("sampleA")
+    assert data[ColumnKey("pct_bases_clipped")] == pytest.approx(100.0 * 25000 / (178000 + 25000))
+    assert data[ColumnKey("pct_bases_clipped")] != pytest.approx(100.0 * 25000 / 178000)
+    assert data[ColumnKey("pct_reads_clipped")] == pytest.approx(100.0 * 1220 / 2000)
+
+    assert not headers[ColumnKey("pct_bases_clipped")].get("hidden")
+    assert headers[ColumnKey("pct_reads_clipped")]["hidden"] is True
+    assert "bases + bases_clipped_post" in headers[ColumnKey("pct_bases_clipped")]["description"]
+
+
+def test_table_groups_all_as_primary_and_drops_empty_fragment_row(run_fgbio_module):
+    """The `All` row heads each sample's group under the bare sample name, with `Pair`,
+    `ReadOne` and `ReadTwo` nested under it in that order. The all-zero `Fragment` row of
+    paired-end data is left out."""
+    run_fgbio_module({"sampleA.txt": CLIPBAM_PAIRED_TSV})
+
+    rows = _clipbam_table_rows("sampleA")
+    assert rows is not None, "ClipBam table did not produce a sampleA group"
+    assert [str(r.sample) for r in rows] == ["sampleA", "sampleA (Pair)", "sampleA (ReadOne)", "sampleA (ReadTwo)"]
+
+    assert rows[0].data[ColumnKey("reads")].raw == 2000
+    assert rows[1].data[ColumnKey("reads")].raw == 2000
+    assert rows[2].data[ColumnKey("reads")].raw == 1000
+    assert rows[3].data[ColumnKey("reads")].raw == 1000
+    assert rows[0].data[ColumnKey("bases_pre_clip")].raw == 178000 + 25000
+    assert rows[2].data[ColumnKey("pct_bases_clipped_overlapping")].raw == pytest.approx(
+        100.0 * 10000 / (90000 + 12000)
+    )
+
+
+def test_fragment_only_data_collapses_to_a_single_headline_row(run_fgbio_module):
+    """With only unpaired reads `All` equals `Fragment`, so nesting the `Fragment` row would
+    just repeat the headline; the group degrades to the headline row alone."""
+    run_fgbio_module({"sampleB.txt": CLIPBAM_FRAGMENT_TSV})
+
+    rows = _clipbam_table_rows("sampleB")
+    assert rows is not None, "ClipBam table did not produce a sampleB group"
+    assert [str(r.sample) for r in rows] == ["sampleB"]
+    assert rows[0].data[ColumnKey("reads")].raw == 500
+    assert rows[0].data[ColumnKey("pct_bases_clipped")].raw == pytest.approx(100.0 * 1300 / (40000 + 1300))
+
+    _, data = _general_stats_for("sampleB")
+    assert data[ColumnKey("pct_reads_clipped")] == pytest.approx(40.0)
+
+
+def test_all_zero_metrics_add_no_rows_but_do_not_fail(run_fgbio_module):
+    """An empty input BAM yields all-zero counts: nothing can be divided, so the sample gets
+    no percentages, no table row and no general stats entry, without raising."""
+    module = run_fgbio_module({"sampleC.txt": CLIPBAM_EMPTY_TSV})
+
+    assert "fgbio-clipbam" not in {section.anchor for section in module.sections}
+    assert _clipbam_table_rows("sampleC") is None
+    assert not any(SampleGroup("sampleC") in rows for rows in report.general_stats_data.values())
+
+
+def test_data_file_flattens_read_types_and_keeps_derived_metrics(run_fgbio_module):
+    original = config.preserve_module_raw_data
+    config.preserve_module_raw_data = True
+    try:
+        module = run_fgbio_module({"sampleA.txt": CLIPBAM_PAIRED_TSV})
+    finally:
+        config.preserve_module_raw_data = original
+
+    saved = module.saved_raw_data
+    assert saved is not None
+    row = saved["multiqc_fgbio_clipbam"]["sampleA"]
+    assert row["All_reads"] == 2000
+    assert row["ReadTwo_bases_clipped_overlapping"] == 12000
+    assert row["All_bases_pre_clip"] == 203000
+    assert row["All_pct_bases_clipped"] == pytest.approx(100.0 * 25000 / 203000)
+    # A zero denominator leaves the percentage out rather than reporting 0.
+    assert "Fragment_pct_reads_clipped" not in row
+    assert "Fragment_pct_bases_clipped" not in row
+
+
+def test_clipbam_pattern_does_not_match_other_fgbio_outputs(run_fgbio_module):
+    module = run_fgbio_module(
+        {
+            "sampleD.histo.tsv": GROUPREADSBYUMI_TSV,
+            "sampleD.error_rate_by_read_position.txt": ERRORRATEBYREADPOSITION_TSV,
+        }
+    )
+
+    assert list(module.find_log_files("fgbio/clipbam")) == []
+    anchors = {section.anchor for section in module.sections}
+    assert "fgbio-clipbam" not in anchors
+    assert {"fgbio-groupreadsbyumi", "fgbio-error-rate-by-read-position"} <= anchors
+
+
+def test_other_fgbio_patterns_do_not_match_clipbam_output(run_fgbio_module):
+    module = run_fgbio_module({"sampleA.txt": CLIPBAM_PAIRED_TSV})
+
+    assert list(module.find_log_files("fgbio/groupreadsbyumi")) == []
+    assert list(module.find_log_files("fgbio/errorratebyreadposition")) == []
+    assert {section.anchor for section in module.sections} == {"fgbio-clipbam-bases", "fgbio-clipbam"}

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -417,6 +417,9 @@ fgbio/groupreadsbyumi:
 fgbio/errorratebyreadposition:
   contents: "read_number	position	bases_total	errors	error_rate	a_to_c_error_rate	a_to_g_error_rate	a_to_t_error_rate	c_to_a_error_rate	c_to_g_error_rate	c_to_t_error_rate"
   num_lines: 3
+fgbio/clipbam:
+  contents: "read_type	reads	reads_unmapped	reads_clipped_pre	reads_clipped_post"
+  num_lines: 3
 filtlong:
   contents: Scoring long reads
   contents_re: ".*Filtering long reads.*"


### PR DESCRIPTION
Adds a parser for the metrics file written by `fgbio ClipBam --metrics` to the existing fgbio module, alongside GroupReadsByUmi and ErrorRateByReadPosition:

- https://fulcrumgenomics.github.io/fgbio/tools/latest/ClipBam.html

The input metrics file is a plain TSV with one row per read type (`Fragment`, `ReadOne`, `ReadTwo`, `Pair`, `All`; `Pair` sums the two reads and `All` sums `Fragment` and `Pair`) and integer counts of reads and bases clipped, broken down by reason (pre-existing, fixed 5' or 3', mate overlap, extending past the mate).

The report gets:

- General stats: `% Bases clipped` shown by default and `% Reads clipped` hidden by default, both from the `All` row, namespaced `fgbio: ClipBam`.
- A stacked bar plot of the `All` row's bases per sample split into aligned-not-clipped and the five clipping reasons (these add up to the pre-clip total), with the usual counts/percentages switch.
- A table grouped by sample using the `SampleGroup` / `InputRow` pattern from MultiQC/MultiQC#3645: the `All` row is the headline under the bare sample name and `Pair`, `ReadOne`, `ReadTwo`, `Fragment` nest under it as `sample (Pair)` etc. Read types with zero reads are dropped, so paired-end data shows no `Fragment` row and fragment-only data (where `All` equals `Fragment`) collapses to the headline row alone. Percentages and the overlap-clipped count are shown by default; the read count, pre-clip bases and the other per-reason counts are hidden.

Here's what it looks like with random data:

<img width="1728" height="960" alt="Screenshot 2026-09-09 at 7 37 00 PM" src="https://github.com/user-attachments/assets/00501bc7-46db-4810-a2ee-27995650eb0f" />

<img width="1728" height="591" alt="Screenshot 2026-09-09 at 7 37 15 PM" src="https://github.com/user-attachments/assets/a6eff6b7-65b6-42fe-8884-61ac41ed9ca8" />

Checklist:
- [x] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
- [x] Code is tested and works locally (including with `--strict` flag)
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (e.g. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
