### PR TITLE
Somalier: match pairs.tsv after concordance column rename

### DIFF
--- a/multiqc/modules/somalier/tests/test_somalier.py
+++ b/multiqc/modules/somalier/tests/test_somalier.py
@@ -1,0 +1,60 @@
+"""Tests for the Somalier module."""
+
+import pytest
+
+from multiqc import config, report
+from multiqc.modules.somalier import MultiqcModule
+
+SAMPLES_TSV = (
+    "#family_id\tsample_id\tpaternal_id\tmaternal_id\tsex\tphenotype\n"
+    "FAM1\tsampleA\t0\t0\t1\t-9\n"
+    "FAM1\tsampleB\t0\t0\t2\t-9\n"
+)
+
+
+def _pairs_tsv(concordance_col: str) -> str:
+    return (
+        "#sample_a\tsample_b\trelatedness\tibs0\tibs2\t"
+        f"{concordance_col}\thets_a\thets_b\thets_ab\tshared_hets\t"
+        "hom_alts_a\thom_alts_b\tshared_hom_alts\tn\tx_ibs0\tx_ibs2\t"
+        "expected_relatedness\n"
+        "sampleA\tsampleB\t0.500\t10\t100\t0.990\t50\t50\t40\t45\t20\t20\t"
+        "18\t200\t0\t5\t0.5\n"
+    )
+
+
+@pytest.fixture
+def run_somalier(tmp_path):
+    """Write samples plus pairs TSVs and run the Somalier module against them."""
+
+    def _run(pairs_text: str):
+        (tmp_path / "somalier.samples.tsv").write_text(SAMPLES_TSV)
+        (tmp_path / "somalier.pairs.tsv").write_text(pairs_text)
+        report.reset()
+        config.reset()
+        report.analysis_files = [tmp_path]
+        report.search_files(["somalier"])
+        config.preserve_module_raw_data = True
+        return MultiqcModule()
+
+    return _run
+
+
+@pytest.mark.parametrize("concordance_col", ["concordance", "hom_concordance"])
+def test_relatedness_heatmap_from_pairs_tsv(run_somalier, concordance_col):
+    """Newer somalier writes `concordance` instead of `hom_concordance`.
+
+    The pairs search pattern must match both headers so the relatedness
+    heatmap is still produced. Samples.tsv is present either way, so a
+    missed pairs file used to yield a report with no heatmap rather than
+    ModuleNoSamplesFound.
+    """
+    module = run_somalier(_pairs_tsv(concordance_col))
+
+    assert "Relatedness Heatmap" in [section.name for section in module.sections]
+    assert "somalier_relatedness_heatmap_plot" in report.plot_by_id
+
+    saved = module.saved_raw_data
+    assert saved is not None
+    pair = saved["multiqc_somalier"]["sampleA*sampleB"]
+    assert pair["relatedness"] == 0.5

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -755,7 +755,7 @@ somalier/samples:
   num_lines: 5
 somalier/pairs:
   fn: "*.pairs.tsv"
-  contents: "hom_concordance"
+  contents: "concordance"
   num_lines: 5
 sourmash/compare:
   fn: "*.labels.txt"


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

Closes #3649

The Somalier pairs `contents` fingerprint is now `concordance` instead of `hom_concordance`. Somalier renamed that `pairs.tsv` header, so newer files were never discovered. When `samples.tsv` was present the module still ran, but the relatedness heatmap was skipped because it is built from pairs data.

Content matching is a substring test, so older `hom_concordance` files still match. The heatmap already plots the `relatedness` column, which somalier still writes, so the plot code is unchanged. The Relatedness scatter (also pairs-only) comes back for the same reason.

A regression test writes both header variants, runs file search, and checks that the Relatedness Heatmap section is produced.

A `contents_re` that names both headers would need to match a full header line, because `contents_re` is start-anchored. Substring `concordance` already covers both names, so a yaml-only change is enough for discovery. Regenerating `docs/markdown/config_schema.md` and `docs/multiqc_config_wizard.html` in this PR would make the embedded copy of `sp` match; those files are generated from `search_patterns.yaml` at release and were left untouched on the last search-pattern fix (#3647). Happy to switch to the regex and/or regenerate those two generated files if that is preferred.

## Test plan

- [ ] `pytest -vv multiqc/modules/somalier/tests/test_somalier.py`
- [ ] Run MultiQC on a current-somalier `*.pairs.tsv` (header `concordance`) plus `*.samples.tsv` and confirm Relatedness Heatmap appears
- [ ] Run MultiQC on an older `hom_concordance` pairs file and confirm the heatmap still appears
